### PR TITLE
Add check for empty item to getItemId

### DIFF
--- a/src/services/iiif-parser.js
+++ b/src/services/iiif-parser.js
@@ -243,7 +243,9 @@ export function getItemId(item) {
   if (!item) {
     return;
   }
-  if (item['items']) {
+  if (item['items'].length === 0) {
+    return;
+  } else if (item['items']) {
     return item['items'][0]['id'];
   }
 }
@@ -518,7 +520,7 @@ export function parseAutoAdvance(manifest) {
 /**
  * Parses the manifest to identify whether it is a playlist manifest
  * or not
- * @param {Object} manifest 
+ * @param {Object} manifest
  * @returns {Boolean}
  */
 export function getIsPlaylist(manifest) {
@@ -534,7 +536,7 @@ export function getIsPlaylist(manifest) {
 
 /**
  * Parse `highlighting` annotations with TextualBody type as markers
- * @param {Object} manifest 
+ * @param {Object} manifest
  * @param {Number} canvasIndex current canvas index
  * @returns {Array<Object>} JSON object array with the following format,
  * [{ id: String, time: Number, timeStr: String, canvasId: String, value: String}]

--- a/src/test_data/lunchroom-manners.js
+++ b/src/test_data/lunchroom-manners.js
@@ -425,6 +425,12 @@ export default {
                 },
               ],
             },
+            {
+              id: 'https://example.com/manifest/lunchroom_manners/range/3',
+              type: 'Range',
+              label: { en: ['Empty Range'] },
+              items: [],
+            },
           ],
         },
       ],


### PR DESCRIPTION
[The behavior encountered](https://github.com/avalonmediasystem/avalon/issues/5350) by Avalon with Ramp components not loading was because of top level ranges having an empty item section: `item: [ ]`. The parser would attempt to grab the item's ID and the parsing would fail, causing all of the components to stop processing.

This PR adds a condition to check the length of the item array before grabbing the ID value. 