### PR TITLE
Fix player css for zooming in demo site

### DIFF
--- a/demo/app.scss
+++ b/demo/app.scss
@@ -5,8 +5,7 @@ html {
 
 div.iiif-player-demo {
   .ramp--media_player {
-    width: 60%;
-    margin: auto;
+    margin: 0 10%;
   }
 
   .components-row {


### PR DESCRIPTION
The issue with icons in the control bar we were seeing when zooming-in was happening only in the demo site, because it sets the player width to 60%. The issue was not with VideoJS CSS. Example screenshots below where the player's width is not adjusted show the full control bar at 240% zoom level in the browser. 

GitHub documentation site:
![image](https://github.com/samvera-labs/ramp/assets/1331659/153212b2-a2c1-4cff-98d5-744e9f103ac6)

avalon-dev:
![image](https://github.com/samvera-labs/ramp/assets/1331659/5db48c0c-5b96-4482-8891-82b4d9346f82)

