### PR TITLE
Keep focus on next/previous buttons when using keyboard navigation

### DIFF
--- a/src/components/MediaPlayer/MediaPlayer.js
+++ b/src/components/MediaPlayer/MediaPlayer.js
@@ -44,7 +44,7 @@ const MediaPlayer = ({ enableFileDownload = false, enablePIP = false }) => {
     playlist
   } =
     manifestState;
-  const { player, currentTime } = playerState;
+  const { playerFocusElement, currentTime } = playerState;
 
   React.useEffect(() => {
     if (manifest) {
@@ -181,14 +181,21 @@ const MediaPlayer = ({ enableFileDownload = false, enablePIP = false }) => {
     }
   };
 
-  // Switch player when navigating across canvases
-  const switchPlayer = (index, fromStart) => {
+  /**
+   * Switch player when navigating across canvases
+   * @param {Number} index canvas index to be loaded into the player
+   * @param {Boolean} fromStart flag to indicate set player start time to zero or not
+   * @param {String} focusElement element to be focused within the player when using 
+   * next or previous buttons with keyboard
+   */
+  const switchPlayer = (index, fromStart, focusElement = '') => {
     if (canvasIndex != index) {
       manifestDispatch({
         canvasIndex: index,
         type: 'switchCanvas',
       });
     }
+    playerDispatch({ element: focusElement, type: 'setPlayerFocusElement' });
     initCanvas(index, fromStart);
   };
 
@@ -342,12 +349,14 @@ const MediaPlayer = ({ enableFileDownload = false, enablePIP = false }) => {
         ...videoJsOptions.controlBar,
         videoJSPreviousButton: {
           canvasIndex,
-          switchPlayer
+          switchPlayer,
+          playerFocusElement,
         },
         videoJSNextButton: {
           canvasIndex,
           lastCanvasIndex,
-          switchPlayer
+          switchPlayer,
+          playerFocusElement,
         },
       }
     };

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -62,6 +62,7 @@ function VideoJSPlayer({
     startTime,
     currentTime,
     playerRange,
+    playerFocusElement,
   } = playerState;
 
   const [cIndex, setCIndex] = React.useState(canvasIndex);
@@ -169,7 +170,9 @@ function VideoJSPlayer({
         console.log('Player ready');
 
         // Focus the player for hotkeys to work
-        player.focus();
+        if (playerFocusElement == '') {
+          player.focus();
+        }
 
         // Add class for volume panel in audio player to make it always visible
         if (!isVideo) {

--- a/src/components/MediaPlayer/VideoJS/components/js/VideoJSNextButton.js
+++ b/src/components/MediaPlayer/VideoJS/components/js/VideoJSNextButton.js
@@ -34,6 +34,7 @@ class VideoJSNextButton extends vjsComponent {
 
     this.mount = this.mount.bind(this);
     this.options = options;
+    this.player = player;
 
     /* When player is ready, call method to mount React component */
     player.ready(() => {
@@ -48,16 +49,41 @@ class VideoJSNextButton extends vjsComponent {
 
   mount() {
     ReactDOM.render(
-      <NextButton {...this.options} />,
+      <NextButton {...this.options}
+        player={this.player} />,
       this.el()
     );
   }
 }
 
-function NextButton({ canvasIndex, lastCanvasIndex, switchPlayer }) {
-  const handleNextClick = () => {
+function NextButton({
+  canvasIndex,
+  lastCanvasIndex,
+  switchPlayer,
+  playerFocusElement,
+  player
+}) {
+  let nextRef = React.useRef();
+
+  React.useEffect(() => {
+    if (playerFocusElement == 'nextBtn') {
+      nextRef.current.focus();
+    }
+  }, []);
+
+  const handleNextClick = (isKeyDown) => {
     if (canvasIndex != lastCanvasIndex) {
-      switchPlayer(canvasIndex + 1, true);
+      switchPlayer(
+        canvasIndex + 1,
+        true,
+        isKeyDown ? 'nextBtn' : '');
+    }
+  };
+
+  const handleNextKeyDown = (e) => {
+    if (e.which === 32 || e.which === 13) {
+      e.stopPropagation();
+      handleNextClick(true);
     }
   };
 
@@ -65,9 +91,11 @@ function NextButton({ canvasIndex, lastCanvasIndex, switchPlayer }) {
     <div className="vjs-button vjs-control">
       <button className="vjs-button vjs-next-button"
         role="button"
+        ref={nextRef}
         tabIndex={0}
         title={"Next"}
-        onClick={handleNextClick}>
+        onClick={() => handleNextClick(false)}
+        onKeyDown={handleNextKeyDown}>
         <NextButtonIcon scale="0.9" />
       </button>
     </div >

--- a/src/components/MediaPlayer/VideoJS/components/js/VideoJSPreviousButton.js
+++ b/src/components/MediaPlayer/VideoJS/components/js/VideoJSPreviousButton.js
@@ -55,12 +55,35 @@ class VideoJSPreviousButton extends vjsComponent {
   }
 }
 
-function PreviousButton({ canvasIndex, switchPlayer, player }) {
-  const handlePreviousClick = () => {
+function PreviousButton({
+  canvasIndex,
+  switchPlayer,
+  playerFocusElement,
+  player
+}) {
+  let previousRef = React.useRef();
+
+  React.useEffect(() => {
+    if (playerFocusElement == 'previousBtn') {
+      previousRef.current.focus();
+    }
+  }, []);
+
+  const handlePreviousClick = (isKeyDown) => {
     if (canvasIndex > -1 && canvasIndex != 0) {
-      switchPlayer(canvasIndex - 1, true);
+      switchPlayer(
+        canvasIndex - 1,
+        true,
+        isKeyDown ? 'previousBtn' : '');
     } else if (canvasIndex == 0) {
       player.currentTime(0);
+    }
+  };
+
+  const handlePreviousKeyDown = (e) => {
+    if (e.which === 32 || e.which === 13) {
+      e.stopPropagation();
+      handlePreviousClick(true);
     }
   };
 
@@ -68,12 +91,14 @@ function PreviousButton({ canvasIndex, switchPlayer, player }) {
     <div className="vjs-button vjs-control">
       <button className="vjs-button vjs-previous-button"
         role="button"
+        ref={previousRef}
         tabIndex={0}
         title={canvasIndex == 0 ? "Replay" : "Previous"}
-        onClick={handlePreviousClick}>
+        onClick={() => handlePreviousClick(false)}
+        onKeyDown={handlePreviousKeyDown}>
         <PreviousButtonIcon scale="0.9" />
       </button>
-    </div >
+    </div>
   );
 }
 

--- a/src/context/player-context.js
+++ b/src/context/player-context.js
@@ -16,6 +16,7 @@ const defaultState = {
   isEnded: false,
   currentTime: null,
   playerRange: { start: null, end: null },
+  playerFocusElement: ''
 };
 
 function PlayerReducer(state = defaultState, action) {
@@ -60,6 +61,12 @@ function PlayerReducer(state = defaultState, action) {
           start: action.start,
           end: action.end,
         },
+      };
+    }
+    case 'setPlayerFocusElement': {
+      return {
+        ...state,
+        playerFocusElement: action.element ? action.element : '',
       };
     }
     default: {


### PR DESCRIPTION
Use a state variable in the state management called `playerFocusElement` to persist the focused element information when using previous/next buttons with keyboard assistance. 
This value is then used to retain focus on the previous/next buttons when the new player instance loaded on the page.