### PR TITLE
Fix broken scrubbing due to time tooltip styling

### DIFF
--- a/src/components/MediaPlayer/VideoJS/components/styles/VideoJSProgress.scss
+++ b/src/components/MediaPlayer/VideoJS/components/styles/VideoJSProgress.scss
@@ -137,7 +137,7 @@
   text-align: center;
   border-radius: 6px;
   padding: 5px 5px;
-  top: -2em;
+  top: -2.75em;
   position: absolute;
   z-index: 1;
 }


### PR DESCRIPTION
Before:
![image](https://github.com/samvera-labs/ramp/assets/1331659/fe5ad0a4-20db-4eff-8d6a-c79cdfcc0cda)
With the time tooltip on top of the time rail, scrubbing doesn't work because the progress bar doesn't register the mouse click event.

After:
![image](https://github.com/samvera-labs/ramp/assets/1331659/a9986a28-e977-4072-a5e9-f75b5d7da84d)
