### PR TITLE
Provide test:debug script alias that makes it easy to debug with any dev tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "styleguide:build": "styleguidist build",
     "test": "jest --coverage --colors",
     "test:watch": "jest --watch",
+    "test:debug": "node --inspect $(npm bin)/jest --runInBand",
     "demo": "webpack serve --mode=development",
     "demo:build": "webpack --mode=production"
   },


### PR DESCRIPTION
I was finding this useful when debugging tests I was writing.  The `--inspect` flag to `node` sets up a debugging server on port 9229 which I connected to with Chrome using `chrome://inspect` and clicking `Open dedicated DevTools for Node`.  Then all I had to do was put in `debugger` statements in the code where I wanted them.

I'm guessing that IDEs like VSCode has some built in tools that invoke node with this flag and connect for interactive debugging within the IDE.  There may also be commandline debugging clients.   I think this script alias should expose the node inspector allowing for developers to use whichever tool they prefer.

See https://nodejs.org/en/guides/debugging-getting-started