### PR TITLE
Make canvas-level items w/o mediafragment into spans instead of buttons

### DIFF
--- a/src/components/StructuredNavigation/NavUtils/List.test.js
+++ b/src/components/StructuredNavigation/NavUtils/List.test.js
@@ -1,12 +1,11 @@
 import React from 'react';
 import List from './List';
 import { render, screen } from '@testing-library/react';
-import manifest from '@TestData/lunchroom-manners';
 import { withManifestAndPlayerProvider } from '../../../services/testing-helpers';
 
 describe('List component', () => {
   const sectionRef = { current: '' };
-  describe('with manifest', () => {
+  describe('displays', () => {
     const items =
     {
       id: undefined,
@@ -55,80 +54,6 @@ describe('List component', () => {
               items: [],
             },
           ],
-        },
-        {
-          id: undefined,
-          duration: '',
-          rangeId: 'https://example.com/manifest/lunchroom_manners/range/1-2',
-          isTitle: true,
-          isCanvas: false,
-          itemIndex: undefined,
-          isClickable: false,
-          isEmpty: false,
-          label: 'Washing Hands',
-          items: [
-            {
-              id: 'https://example.com/manifest/lunchroom_manners/canvas/1#t=157,160',
-              duration: '00:03',
-              rangeId: 'https://example.com/manifest/lunchroom_manners/range/1-2-1',
-              isTitle: false,
-              isCanvas: false,
-              itemIndex: 3,
-              isClickable: true,
-              isEmpty: false,
-              label: 'Using Soap',
-              items: [],
-            },
-            {
-              id: 'https://example.com/manifest/lunchroom_manners/canvas/1#t=165,170',
-              duration: '00:05',
-              rangeId: 'https://example.com/manifest/lunchroom_manners/range/1-2-3',
-              isTitle: false,
-              isCanvas: false,
-              itemIndex: 4,
-              isClickable: true,
-              isEmpty: false,
-              label: 'Rinsing Well',
-              items: [],
-            },
-            {
-              id: undefined,
-              duration: '',
-              rangeId: 'https://example.com/manifest/lunchroom_manners/range/1-2-4',
-              isTitle: true,
-              isCanvas: false,
-              itemIndex: undefined,
-              isClickable: false,
-              isEmpty: false,
-              label: 'After Washing Hands',
-              items: [
-                {
-                  id: 'https://example.com/manifest/lunchroom_manners/canvas/1#t=170,180',
-                  duration: '00:10',
-                  rangeId: 'https://example.com/manifest/lunchroom_manners/range/1-2-4-1',
-                  isTitle: false,
-                  isCanvas: false,
-                  itemIndex: 5,
-                  isClickable: true,
-                  isEmpty: false,
-                  label: 'Drying Hands',
-                  items: [],
-                },
-                {
-                  id: 'https://example.com/manifest/lunchroom_manners/canvas/1#t=180,190',
-                  duration: '00:10',
-                  rangeId: 'https://example.com/manifest/lunchroom_manners/range/1-2-4-2',
-                  isTitle: false,
-                  isCanvas: false,
-                  itemIndex: 6,
-                  isClickable: true,
-                  isEmpty: false,
-                  label: 'Getting Ready',
-                  items: [],
-                }
-              ],
-            }
-          ],
         }
       ],
     };
@@ -144,19 +69,60 @@ describe('List component', () => {
       });
       render(<ListWithManifest />);
     });
-    test('renders successfully', () => {
+    test('sstructures uccessfully', () => {
       expect(screen.getAllByTestId('list'));
     });
 
-    test('displays canvas level node as a button', () => {
-      expect(screen.queryByTestId('listitem-section-button')).toBeInTheDocument();
-      const sectionButton = screen.getByTestId('listitem-section-button');
-      expect(sectionButton.children[0]).toHaveTextContent('1. Lunchroom Manners09:32');
+    test('canvas level structure item w/o mediafragment as a span', () => {
+      expect(screen.queryByTestId('listitem-section-span')).toBeInTheDocument();
+      expect(screen.getByTestId('listitem-section-span'))
+        .toHaveTextContent('1. Lunchroom Manners09:32');
     });
 
-    test('displays the correct ListItems', () => {
-      expect(screen.getByText('3. Using Soap (00:03)'));
-      expect(screen.getByText('After Washing Hands'));
+    test('structures with the correct ListItems', () => {
+      expect(screen.getByText('1. Part I (00:45)'));
+      expect(screen.getByText('Introduction'));
     });
+  });
+
+  test('displays canvas level structure item with mediafragment as a button', () => {
+    const items = {
+      id: 'https://example.com/manifest/lunchroome_manners/canvas/1#t=0.0,572',
+      duration: '09:32',
+      rangeId: 'https://example.com/manifest/lunchroom_manners/range/1',
+      isTitle: true,
+      isCanvas: true,
+      itemIndex: 1,
+      isClickable: false,
+      isEmpty: false,
+      label: 'Lunchroom Manners',
+      items: [
+        {
+          id: undefined,
+          duration: '00:00',
+          rangeId: 'https://example.com/manifest/lunchroom_manners/range/1-1',
+          isTitle: true,
+          isCanvas: false,
+          itemIndex: undefined,
+          isClickable: false,
+          isEmpty: false,
+          label: 'Introduction',
+          items: []
+        }
+      ],
+    };
+    const props = {
+      items: [items],
+      sectionRef
+    };
+    const ListWithManifest = withManifestAndPlayerProvider(List, {
+      initialManifestState: { playlist: { isPlaylist: false } },
+      initialPlayerState: {},
+      ...props
+    });
+    render(<ListWithManifest />);
+    expect(screen.queryByTestId('listitem-section-button')).toBeInTheDocument();
+    expect(screen.getByTestId('listitem-section-button'))
+      .toHaveTextContent('1. Lunchroom Manners');
   });
 });

--- a/src/components/StructuredNavigation/NavUtils/ListItem.js
+++ b/src/components/StructuredNavigation/NavUtils/ListItem.js
@@ -93,31 +93,21 @@ const ListItem = ({
         {isCanvas && !isPlaylist
           ?
           <React.Fragment>
-            {itemIdRef.current != undefined
-              ? <a href={itemIdRef.current} onClick={handleClick} className="ramp--structured-nav__section-link">
-                <SectionButton
-                  itemIndex={itemIndex}
-                  duration={duration}
-                  label={label}
-                  itemsLength={items?.length}
-                  sectionRef={sectionRef}
-                />
-              </a>
-              :
-              <SectionButton
-                itemIndex={itemIndex}
-                duration={duration}
-                label={label}
-                itemsLength={items?.length}
-                sectionRef={sectionRef}
-              />
-            }
+            <SectionButton
+              itemIndex={itemIndex}
+              duration={duration}
+              label={label}
+              itemsLength={items?.length}
+              sectionRef={sectionRef}
+              itemId={itemIdRef.current}
+              handleClick={handleClick}
+            />
           </React.Fragment>
           :
           <React.Fragment>
             {isTitle
               ?
-              (<span className="ramp--structured-nav__section-title"
+              (<span className="ramp--structured-nav__item-title"
                 role="listitem"
                 aria-label={itemLabelRef.current}
               >
@@ -153,6 +143,7 @@ const ListItem = ({
         className="ramp--structured-nav__list-item"
         aria-label={itemLabelRef.current}
         role="listitem"
+        data-label={label}
       >
         {renderListItem()}
         {subMenu}

--- a/src/components/StructuredNavigation/NavUtils/SectionButton.js
+++ b/src/components/StructuredNavigation/NavUtils/SectionButton.js
@@ -16,7 +16,15 @@ const AccordionArrow = () => {
   );
 };
 
-const SectionButton = ({ duration, label, itemIndex, itemsLength, sectionRef }) => {
+const SectionButton = ({
+  duration,
+  label,
+  itemIndex,
+  itemsLength,
+  sectionRef,
+  itemId,
+  handleClick
+}) => {
   let itemLabelRef = React.useRef();
   itemLabelRef.current = label;
 
@@ -38,24 +46,42 @@ const SectionButton = ({ duration, label, itemIndex, itemsLength, sectionRef }) 
   //   }
   // };
 
-  return (
-    <button className="ramp--structured-nav__section-button" data-testid="listitem-section-button"
-      ref={sectionRef}>
-      <span className="ramp--structured-nav__section-title"
-        role="listitem"
-        aria-label={itemLabelRef.current}
-      >
-        {`${itemIndex}. `}
-        {itemLabelRef.current}
-        {duration != '' &&
-          <span className="ramp--structured-nav__section-duration">
-            {duration}
-          </span>}
-      </span>
-      {/* {itemsLength > 0 ? <AccordionArrow /> : null} */}
-    </button>
-  );
-
+  if (itemId != undefined) {
+    return (
+      <button className="ramp--structured-nav__section-button" data-testid="listitem-section-button"
+        ref={sectionRef} onClick={handleClick}>
+        <span className="ramp--structured-nav__title"
+          role="listitem"
+          aria-label={itemLabelRef.current}
+        >
+          {`${itemIndex}. `}
+          {itemLabelRef.current}
+          {duration != '' &&
+            <span className="ramp--structured-nav__section-duration">
+              {duration}
+            </span>}
+        </span>
+        {/* {itemsLength > 0 ? <AccordionArrow /> : null} */}
+      </button>
+    );
+  } else {
+    return (
+      <div className="ramp--structured-nav__section" data-testid="listitem-section-span">
+        <span className="ramp--structured-nav__section-title"
+          role="listitem"
+          aria-label={itemLabelRef.current}
+        >
+          {`${itemIndex}. `}
+          {itemLabelRef.current}
+          {duration != '' &&
+            <span className="ramp--structured-nav__section-duration">
+              {duration}
+            </span>
+          }
+        </span>
+      </div>
+    );
+  }
 };
 
 SectionButton.propTypes = {
@@ -63,7 +89,9 @@ SectionButton.propTypes = {
   duration: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
   itemsLength: PropTypes.number.isRequired,
-  sectionRef: PropTypes.object.isRequired
+  sectionRef: PropTypes.object.isRequired,
+  itemId: PropTypes.string,
+  handleClick: PropTypes.func.isRequired,
 };
 
 export default SectionButton;

--- a/src/components/StructuredNavigation/NavUtils/SectionButton.test.js
+++ b/src/components/StructuredNavigation/NavUtils/SectionButton.test.js
@@ -1,8 +1,9 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import SectionButton from './SectionButton';
 
 describe('SectionButon component', () => {
+  const handleClickMock = jest.fn();
   test('renders canvas with children items', () => {
     const sectionRef = { current: '' };
     render(
@@ -12,10 +13,13 @@ describe('SectionButon component', () => {
         itemsLength={2}
         itemIndex={1}
         sectionRef={sectionRef}
+        handleClick={handleClickMock}
       />
     );
-    expect(screen.queryAllByTestId('listitem-section-button')).toHaveLength(1);
-    expect(screen.getByTestId('listitem-section-button')).toHaveTextContent('1. Lunchroom Manners09:32');
+    expect(screen.queryAllByTestId('listitem-section-span')).toHaveLength(1);
+    expect(screen.queryAllByTestId('listitem-section-button')).toHaveLength(0);
+    expect(screen.getByTestId('listitem-section-span'))
+      .toHaveTextContent('1. Lunchroom Manners09:32');
   });
 
   test('renders canvas without children items', () => {
@@ -27,9 +31,50 @@ describe('SectionButon component', () => {
         itemsLength={0}
         itemIndex={1}
         sectionRef={sectionRef}
+        handleClick={handleClickMock}
       />
     );
+    expect(screen.queryAllByTestId('listitem-section-span')).toHaveLength(1);
+    expect(screen.queryAllByTestId('listitem-section-button')).toHaveLength(0);
+    expect(screen.getByTestId('listitem-section-span'))
+      .toHaveTextContent('1. Lunchroom Manners09:32');
+  });
+
+  test('renders canvas with mediafragment as a button', () => {
+    const sectionRef = { current: '' };
+    render(
+      <SectionButton
+        duration={'09:32'}
+        label={'Lunchroom Manners'}
+        itemsLength={0}
+        itemIndex={1}
+        sectionRef={sectionRef}
+        itemId='https://example.com/manifest/canvas#t=0.0,572'
+        handleClick={handleClickMock}
+      />
+    );
+    expect(screen.queryAllByTestId('listitem-section-span')).toHaveLength(0);
     expect(screen.queryAllByTestId('listitem-section-button')).toHaveLength(1);
-    expect(screen.getByTestId('listitem-section-button')).toHaveTextContent('1. Lunchroom Manners09:32');
+    expect(screen.getByTestId('listitem-section-button'))
+      .toHaveTextContent('1. Lunchroom Manners09:32');
+  });
+
+  test('renders canvas w/o mediafragment as a span', () => {
+    const sectionRef = { current: '' };
+    render(
+      <SectionButton
+        duration={'09:32'}
+        label={'Lunchroom Manners'}
+        itemsLength={0}
+        itemIndex={1}
+        sectionRef={sectionRef}
+        itemId={undefined}
+        handleClick={handleClickMock}
+      />
+    );
+    expect(screen.queryAllByTestId('listitem-section-span')).toHaveLength(1);
+    expect(screen.queryAllByTestId('listitem-section-button')).toHaveLength(0);
+    expect(screen.getByTestId('listitem-section-span'))
+      .toHaveTextContent('1. Lunchroom Manners09:32');
   });
 });

--- a/src/components/StructuredNavigation/StructuredNavigation.scss
+++ b/src/components/StructuredNavigation/StructuredNavigation.scss
@@ -4,6 +4,7 @@
   margin-top: 20px;
   max-height: 40vh;
   min-width: 45vh;
+  max-width: 50vw;
   overflow-y: auto;
 
   a {
@@ -63,11 +64,20 @@ ul.ramp--structured-nav__list {
     }
   }
 
+  .ramp--structured-nav__section {
+    display: flex;
+    align-items: center;
+    background-color: $primaryLightest;
+    border-top: 1px solid $primaryLight;
+    padding: 1rem;
+    font-size: 1.25rem;
+  }
+
   button.ramp--structured-nav__section-button {
     cursor: pointer;
     align-items: center;
     display: flex;
-    background-color: transparent;
+    background-color: $primaryLightest;
     border: none;
     border-top: 1px solid $primaryLight;
     text-align: left;
@@ -77,7 +87,7 @@ ul.ramp--structured-nav__list {
     font-weight: 400;
 
     &:hover {
-      background-color: $primaryLightest;
+      background-color: $primaryGreenLight;
     }
 
     .ramp--structured-nav__section-title {
@@ -99,7 +109,7 @@ ul.ramp--structured-nav__list {
   }
 
   span.ramp--structured-nav__section-duration {
-    border: 2px solid $primaryLight;
+    border: 1px solid $primaryDark;
     border-radius: 999px;
     color: $primaryDarkest;
     font-weight: 500;
@@ -113,5 +123,4 @@ ul.ramp--structured-nav__list {
   svg.structure-item-locked {
     margin-right: 0.5rem;
   }
-
 }

--- a/src/components/StructuredNavigation/StructuredNavigation.test.js
+++ b/src/components/StructuredNavigation/StructuredNavigation.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, queryAllByTestId, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import StructuredNavigation from './StructuredNavigation';
 import manifest from '@TestData/lunchroom-manners';
 import {
@@ -47,7 +47,10 @@ describe('StructuredNavigation component', () => {
           'Lunchroom Manners'
         );
         expect(firstItem.children[0]).toHaveClass(
-          'ramp--structured-nav__section-button'
+          'ramp--structured-nav__section'
+        );
+        expect(firstItem.children[0].children[0]).toHaveClass(
+          'ramp--structured-nav__section-title'
         );
       });
     });


### PR DESCRIPTION
Canvas w/o mediafragment information displayed as a span:
![image](https://github.com/samvera-labs/ramp/assets/1331659/dd524c97-61a6-4e11-9f97-010f2be176ce)

Canvas with medifragment information displayed as a button;
![image](https://github.com/samvera-labs/ramp/assets/1331659/860b8b2b-3970-4c42-aa99-24f2573099f4)

