### PR TITLE
Handle case when range only has a single canvas child

### DIFF
--- a/src/services/iiif-parser.js
+++ b/src/services/iiif-parser.js
@@ -224,6 +224,13 @@ export function getNextItem({ canvasIndex, manifest }) {
     const nextSection = manifest.structures[0].items[canvasIndex + 1];
     if (nextSection && nextSection.items) {
       let item = nextSection.items[0];
+      if (item.type == "Canvas") {
+        return {
+          isTitleTimespan: false,
+          id: item.id,
+          label: getLabelValue(nextSection.label)
+        };
+      }
       let childCanvases = getChildCanvases({ rangeId: item.id, manifest });
       return {
         isTitleTimespan: childCanvases.length == 1 ? true : false,


### PR DESCRIPTION
Without this change manifests like https://avalon-dev.dlib.indiana.edu/playlists/32/manifest.json would log an error message to the console but not sure if it actually broke anything.