### PR TITLE
Prevent retrieving currentTime when player is disposed

### DIFF
--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -171,20 +171,6 @@ function VideoJSPlayer({
         if (!isVideo) {
           player.getChild('controlBar').getChild('VolumePanel').addClass('vjs-slider-active');
         }
-
-        // Options for videojs-hotkeys: https://github.com/ctd1500/videojs-hotkeys#options
-        if (player.hotkeys) {
-          player.hotkeys({
-            volumeStep: 0.1,
-            seekStep: 5,
-            enableModifiersForNumbers: false,
-            enableVolumeScroll: false,
-            fullscreenKey: function (event, player) {
-              // override fullscreen to trigger only when it's video
-              return isVideo ? event.which === 70 : false;
-            },
-          });
-        }
       });
       player.on('ended', () => {
         playerDispatch({ isEnded: true, type: 'setIsEnded' });

--- a/src/components/MediaPlayer/VideoJS/components/js/VideoJSCurrentTime.js
+++ b/src/components/MediaPlayer/VideoJS/components/js/VideoJSCurrentTime.js
@@ -48,6 +48,7 @@ function CurrentTimeDisplay({ player, options }) {
   const [currTime, setCurrTime] = React.useState(player.currentTime());
 
   player.on('timeupdate', () => {
+    if (player.isDisposed()) return;
     let time = player.currentTime();
 
     if (targets.length > 1) time += targets[srcIndex].altStart;

--- a/src/components/MediaPlayer/VideoJS/components/js/VideoJSProgress.js
+++ b/src/components/MediaPlayer/VideoJS/components/js/VideoJSProgress.js
@@ -112,8 +112,8 @@ class VideoJSProgress extends vjsComponent {
     }
     if (curTime >= end) {
       if (nextItems.length == 0) options.nextItemClicked(0, targets[0].start);
-      player.trigger('ended');
       player.pause();
+      player.trigger('ended');
 
       // On the next play event set the time to start or a seeked time
       // in between the 'ended' event and 'play' event
@@ -163,13 +163,13 @@ class VideoJSProgress extends vjsComponent {
 }
 
 /**
- * 
+ *
  * @param {Object} obj
  * @param {obj.player} - current VideoJS player instance
  * @param {obj.handleTimeUpdate} - callback function to update time
  * @param {obj.times} - start and end times for the current source
- * @param {obj.options} - options passed when initilizing the component 
- * @returns 
+ * @param {obj.options} - options passed when initilizing the component
+ * @returns
  */
 function ProgressBar({ player, handleTimeUpdate, times, options }) {
   const [progress, _setProgress] = React.useState(0);
@@ -232,6 +232,7 @@ function ProgressBar({ player, handleTimeUpdate, times, options }) {
   });
 
   player.on('timeupdate', () => {
+    if (player.isDisposed()) return;
     const curTime = player.currentTime();
     setProgress(curTime);
     handleTimeUpdate(curTime);


### PR DESCRIPTION
This PR also includes a commit that removes videojs-hotkeys initialization code that was accidentally reintroduced after we stopped using that plugin.