### PR TITLE
Retrieve and use CSRF token in Marker component

### DIFF
--- a/src/components/MarkersDisplay/MarkerUtils/CreateMarker.js
+++ b/src/components/MarkersDisplay/MarkerUtils/CreateMarker.js
@@ -4,7 +4,7 @@ import { createNewAnnotation, parseMarkerAnnotation } from '@Services/playlist-p
 import { validateTimeInput, timeToS, timeToHHmmss } from '@Services/utility-helpers';
 import { SaveIcon, CancelIcon } from './SVGIcons';
 
-const CreateMarker = ({ newMarkerEndpoint, canvasId, handleCreate, getCurrentTime }) => {
+const CreateMarker = ({ newMarkerEndpoint, canvasId, handleCreate, getCurrentTime, csrfToken }) => {
   const [isOpen, setIsOpen] = React.useState(false);
   const [isValid, setIsValid] = React.useState(false);
   const [saveError, setSaveError] = React.useState(false);
@@ -36,12 +36,14 @@ const CreateMarker = ({ newMarkerEndpoint, canvasId, handleCreate, getCurrentTim
     const requestOptions = {
       method: 'POST',
       /** NOTE: In avalon try this option */
+      credentials: 'same-origin',
       headers: {
         'Accept': 'application/json',
         // 'Avalon-Api-Key': '',
       },
       body: JSON.stringify(annotation)
     };
+    if (csrfToken) { requestOptions.headers.push({'X-CSRF-Token': csrfToken }) };
     fetch(newMarkerEndpoint, requestOptions)
       .then((response) => {
         if (response.status != 201) {

--- a/src/components/MarkersDisplay/MarkerUtils/MarkerRow.js
+++ b/src/components/MarkersDisplay/MarkerUtils/MarkerRow.js
@@ -10,7 +10,8 @@ const MarkerRow = ({
   handleDelete,
   hasAnnotationService,
   isEditing,
-  toggleIsEditing
+  toggleIsEditing,
+  csrfToken
 }) => {
   const [editing, setEditing] = React.useState(false);
   const [isValid, setIsValid] = React.useState(true);
@@ -72,13 +73,14 @@ const MarkerRow = ({
     const requestOptions = {
       method: 'PUT',
       /** NOTE: In avalon try this option */
-      // credentials: 'same-origin',
+      credentials: 'same-origin',
       headers: {
         'Accept': 'application/json',
         // 'Avalon-Api-Key': '',
       },
       body: JSON.stringify(annotation)
     };
+    if (csrfToken) { requestOptions.headers.push({'X-CSRF-Token': csrfToken }) };
     fetch(marker.id, requestOptions)
       .then((response) => {
         if (response.status != 201) {
@@ -114,12 +116,13 @@ const MarkerRow = ({
     const requestOptions = {
       method: 'DELETE',
       /** NOTE: In avalon try this option */
-      // credentials: 'same-origin',
+      credentials: 'same-origin',
       headers: {
         'Accept': 'application/json',
         // 'Avalon-Api-Key': '',
       }
     };
+    if (csrfToken) { requestOptions.headers.push({'X-CSRF-Token': csrfToken }) };
     // API call for DELETE
     fetch(marker.id, requestOptions)
       .then((response) => {

--- a/src/components/MarkersDisplay/MarkersDisplay.js
+++ b/src/components/MarkersDisplay/MarkersDisplay.js
@@ -28,6 +28,9 @@ const MarkersDisplay = ({ showHeading = true, headingText = 'Markers' }) => {
     playlistMarkersRef.current = list;
   };
 
+  // Retrieves the CRSF authenticity token when component is embedded in a Rails app.
+  const csrfToken = document.getElementsByName('csrf-token')[0]?.content;
+
   React.useEffect(() => {
     if (manifest) {
       try {
@@ -124,6 +127,7 @@ const MarkersDisplay = ({ showHeading = true, headingText = 'Markers' }) => {
           canvasId={canvasIdRef.current}
           handleCreate={handleCreate}
           getCurrentTime={getCurrentTime}
+          csrfToken={csrfToken}
         />
       )}
       {playlistMarkersRef.current.length > 0 && (
@@ -145,7 +149,8 @@ const MarkersDisplay = ({ showHeading = true, headingText = 'Markers' }) => {
                 handleDelete={handleDelete}
                 hasAnnotationService={hasAnnotationService}
                 isEditing={isEditing}
-                toggleIsEditing={toggleIsEditing} />
+                toggleIsEditing={toggleIsEditing}
+                csrfToken={csrfToken} />
             ))}
           </tbody>
         </table>
@@ -168,4 +173,3 @@ MarkersDisplay.propTypes = {
 };
 
 export default MarkersDisplay;
-


### PR DESCRIPTION
We can retrieve the Rails CSRF token within Ramp from the HTML document. Passing that token into the parts of the component that create/handle requests, we can provide the proper headers to the `fetch` requests to get the actions to carry out as expected in Avalon.