### PR TITLE
Primarily rely on browser for file extension assignment

### DIFF
--- a/src/components/Transcript/Transcript.js
+++ b/src/components/Transcript/Transcript.js
@@ -20,7 +20,7 @@ const NO_SUPPORT = 'Transcript format is not supported, please check again.';
  * @param {String} param0 ID of the HTML element for the player on page
  * @param {String} param1 manifest URL to read transcripts from
  * @param {Object} param2 transcripts resource
- * @returns 
+ * @returns
  */
 const Transcript = ({ playerID, manifestUrl, transcripts = [] }) => {
   const [transcriptsList, setTranscriptsList] = React.useState([]);
@@ -279,7 +279,7 @@ const Transcript = ({ playerID, manifestUrl, transcripts = [] }) => {
       return;
     }
 
-    // Scroll the transcript line to the center of the 
+    // Scroll the transcript line to the center of the
     // transcript component view
     autoScroll(tr, transcriptContainerRef);
   };
@@ -460,7 +460,7 @@ const Transcript = ({ playerID, manifestUrl, transcripts = [] }) => {
               selectTranscript={selectTranscript}
               transcriptData={canvasTranscripts}
               transcriptInfo={transcriptInfo}
-              noTranscript={errorMsg?.length > 0}
+              noTranscript={errorMsg?.length > 0 && errorMsg != NO_SUPPORT}
             />
           </div>
         )}

--- a/src/services/utility-helpers.js
+++ b/src/services/utility-helpers.js
@@ -181,10 +181,10 @@ export function fileDownload(fileUrl, fileName, fileExt = '', machineGenerated =
     fileNameNoExt = `${fileNameNoExt} (machine generated)`;
   }
 
-  // For Avalon style downloads, rely on the browser to properly determine file
-  // extension unless it is an unsupported format, then we provide a '.doc'
-  // extension. If extension is included in download name the browser does not
-  // try to insert its own, preventing duplication or multiple extensions.
+  // Rely on the browser to properly determine file extension unless it is an 
+  // unsupported format, then we provide a '.doc' extension. If extension is 
+  // included in download name the browser does not try to insert its own, 
+  // preventing duplication or multiple extensions.
   let downloadName = fileExtension === 'doc'
     ? `${fileNameNoExt}.${fileExtension}`
     : fileNameNoExt;

