### PR TITLE
Replace videojs-hotkeys with builtin hotkeys function

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ yarn add @samvera/ramp
 
 // Add peer dependencies
 yarn add video.js@7.21.3
-yarn add videojs-hotkeys
 ```
 
 **NOTE**: `video.js@7.21.3` needs to be used until the [fix](https://github.com/silvermine/videojs-quality-selector/pull/93) to use the latest Video.js (v8.0.4) in `@silvermine/videojs-quality-selector` is merged and released.
@@ -115,7 +114,7 @@ This will create CommoneJS, ES Module, and UMD distribution files located in the
 
 ### Netlify Demo-site Deploy
 
-A [demo site](https://ramp.avalonmediasystem.org/) is hosted with [Netlify](https://www.netlify.com). 
+A [demo site](https://ramp.avalonmediasystem.org/) is hosted with [Netlify](https://www.netlify.com).
 
 This demo instance can read a **publicly available IIIF Presentation 3.0 Manifest** given the URL of the manifest and display content in the manifest.
 

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "style-loader": "^2.0.0",
     "svg-url-loader": "^6.0.0",
     "video.js": "^7.10.2",
-    "videojs-hotkeys": "^0.2.27",
     "webpack": "^5.75.0",
     "webpack-cli": "^5.0.1",
     "webpack-dev-server": "^4.11.1"
@@ -88,8 +87,7 @@
   "peerDependencies": {
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "video.js": "^7.10.2",
-    "videojs-hotkeys": "^0.2.27"
+    "video.js": "^7.10.2"
   },
   "repository": {
     "type": "git",

--- a/src/components/MediaPlayer/MediaPlayer.js
+++ b/src/components/MediaPlayer/MediaPlayer.js
@@ -244,6 +244,70 @@ const MediaPlayer = ({ enableFileDownload = false, enablePIP = false }) => {
       ? playerConfig.sources[srcIndex]
       : playerConfig.sources,
     tracks: playerConfig.tracks,
+    userActions: {
+      hotkeys: function(event) {
+        // event.which key code values found at: https://css-tricks.com/snippets/javascript/javascript-keycodes/
+
+        // Prevent default browser actions so that page does not react when hotkeys are used.
+        // e.g. pressing space will pause/play without scrolling the page down.
+        event.preventDefault();
+
+        // Space and k toggle play/pause
+        if (event.which === 32 || event.which === 75) {
+          if (this.paused()) {
+            this.play();
+          } else {
+            this.pause();
+          }
+        }
+
+        // Adapted from https://github.com/videojs/video.js/blob/bad086dad68d3ff16dbe12e434c15e1ee7ac2875/src/js/control-bar/mute-toggle.js#L56
+        // m toggles mute
+        if (event.which === 77) {
+          const vol = this.volume();
+          const lastVolume = this.lastVolume_();
+
+          if (vol === 0) {
+            const volumeToSet = lastVolume < 0.1 ? 0.1 : lastVolume;
+
+            this.volume(volumeToSet);
+            this.muted(false);
+          } else {
+            this.muted(this.muted() ? false : true);
+          }
+        }
+
+        // f toggles fullscreen
+        // Fullscreen should only be available for videos
+        if (event.which === 70 && !this.isAudio()) {
+          if (!this.isFullscreen()) {
+            this.requestFullscreen();
+          } else {
+            this.exitFullscreen();
+          }
+        }
+
+        // Right arrow seeks 5 seconds ahead
+        if (event.which === 39) {
+          this.currentTime(this.currentTime() + 5);
+        }
+
+        // Left arrow seeks 5 seconds back
+        if (event.which === 37) {
+          this.currentTime(this.currentTime() - 5);
+        }
+
+        // Up arrow raises volume by 0.1
+        if (event.which === 38) {
+          this.volume(this.volume() + 0.1);
+        }
+
+        // Down arrow lowers volume by 0.1
+        if (event.which === 40) {
+          this.volume(this.volume() - 0.1);
+        }
+      }
+    },
   } : {}; // Empty configurations for empty canvases
 
   // Add file download to toolbar when it is enabled via props

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import videojs from 'video.js';
-import 'videojs-hotkeys';
 import 'videojs-markers-plugin/dist/videojs-markers-plugin';
 import 'videojs-markers-plugin/dist/videojs.markers.plugin.css';
 
@@ -167,19 +166,6 @@ function VideoJSPlayer({
         // Focus the player for hotkeys to work
         player.focus();
 
-        // Options for videojs-hotkeys: https://github.com/ctd1500/videojs-hotkeys#options
-        if (player.hotkeys) {
-          player.hotkeys({
-            volumeStep: 0.1,
-            seekStep: 5,
-            enableModifiersForNumbers: false,
-            enableVolumeScroll: false,
-            fullscreenKey: function (event, player) {
-              // override fullscreen to trigger only when it's video
-              return isVideo ? event.which === 70 : false;
-            },
-          });
-        }
       });
       player.on('ended', () => {
         playerDispatch({ isEnded: true, type: 'setIsEnded' });

--- a/yarn.lock
+++ b/yarn.lock
@@ -11164,11 +11164,6 @@ videojs-font@3.2.0:
   resolved "https://registry.yarnpkg.com/videojs-font/-/videojs-font-3.2.0.tgz#212c9d3f4e4ec3fa7345167d64316add35e92232"
   integrity sha512-g8vHMKK2/JGorSfqAZQUmYYNnXmfec4MLhwtEFS+mMs2IDY398GLysy6BH6K+aS1KMNu/xWZ8Sue/X/mdQPliA==
 
-videojs-hotkeys@^0.2.27:
-  version "0.2.28"
-  resolved "https://registry.yarnpkg.com/videojs-hotkeys/-/videojs-hotkeys-0.2.28.tgz#73d7d7b43ff62b046e6b93a0ce71c6ed5fcac105"
-  integrity sha512-M8rlD5OSB3EDRdbS4MRNlGKFpA2sSIStmUPvy5zfl/NigzWaN6r4wnb32rEN0v97GiQwmUfXSmqrPNrXhiFQmQ==
-
 videojs-markers-plugin@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/videojs-markers-plugin/-/videojs-markers-plugin-1.0.2.tgz#7e40da152504a0f1be0ee1cf608c7dccc4abf8b3"


### PR DESCRIPTION
Videojs-hotkeys was not interfacing correctly between Avalon and embedded Ramp. This could be an issue encountered by other implementers. Rather than cobble together a fix on the Avalon side and documenting that for others, it felt better to try to change the approach in Ramp so that hopefully workarounds would not be necessary. 

To that end, recent versions of VideoJS have added a builtin hotkey ability so we are going to try switching to that. This currently requires building the hotkeys out from scratch because the defaults do not include all of the functionality we require and adding any customization disables the defaults. It may be worthwhile exploring contributing "seek" and "volume" hotkey components back upstream to be added to the VideoJS default behaviors but that is a future discussion.