### PR TITLE
Backport of Accessibility fixes for current versions of avalon

### DIFF
--- a/src/components/Transcript/Transcript.js
+++ b/src/components/Transcript/Transcript.js
@@ -346,6 +346,7 @@ const Transcript = ({ playerID, transcripts }) => {
               className="transcript_viewer"
               data-testid="transcript_viewer"
               src={transcriptUrl}
+              aria-label="Attached transcript content"
             ></iframe>
           )}
         </div>

--- a/src/components/Transcript/TranscriptMenu/TranscriptDownloader.js
+++ b/src/components/Transcript/TranscriptMenu/TranscriptDownloader.js
@@ -44,6 +44,7 @@ const TranscriptDownloader = ({ fileUrl, fileName }) => {
       data-testid="transcript-downloader"
       onClick={handleDownload}
       href="#"
+      aria-label="Download transcript"
     >
       <span className="download-label"></span>
     </button>

--- a/src/components/Transcript/TranscriptMenu/TranscriptSelector.js
+++ b/src/components/Transcript/TranscriptMenu/TranscriptSelector.js
@@ -21,6 +21,9 @@ const TanscriptSelector = (props) => {
             data-testid="transcript-select-option"
             value={title}
             onChange={selectItem}
+            aria-label="Select transcript"
+            aria-expanded={false}
+            aria-haspopup="true"
           >
             {props.transcriptData.map((t, i) => (
               <option value={t.title} key={i}>


### PR DESCRIPTION
Part of https://github.com/avalonmediasystem/avalon/issues/5341 

This is a partial backport of https://github.com/samvera-labs/ramp/commit/ab51ab095c25a7a3039a9e41a8f41cc9243e4a9c although I did change the labels slightly based upon what I thought would be more readable and consistent.  If these changes are okay then we should forwardport them to `main`.

Once this is merged I can work on cutting a v1.2.2 from the new v1.2.x branch.