--- a/src/services/utility-helpers.js
+++ b/src/services/utility-helpers.js
@@ -210,7 +210,7 @@ export function fileDownload(fileUrl, fileName, fileExt = '', machineGenerated =
     // For URLs of format: http://.../<filename>
     const link = document.createElement('a');
     link.setAttribute('href', fileUrl);
-    link.setAttribute('download', `${fileNameNoExt}.${fileExtension}`);
+    link.setAttribute('download', `${downloadName}`);
     link.style.display = 'none';
 
     document.body.appendChild(link);

--- a/src/services/utility-helpers.js
+++ b/src/services/utility-helpers.js
@@ -153,9 +153,14 @@ export function getCanvasTarget(targets, timeFragment, duration) {
  * @param {Boolean} machineGenerated flag to indicate file is machine generated/not
  */
 export function fileDownload(fileUrl, fileName, fileExt = '', machineGenerated = false) {
-  const extension = fileExt === ''
-    ? fileUrl.split('.').reverse()[0]
+  // Avalon transcripts do not include file extensions in the fileUrl.
+  // Prioritize user defined extension from fileName if no fileExt is present.
+  let extension = fileExt === ''
+    ? fileName.split('.').reverse()[0]
     : fileExt;
+
+  // If no extension present in fileName, check for the extension in the fileUrl
+  extension = extension.length > 4 ? fileUrl.split('.').reverse()[0] : extension;
 
   // If unhandled file type use .doc
   const fileExtension = VALID_FILE_EXTENSIONS.includes(extension)

--- a/src/services/utility-helpers.test.js
+++ b/src/services/utility-helpers.test.js
@@ -293,7 +293,7 @@ describe('util helper', () => {
       expect(createElementSpy).toBeCalledWith('a');
       expect(link.setAttribute.mock.calls.length).toBe(2);
       expect(link.setAttribute.mock.calls[0]).toEqual(['href', 'https://example.com/transcript.json']);
-      expect(link.setAttribute.mock.calls[1]).toEqual(['download', 'Transcript test.json']);
+      expect(link.setAttribute.mock.calls[1]).toEqual(['download', 'Transcript test']);
       expect(link.style.display).toBe('none');
       expect(document.body.appendChild).toBeCalledWith(link);
       expect(link.click).toBeCalled();
@@ -307,7 +307,7 @@ describe('util helper', () => {
         expect(createElementSpy).toBeCalledWith('a');
         expect(link.setAttribute.mock.calls.length).toBe(2);
         expect(link.setAttribute.mock.calls[0]).toEqual(['href', 'https://example.com/transcript.json']);
-        expect(link.setAttribute.mock.calls[1]).toEqual(['download', 'Transcript test (machine generated).json']);
+        expect(link.setAttribute.mock.calls[1]).toEqual(['download', 'Transcript test (machine generated)']);
         expect(link.style.display).toBe('none');
         expect(document.body.appendChild).toBeCalledWith(link);
         expect(link.click).toBeCalled();
@@ -324,21 +324,21 @@ describe('util helper', () => {
         expect(link.setAttribute.mock.calls[0]).toEqual(['href', 'https://example.com/transcript']);
         expect(link.setAttribute.mock.calls[1]).toEqual(['download', 'Transcript test.doc']);
       });
-      test('extension in url gets used if no extension in filename', () => {
+      test('valid extension in URL relies on browser extension assignment', () => {
         util.fileDownload('https://example.com/transcript.json', 'Transcript test');
 
         expect(createElementSpy).toBeCalledWith('a');
         expect(link.setAttribute.mock.calls.length).toBe(2);
         expect(link.setAttribute.mock.calls[0]).toEqual(['href', 'https://example.com/transcript.json']);
-        expect(link.setAttribute.mock.calls[1]).toEqual(['download', 'Transcript test.json']);
+        expect(link.setAttribute.mock.calls[1]).toEqual(['download', 'Transcript test']);
       });
-      test('extension in filename takes precedence over url', () => {
-        util.fileDownload('https://example.com/transcript.json', 'Transcript test.docx');
+      test('valid extension in filename relies on browser extension assignment', () => {
+        util.fileDownload('https://example.com/transcript', 'Transcript test.docx');
 
         expect(createElementSpy).toBeCalledWith('a');
         expect(link.setAttribute.mock.calls.length).toBe(2);
-        expect(link.setAttribute.mock.calls[0]).toEqual(['href', 'https://example.com/transcript.json']);
-        expect(link.setAttribute.mock.calls[1]).toEqual(['download', 'Transcript test.docx']);
+        expect(link.setAttribute.mock.calls[0]).toEqual(['href', 'https://example.com/transcript']);
+        expect(link.setAttribute.mock.calls[1]).toEqual(['download', 'Transcript test']);
       });
     });
   });

--- a/src/services/utility-helpers.test.js
+++ b/src/services/utility-helpers.test.js
@@ -314,6 +314,33 @@ describe('util helper', () => {
         expect(document.body.removeChild).toBeCalledWith(link);
       });
     });
+
+    describe('file extension handling', () => {
+      test('no extension defaults to .doc', () => {
+        util.fileDownload('https://example.com/transcript', 'Transcript test');
+
+        expect(createElementSpy).toBeCalledWith('a');
+        expect(link.setAttribute.mock.calls.length).toBe(2);
+        expect(link.setAttribute.mock.calls[0]).toEqual(['href', 'https://example.com/transcript']);
+        expect(link.setAttribute.mock.calls[1]).toEqual(['download', 'Transcript test.doc']);
+      });
+      test('extension in url gets used if no extension in filename', () => {
+        util.fileDownload('https://example.com/transcript.json', 'Transcript test');
+
+        expect(createElementSpy).toBeCalledWith('a');
+        expect(link.setAttribute.mock.calls.length).toBe(2);
+        expect(link.setAttribute.mock.calls[0]).toEqual(['href', 'https://example.com/transcript.json']);
+        expect(link.setAttribute.mock.calls[1]).toEqual(['download', 'Transcript test.json']);
+      });
+      test('extension in filename takes precedence over url', () => {
+        util.fileDownload('https://example.com/transcript.json', 'Transcript test.docx');
+
+        expect(createElementSpy).toBeCalledWith('a');
+        expect(link.setAttribute.mock.calls.length).toBe(2);
+        expect(link.setAttribute.mock.calls[0]).toEqual(['href', 'https://example.com/transcript.json']);
+        expect(link.setAttribute.mock.calls[1]).toEqual(['download', 'Transcript test.docx']);
+      });
+    });
   });
 
   describe('identifyMachineGen()', () => {


### PR DESCRIPTION
Fixes #309, Fixes #321

This PR handles the case where a ".doc" extension was being duplicated. This approach checks for an extension in the file name before checking the URL since Avalon does not include file names in the URL. It then checks if the extension it found is part of the internal list of valid extensions. If it is, we add "(machine generated)" to the filename if necessary and then rely on the browser to assign the right extension to the download. If it is not valid, we do the same processing for "(machine generated)" and then manually add ".doc" and provide that filename to the download link. This prevents the duplication we were seeing and should prevent multiple extensions in general.

This PR also includes a fix for #321 where the download button was not rendering for unsupported file types. It was necessary for testing to have the download button always available.

~~Thinking on it more though, should we a take different approach? If the filename is "example.vtt" but the mime type is "application/msword", I think the current processing would still result in the downloaded file being "example.vtt.doc".~~

~~Rather than ever use the extension from the filename, should we instead excise anything that looks like an extension from the filename and rely on what gets generated from the mime type processing? That could be problematic though if there is a filename without extension but including periods. We could end up with weirdly truncated filenames on download if the parsing is incorrect.~~

~~Or should we approach this how @elynema suggested in the ticket, where we improve how Avalon generates the filename for the manifest and simplify/remove any processing on Ramp's side, relying on implementers to provide properly formatted "filename.ext".~~

~~Or is there another approach that could work?~~