### PR TITLE
Remove Avalon-Api-Key field from request

### DIFF
--- a/src/components/IIIFPlayerWrapper.js
+++ b/src/components/IIIFPlayerWrapper.js
@@ -20,7 +20,7 @@ export default function IIIFPlayerWrapper({
       let requestOptions = {
         // NOTE: try thin in Avalon
         //credentials: 'include',
-        headers: { 'Avalon-Api-Key': '' },
+        // headers: { 'Avalon-Api-Key': '' },
       };
       fetch(manifestUrl, requestOptions)
         .then((result) => result.json())

--- a/src/components/MarkersDisplay/MarkerUtils/CreateMarker.js
+++ b/src/components/MarkersDisplay/MarkerUtils/CreateMarker.js
@@ -38,7 +38,7 @@ const CreateMarker = ({ newMarkerEndpoint, canvasId, handleCreate, getCurrentTim
       /** NOTE: In avalon try this option */
       headers: {
         'Accept': 'application/json',
-        'Avalon-Api-Key': '',
+        // 'Avalon-Api-Key': '',
       },
       body: JSON.stringify(annotation)
     };

--- a/src/components/MarkersDisplay/MarkerUtils/MarkerRow.js
+++ b/src/components/MarkersDisplay/MarkerUtils/MarkerRow.js
@@ -75,7 +75,7 @@ const MarkerRow = ({
       // credentials: 'same-origin',
       headers: {
         'Accept': 'application/json',
-        'Avalon-Api-Key': '',
+        // 'Avalon-Api-Key': '',
       },
       body: JSON.stringify(annotation)
     };
@@ -117,7 +117,7 @@ const MarkerRow = ({
       // credentials: 'same-origin',
       headers: {
         'Accept': 'application/json',
-        'Avalon-Api-Key': '',
+        // 'Avalon-Api-Key': '',
       }
     };
     // API call for DELETE


### PR DESCRIPTION
Cookbook recipes or any other external manifests don't open in the demo site with the `Avalon-Api-Key` in the header of the manifest request. This PR remove it from the header fields.
