### PR TITLE
Add safe navigation and fallback in case there aren't any canvases in manifest

### DIFF
--- a/src/components/MetadataDisplay/MetadataDisplay.js
+++ b/src/components/MetadataDisplay/MetadataDisplay.js
@@ -82,7 +82,7 @@ const MetadataDisplay = ({
    */
   const setCanvasMetadataInState = () => {
     let canvasData = canvasesMetadataRef.current
-      .filter((m) => m.canvasindex === canvasIndex)[0].metadata;
+      .filter((m) => m.canvasindex === canvasIndex)[0]?.metadata || [];
     if (!displayTitle) {
       canvasData = canvasData.filter(md => md.label.toLowerCase() != 'title');
     }

--- a/src/components/MetadataDisplay/MetadataDisplay.test.js
+++ b/src/components/MetadataDisplay/MetadataDisplay.test.js
@@ -2,7 +2,8 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import MetadataDisplay from './MetadataDisplay';
 import manifest from '@TestData/lunchroom-manners';
-import manfiestWoMetadata from '@TestData/volleyball-for-boys';
+import manifestWoMetadata from '@TestData/volleyball-for-boys';
+import manifestWoCanvases from '@TestData/empty-playlist';
 import playlistManifest from '@TestData/playlist';
 import { withManifestProvider } from '../../services/testing-helpers';
 
@@ -174,12 +175,25 @@ describe('MetadataDisplay component', () => {
 
   it('with manifest without metadata renders a message', () => {
     const MetadataDisp = withManifestProvider(MetadataDisplay, {
-      initialState: { manifest: manfiestWoMetadata },
+      initialState: { manifest: manifestWoMetadata },
     });
     render(<MetadataDisp />);
     expect(screen.queryByTestId('metadata-display')).toBeInTheDocument();
     expect(screen.queryByTestId('metadata-display-message')).toBeInTheDocument();
     expect(screen.getByText('No valid Metadata is in the Manifest/Canvas(es)')).toBeInTheDocument();
     expect(console.log).toBeCalledTimes(1);
+  });
+
+  it('with manifest without canavses renders a message', () => {
+    const MetadataDisp = withManifestProvider(MetadataDisplay, {
+      initialState: { manifest: manifestWoCanvases },
+      displayOnlyCanvasMetadata: true,
+      displayTitle: false
+    });
+    render(<MetadataDisp />);
+    expect(screen.queryByTestId('metadata-display')).toBeInTheDocument();
+    expect(screen.queryByTestId('metadata-display-message')).toBeInTheDocument();
+    expect(screen.getByText('No valid Metadata is in the Manifest/Canvas(es)')).toBeInTheDocument();
+    expect(console.log).toBeCalledTimes(0);
   });
 });

--- a/src/test_data/empty-playlist.js
+++ b/src/test_data/empty-playlist.js
@@ -1,0 +1,58 @@
+export default {
+  '@context': [
+    "http://www.w3.org/ns/anno.jsonld",
+    "http://iiif.io/api/presentation/3/context.json"
+  ],
+  type: "Manifest",
+  id: "https://example.com/manifest/empty-playlist",
+  label: {
+    none: [
+      "Empty playlist [Playlist]"
+    ]
+  },
+  behavior: [
+    "auto-advance"
+  ],
+  metadata: [
+    {
+      label: {
+        none: [
+          "Title"
+        ]
+      },
+      value: {
+        none: [
+          "Empty playlist [Playlist]"
+        ]
+      }
+    }
+  ],
+  service: [
+    {
+      id: "https://example.com/avalon_marker",
+      type: "AnnotationService0"
+    }
+  ],
+  homepage: [
+    {
+      id: "https://example.com/playlists/1",
+      type: "Text",
+      label: {
+        none: [
+          "View in Repository"
+        ]
+      },
+      format: "text/html"
+    }
+  ],
+  items: [],
+  structures: [
+    {
+      type: "Range",
+      id: "https://example.com/playlists/1/manifest/range/1",
+      label: null,
+      behavior: "top",
+      items: []
+    }
+  ]
+};


### PR DESCRIPTION
Resolves #339 

This PR addresses the specific error seen in #339 and may resolve https://github.com/avalonmediasystem/avalon/issues/5504 but I don't think that it fully allows ramp to open manifests with no canvases.  When I try to open a manifest with no canvases (playlist or normal) in the ramp demo app it hits an error boundary in iiif-parser.  It looks like this happens in ramp in avalon as well but that it logs the error and moves on.