### PR TITLE
Fix mismatching colors for button and span section items in structure

### DIFF
--- a/src/components/StructuredNavigation/StructuredNavigation.scss
+++ b/src/components/StructuredNavigation/StructuredNavigation.scss
@@ -74,6 +74,7 @@ ul.ramp--structured-nav__list {
       padding: 1rem;
       font-size: 1.25rem;
       font-weight: inherit;
+      background: transparent;
 
       &:hover {
         background-color: $primaryGreenLight;


### PR DESCRIPTION
Before:
![image](https://github.com/samvera-labs/ramp/assets/1331659/9e380587-a535-494e-8f66-9cd2a43e4481)

After:
![image](https://github.com/samvera-labs/ramp/assets/1331659/171c034d-a2d4-47a7-862a-653b3e104612)
