### PR TITLE
Change canvas change trigger from a mutation observer to an event listener

### DIFF
--- a/src/components/Transcript/Transcript.js
+++ b/src/components/Transcript/Transcript.js
@@ -33,7 +33,6 @@ const Transcript = ({ playerID, manifestUrl, transcripts = [] }) => {
     isMachineGen: false,
   });
   const [canvasIndex, _setCanvasIndex] = React.useState(0);
-  const [canvasIsEmpty, setCanvasIsEmpty] = React.useState(false);
   const [isLoading, setIsLoading] = React.useState(true);
   const [errorMsg, setError] = React.useState('');
   const [timedTextState, setTimedText] = React.useState([]);
@@ -151,7 +150,7 @@ const Transcript = ({ playerID, manifestUrl, transcripts = [] }) => {
       setCanvasTranscripts(cTranscripts.items);
       setStateVar(cTranscripts.items[0]);
     }
-  }, [canvasIndex, canvasIsEmpty]);
+  }, [canvasIndex]);
 
   const initTranscriptData = (allTranscripts) => {
     let getCanvasT = (tr) => {

--- a/src/services/transcript-parser.js
+++ b/src/services/transcript-parser.js
@@ -11,7 +11,6 @@ import {
   identifySupplementingAnnotation,
   parseSequences,
 } from './utility-helpers';
-import { canvasesInManifest } from '@Services/iiif-parser'
 
 const TRANSCRIPT_MIME_TYPES = [
   { type: 'application/json', ext: 'json' },
@@ -596,32 +595,4 @@ function parseWebVTTLine({ times, line }) {
   }
   let transcriptText = { begin: timeToS(start), end: timeToS(end), text: line };
   return transcriptText;
-}
-
-/**
- * Get all the canvases in manifest
- * @param {String} manifestURL IIIF Presentation 3.0 manifest URL
- * @return {Array} array of canvas IDs in manifest
- */
-export async function getCanvasesInManifest(manifestURL) {
-  let data = await fetch(manifestURL)
-    .then(function (response) {
-      const fileType = response.headers.get('Content-Type');
-      if (fileType.includes('application/json')) {
-        const jsonData = response.json();
-        return jsonData;
-      }
-    }).then((data) => {
-      const canvases = canvasesInManifest(data);
-
-      return canvases;
-    })
-    .catch(error => {
-      console.error(
-        'transcript-parser -> getCanvasesInManifest() -> error fetching canvases from, '
-        , manifestURL
-      );
-      return [];
-    });
-  return data;
 }


### PR DESCRIPTION
This PR adjusts how `canvasIndex` in the state is set. The behavior with these changes is somewhat flaky. Sometimes the hooks fire on every canvas change, sometimes they don't fire at all. I would guess it has something to do with the event listener not actually getting associated with player. 

Having the event listener and the mutation observer in place at the same time I think did provide somewhat more consistent behavior in testing when switching canvases but would trigger the transcript component to enter its loading state multiple times.

@Dananji, could you do some testing and see if you can get it working consistently?