### PR TITLE
Add fade out and message to indicate scrolling of structured nav

### DIFF
--- a/src/components/StructuredNavigation/StructuredNavigation.js
+++ b/src/components/StructuredNavigation/StructuredNavigation.js
@@ -48,7 +48,7 @@ const StructuredNavigation = () => {
     }
   }, [manifest]);
 
-  // Set currentNavItem when current Canvas is an inaccessible/empty item 
+  // Set currentNavItem when current Canvas is an inaccessible/empty item
   React.useEffect(() => {
     if (canvasIsEmpty && playlist.isPlaylist) {
       manifestDispatch({
@@ -124,33 +124,57 @@ const StructuredNavigation = () => {
     }
   }, [isClicked, player]);
 
+  const handleScroll = (e) => {
+    const elem = e.target;
+    const sibling = elem.nextSibling;
+    const structureEnd = Math.abs(elem.scrollHeight - (elem.scrollTop + elem.clientHeight)) <= 1;
+
+    if (structureEnd && elem.classList.contains('scrollable')) {
+      elem.classList.remove('scrollable');
+    } else if (!structureEnd && !elem.classList.contains('scrollable')) {
+      elem.classList.add('scrollable');
+    }
+
+    if (structureEnd) {
+      sibling.style.display = "none";
+    } else if (!structureEnd) {
+      sibling.style.display = '';
+    }
+  }
+
   if (!manifest) {
     return <p>No manifest - Please provide a valid manifest.</p>;
   }
 
   return (
-    <div
-      data-testid="structured-nav"
-      className="ramp--structured-nav"
-      key={Math.random()}
-      ref={structureContainerRef}
-      role="structure"
-      aria-label="Structural content"
-    >
-      {structureItemsRef.current?.length > 0 ? (
-        structureItemsRef.current.map((item, index) => (
-          <List
-            items={[item]}
-            sectionRef={React.createRef()}
-            key={index}
-            structureContainerRef={structureContainerRef}
-          />
-        ))
-      ) : (
-        <p className="ramp--no-structure">
-          There are no structures in the manifest
-        </p>
-      )}
+    <div className="ramp--structured-nav__border">
+      <div
+        data-testid="structured-nav"
+        className="ramp--structured-nav scrollable"
+        key={Math.random()}
+        ref={structureContainerRef}
+        role="structure"
+        aria-label="Structural content"
+        onScroll={handleScroll}
+      >
+        {structureItemsRef.current?.length > 0 ? (
+          structureItemsRef.current.map((item, index) => (
+            <List
+              items={[item]}
+              sectionRef={React.createRef()}
+              key={index}
+              structureContainerRef={structureContainerRef}
+            />
+          ))
+        ) : (
+          <p className="ramp--no-structure">
+            There are no structures in the manifest
+          </p>
+        )}
+      </div>
+      <span className="scrollable">
+        Scroll to see more
+      </span>
     </div>
   );
 };

--- a/src/components/StructuredNavigation/StructuredNavigation.js
+++ b/src/components/StructuredNavigation/StructuredNavigation.js
@@ -32,6 +32,7 @@ const StructuredNavigation = () => {
   let canvasIsEmptyRef = React.useRef(canvasIsEmpty);
 
   const structureContainerRef = React.useRef();
+  const scrollableStructure = React.useRef();
 
   React.useEffect(() => {
     // Update currentTime and canvasIndex in state if a
@@ -124,6 +125,17 @@ const StructuredNavigation = () => {
     }
   }, [isClicked, player]);
 
+  // Structured nav is populated by the time the player hook fires so we listen for
+  // that to run the check on whether the structured nav is scrollable.
+  React.useEffect(() => {
+    if (structureContainerRef.current) {
+      const elem = structureContainerRef.current;
+      const structureEnd = Math.abs(elem.scrollHeight - (elem.scrollTop + elem.clientHeight)) <= 1;
+      scrollableStructure.current = !structureEnd;
+    }
+  }, [player]);
+
+  // Update scrolling indicators when end of scrolling has been reached
   const handleScroll = (e) => {
     const elem = e.target;
     const sibling = elem.nextSibling;
@@ -135,10 +147,10 @@ const StructuredNavigation = () => {
       elem.classList.add('scrollable');
     }
 
-    if (structureEnd) {
-      sibling.style.display = "none";
-    } else if (!structureEnd) {
-      sibling.style.display = '';
+    if (structureEnd && sibling.classList.contains('scrollable')) {
+      sibling.classList.remove('scrollable');
+    } else if (!structureEnd && !sibling.classList.contains('scrollable')) {
+      sibling.classList.add('scrollable');
     }
   }
 
@@ -146,11 +158,21 @@ const StructuredNavigation = () => {
     return <p>No manifest - Please provide a valid manifest.</p>;
   }
 
+  // Check for scrolling on initial render and build appropriate element class
+  let divClass = ''
+  let spanClass = ''
+  if (scrollableStructure.current) {
+    divClass = "ramp--structured-nav scrollable";
+    spanClass = "scrollable";
+  } else {
+    divClass = "ramp--structured-nav";
+  }
+
   return (
     <div className="ramp--structured-nav__border">
       <div
         data-testid="structured-nav"
-        className="ramp--structured-nav scrollable"
+        className={divClass}
         key={Math.random()}
         ref={structureContainerRef}
         role="structure"
@@ -172,7 +194,7 @@ const StructuredNavigation = () => {
           </p>
         )}
       </div>
-      <span className="scrollable">
+      <span className={spanClass}>
         Scroll to see more
       </span>
     </div>

--- a/src/components/StructuredNavigation/StructuredNavigation.scss
+++ b/src/components/StructuredNavigation/StructuredNavigation.scss
@@ -1,7 +1,7 @@
 @import '../../styles/_vars.scss';
 
 .ramp--structured-nav {
-  margin-top: 0 !important;
+  margin-top: 0;
   max-height: 40vh;
   max-width: 50vw;
   overflow-y: auto;
@@ -58,23 +58,23 @@
 // CSS for accordion style UI in structure
 ul.ramp--structured-nav__list {
   list-style: none;
-  padding: 0 0 0 0 !important;
+  padding: 0 0 0 0;
   margin: 0px;
 
   li:last-child {
-    padding: 0 0 0 0 !important;
+    padding: 0 0 0 0;
   }
 
   li {
     display: block;
-    padding: 0 0 0.5rem 0px !important;
+    padding: 0 0 0.5rem 0px;
 
     ul > li {
-      padding: 0 0 0.5rem 1rem !important;
+      padding: 0 0 0.5rem 1rem;
     }
 
     ul > li:last-child {
-      padding: 0 0 0 1rem !important;
+      padding: 0 0 0 1rem;
     }
   }
 

--- a/src/components/StructuredNavigation/StructuredNavigation.scss
+++ b/src/components/StructuredNavigation/StructuredNavigation.scss
@@ -36,8 +36,12 @@
   border-radius: 0.25rem;
 }
 
+.ramp--structured-nav__border > span {
+  display: none;
+}
+
 // Scroll to see more message
-span.scrollable {
+.ramp--structured-nav__border > span.scrollable {
   background: $primary;
   text-align: center;
   display: block;
@@ -56,6 +60,10 @@ ul.ramp--structured-nav__list {
   list-style: none;
   padding: 0 0 0 0 !important;
   margin: 0px;
+
+  li:last-child {
+    padding: 0 0 0 0 !important;
+  }
 
   li {
     display: block;

--- a/src/components/StructuredNavigation/StructuredNavigation.scss
+++ b/src/components/StructuredNavigation/StructuredNavigation.scss
@@ -1,7 +1,7 @@
 @import '../../styles/_vars.scss';
 
 .ramp--structured-nav {
-  margin-top: 20px;
+  margin-top: 0 !important;
   max-height: 40vh;
   max-width: 50vw;
   overflow-y: auto;
@@ -22,15 +22,52 @@
   }
 }
 
+// Mask for scrollable area fadeout
+.ramp--structured-nav.scrollable {
+  mask-image: linear-gradient(to bottom, black 80%, transparent 100%);
+  -webkit-mask-image: linear-gradient(to bottom, black 80%, transparent 100%)
+}
+
+// Border box
+.ramp--structured-nav__border {
+  margin-top: 20px;
+  box-sizing: border-box;
+  border: 1px solid #ddd;
+  border-radius: 0.25rem;
+}
+
+// Scroll to see more message
+span.scrollable {
+  background: $primary;
+  text-align: center;
+  display: block;
+  position: relative;
+  color: black;
+  font-size: 13px;
+  width: 15%;
+  left: 40%;
+  border: 1px solid #ddd;
+  border-radius: 0.25rem 0.25rem 0 0;
+  border-bottom: none;
+}
+
 // CSS for accordion style UI in structure
 ul.ramp--structured-nav__list {
   list-style: none;
-  padding: 0 0 0 10px;
+  padding: 0 0 0 0 !important;
   margin: 0px;
 
   li {
     display: block;
-    padding: 0.25rem 0.5rem;
+    padding: 0 0 0.5rem 0px !important;
+
+    ul > li {
+      padding: 0 0 0.5rem 1rem !important;
+    }
+
+    ul > li:last-child {
+      padding: 0 0 0 1rem !important;
+    }
   }
 
   li.active>a {


### PR DESCRIPTION
This PR also adds a border around the structured nav. In testing, the `!important` css tags were necessary because the "ramp.css" file from the build (I think) was overriding the component specific file. Should the `!important` tags be removed because the CSS will compile into that file when we do another build?
![Screenshot_20240123_104832](https://github.com/samvera-labs/ramp/assets/68433277/ae5cb0c3-ce9c-48fc-b2ab-5287ae171ccd)

![Screenshot_20240123_104849](https://github.com/samvera-labs/ramp/assets/68433277/981d5aea-b346-4e11-a4cb-fe73e4370bcd)

