### PR TITLE
Setting restricted message timer when using autoplay

### DIFF
--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -33,7 +33,6 @@ function VideoJSPlayer({
   isVideo,
   isPlaylist,
   switchPlayer,
-  handleIsEnded,
   ...videoJSOptions
 }) {
   const playerState = usePlayerState();
@@ -256,10 +255,10 @@ function VideoJSPlayer({
       });
       player.on('waiting', () => {
         /* When using structured navigation while the media is playing,
-      set the currentTime to the start time of the clicked media
-      fragment's start time. Without this the 'timeupdate' event tries
-      to read currentTime before the player is ready, and triggers an error.
-      */
+        set the currentTime to the start time of the clicked media
+        fragment's start time. Without this the 'timeupdate' event tries
+        to read currentTime before the player is ready, and triggers an error.
+        */
         if (isClicked && isEnded) {
           player.currentTime(currentTimeRef.current);
         }
@@ -419,9 +418,6 @@ function VideoJSPlayer({
         } else {
           manifestDispatch({ item: null, type: 'switchItem' });
         }
-
-        handleIsEnded();
-
         setCIndex(cIndex + 1);
       }
     } else if (hasMultiItems) {
@@ -533,7 +529,6 @@ VideoJSPlayer.propTypes = {
   isVideo: PropTypes.bool,
   isPlaylist: PropTypes.bool,
   switchPlayer: PropTypes.func,
-  handleIsEnded: PropTypes.func,
   videoJSOptions: PropTypes.object,
 };
 

--- a/src/services/iiif-parser.js
+++ b/src/services/iiif-parser.js
@@ -10,6 +10,7 @@ import {
   getResourceItems,
   parseAnnotations,
   parseSequences,
+  setCanvasMessageTimeout,
   timeToHHmmss
 } from './utility-helpers';
 
@@ -277,6 +278,7 @@ export function getPlaceholderCanvas(manifest, canvasIndex, isPoster = false) {
             placeholder = item.getLabel().getValue()
               ? getLabelValue(item.getLabel().getValue())
               : 'This item cannot be played.';
+            setCanvasMessageTimeout(placeholderCanvas['duration']);
           }
           return placeholder;
         }

--- a/src/services/iiif-parser.test.js
+++ b/src/services/iiif-parser.test.js
@@ -4,7 +4,9 @@ import lunchroomManifest from '@TestData/lunchroom-manners';
 import manifestWoStructure from '@TestData/transcript-canvas';
 import singleSrcManifest from '@TestData/transcript-multiple-canvas';
 import autoAdvanceManifest from '@TestData/multiple-canvas-auto-advance';
+import playlistManifest from '@TestData/playlist';
 import * as iiifParser from './iiif-parser';
+import * as util from './utility-helpers';
 
 describe('iiif-parser', () => {
   describe('canvasesInManifest()', () => {
@@ -243,20 +245,29 @@ describe('iiif-parser', () => {
       expect(posterUrl).toBeNull();
     });
 
-    it('returns text under placeholderCanvas', () => {
+    it('returns placeholderCanvas text and sets timer to given duration', () => {
       const itemMessage = iiifParser.getPlaceholderCanvas(manifest, 1);
       expect(itemMessage).toEqual('You do not have permission to playback this item. \nPlease contact support to report this error: <a href="mailto:admin-list@example.com">admin-list@example.com</a>.\n');
+      expect(util.CANVAS_MESSAGE_TIMEOUT).toEqual(4000);
     });
 
-    it('returns hard coded text when placeholderCanvas has no text', () => {
+    it('returns placeholderCanvas text and sets timer to default when duration is not defined', () => {
+      const itemMessage = iiifParser.getPlaceholderCanvas(playlistManifest, 0);
+      expect(itemMessage).toEqual('You do not have permission to playback this item.');
+      expect(util.CANVAS_MESSAGE_TIMEOUT).toEqual(3000);
+    });
+
+    it('returns hard coded text when placeholderCanvas has no text and sets timer to default', () => {
       const itemMessage = iiifParser.getPlaceholderCanvas(lunchroomManifest, 0);
       expect(itemMessage).toEqual('This item cannot be played.');
+      expect(util.CANVAS_MESSAGE_TIMEOUT).toEqual(3000);
     });
 
-    it('returns default message when no placeholderCanvas is in the Canvas', () => {
+    it('returns default message when no placeholderCanvas is in the Canvas and sets timer to default', () => {
       const itemMessage = iiifParser.getPlaceholderCanvas(singleSrcManifest, 0);
       expect(console.error).toBeCalledTimes(1);
       expect(itemMessage).toEqual('This item cannot be played.');
+      expect(util.CANVAS_MESSAGE_TIMEOUT).toEqual(3000);
     });
   });
 

--- a/src/services/utility-helpers.js
+++ b/src/services/utility-helpers.js
@@ -1,6 +1,5 @@
 import { parseManifest, Annotation, AnnotationPage } from 'manifesto.js';
 
-
 // Handled file types for downloads
 const VALID_FILE_EXTENSIONS = [
   'doc',
@@ -18,11 +17,34 @@ const VALID_FILE_EXTENSIONS = [
 
 const S_ANNOTATION_TYPE = { transcript: 1, caption: 2, both: 3 };
 
-export let GENERIC_ERROR_MESSAGE = '';
+const DEFAULT_ERROR_MESSAGE = "Error encountered. Please check your Manifest.";
+export let GENERIC_ERROR_MESSAGE = DEFAULT_ERROR_MESSAGE;
 
-export function setAppErrorMessage(message = "Error encountered. Please check your Manifest.") {
-  GENERIC_ERROR_MESSAGE = message;
+// Timer for displaying placeholderCanvas text when a Canvas is empty
+const DEFAULT_TIMEOUT = 3000;
+export let CANVAS_MESSAGE_TIMEOUT = DEFAULT_TIMEOUT;
+
+/**
+ * Sets the timer for displaying the placeholderCanvas text in the player
+ * for an empty Canvas. This value defaults to 3 seconds, if the `duration`
+ * property of the placeholderCanvas is undefined
+ * @param {Number} timeout duration of the placeholderCanvas if given
+ */
+export function setCanvasMessageTimeout(timeout) {
+  CANVAS_MESSAGE_TIMEOUT = timeout || DEFAULT_TIMEOUT;
 }
+
+/**
+ * Sets the generic error message in the ErrorBoundary when the
+ * components fail with critical error. This defaults to the given
+ * vaule when a custom message is not specified in the `customErrorMessage`
+ * prop of the IIIFPlayer component
+ * @param {String} message custom error message from props
+ */
+export function setAppErrorMessage(message) {
+  GENERIC_ERROR_MESSAGE = message || DEFAULT_ERROR_MESSAGE;
+}
+
 export function parseSequences(manifest) {
   let sequences = parseManifest(manifest).getSequences();
   if (sequences != undefined && sequences[0] != undefined) {

--- a/src/services/utility-helpers.test.js
+++ b/src/services/utility-helpers.test.js
@@ -430,4 +430,38 @@ describe('util helper', () => {
       );
     });
   });
+
+  describe('setCanvasMessageTimeout()', () => {
+    it('sets default value when param is undefined', () => {
+      util.setCanvasMessageTimeout(undefined);
+      expect(util.CANVAS_MESSAGE_TIMEOUT).toEqual(3000);
+    });
+
+    it('sets default value when param is null', () => {
+      util.setCanvasMessageTimeout(null);
+      expect(util.CANVAS_MESSAGE_TIMEOUT).toEqual(3000);
+    });
+
+    it('sets the given value', () => {
+      util.setCanvasMessageTimeout(10000);
+      expect(util.CANVAS_MESSAGE_TIMEOUT).toEqual(10000);
+    });
+  });
+
+  describe('setAppErrorMessage()', () => {
+    it('sets default value when param is undefined', () => {
+      util.setAppErrorMessage(undefined);
+      expect(util.GENERIC_ERROR_MESSAGE).toEqual("Error encountered. Please check your Manifest.");
+    });
+
+    it('sets default value when param is null', () => {
+      util.setAppErrorMessage(null);
+      expect(util.GENERIC_ERROR_MESSAGE).toEqual("Error encountered. Please check your Manifest.");
+    });
+
+    it('sets the given value', () => {
+      util.setAppErrorMessage("Error occurred. Please try again later.");
+      expect(util.GENERIC_ERROR_MESSAGE).toEqual("Error occurred. Please try again later.");
+    });
+  });
 });

--- a/src/test_data/transcript-annotation.js
+++ b/src/test_data/transcript-annotation.js
@@ -125,6 +125,7 @@ export default {
       placeholderCanvas: {
         id: 'https://example.com/sample/transcript-annotation/canvas/2/placeholder',
         type: "Canvas",
+        duration: 4000,
         items: [
           {
             id: 'https://example.com/sample/transcript-annotation/canvas/2/placeholder/1',


### PR DESCRIPTION
Default timeout value for message display is set to 3 seconds, this is overwritten by the `duration` property of the `placeholderCanvas` if it exists.

With autoplay turned on:

[autoplay_on.webm](https://github.com/samvera-labs/ramp/assets/1331659/ed3f51de-08d3-4a59-b309-5f81425faa83)

With autoplay turned off:

[autoplay_off.webm](https://github.com/samvera-labs/ramp/assets/1331659/d270c979-2d88-4a48-9065-3d7096329ec0)
