### PR TITLE
Read canvas summary and render as data attribute alongside label

### DIFF
--- a/src/components/StructuredNavigation/NavUtils/ListItem.js
+++ b/src/components/StructuredNavigation/NavUtils/ListItem.js
@@ -33,6 +33,7 @@ const ListItem = ({
   isClickable,
   isEmpty,
   label,
+  summary,
   items,
   itemIndex,
   rangeId,
@@ -48,6 +49,9 @@ const ListItem = ({
 
   let itemLabelRef = React.useRef();
   itemLabelRef.current = label;
+
+  let itemSummaryRef = React.useRef();
+  itemSummaryRef.current = summary;
 
   const subMenu =
     items && items.length > 0 ? (
@@ -141,6 +145,7 @@ const ListItem = ({
         aria-label={itemLabelRef.current}
         role="listitem"
         data-label={itemLabelRef.current}
+        data-summary={itemSummaryRef.current}
       >
         {renderListItem()}
         {subMenu}
@@ -159,6 +164,7 @@ ListItem.propTypes = {
   isClickable: PropTypes.bool.isRequired,
   isEmpty: PropTypes.bool.isRequired,
   label: PropTypes.string.isRequired,
+  summary: PropTypes.string,
   items: PropTypes.array.isRequired,
   itemIndex: PropTypes.number,
   rangeId: PropTypes.string.isRequired,

--- a/src/components/StructuredNavigation/NavUtils/ListItem.test.js
+++ b/src/components/StructuredNavigation/NavUtils/ListItem.test.js
@@ -279,6 +279,7 @@ describe('ListItem component', () => {
         itemIndex: 1,
         items: [],
         label: "Beginning Responsibility: Lunchroom Manners",
+        summary: "Mind your manners!",
         rangeId: "https://example.com/playlists/1/manifest/range/1",
         sectionRef: sectionRef,
         structureContainerRef,
@@ -297,6 +298,8 @@ describe('ListItem component', () => {
       render(<ListItemWithManifest />);
       expect(screen.queryAllByTestId('list-item').length).toEqual(1);
       expect(screen.queryAllByTestId('list-item')[0]).toHaveTextContent('1. Beginning Responsibility: Lunchroom Manners (09:32)');
+      expect(screen.queryAllByTestId('list-item')[0].getAttribute('data-label')).toEqual('Beginning Responsibility: Lunchroom Manners');
+      expect(screen.queryAllByTestId('list-item')[0].getAttribute('data-summary')).toEqual('Mind your manners!');
     });
   });
 });

--- a/src/components/StructuredNavigation/NavUtils/SectionHeading.test.js
+++ b/src/components/StructuredNavigation/NavUtils/SectionHeading.test.js
@@ -62,6 +62,8 @@ describe('SectionHeading component', () => {
     expect(screen.getByTestId('listitem-section')).toHaveAttribute('data-mediafrag');
     expect(screen.getByTestId('listitem-section').getAttribute('data-mediafrag'))
       .toEqual('https://example.com/manifest/canvas#t=0.0,572');
+    expect(screen.getByTestId('listitem-section').getAttribute('data-label'))
+      .toEqual('Lunchroom Manners');
   });
 
   test('renders canvas w/o mediafragment as a span', () => {
@@ -82,6 +84,8 @@ describe('SectionHeading component', () => {
     expect(screen.getByTestId('listitem-section-span'))
       .toHaveTextContent('1. Lunchroom Manners09:32');
     expect(screen.getByTestId('listitem-section')).not.toHaveAttribute('data-mediafrag');
+    expect(screen.getByTestId('listitem-section').getAttribute('data-label'))
+      .toEqual('Lunchroom Manners');
   });
 
   test('has active class when currentNavItem is within the Canvas', () => {

--- a/src/services/iiif-parser.js
+++ b/src/services/iiif-parser.js
@@ -1,4 +1,4 @@
-import { parseManifest } from 'manifesto.js';
+import { parseManifest, PropertyValue } from 'manifesto.js';
 import mimeDb from 'mime-db';
 import sanitizeHtml from 'sanitize-html';
 import {
@@ -50,7 +50,7 @@ export function canvasesInManifest(manifest) {
           canvasesInfo.push({
             canvasId: canvas.id,
             range: timeFragment === undefined ? { start: 0, end: canvasDuration } : timeFragment,
-            isEmpty: sources.length === 0 ? true : false
+            isEmpty: sources.length === 0 ? true : false,
           });
         } catch (error) {
           canvasesInfo.push({
@@ -572,6 +572,7 @@ export function getStructureRanges(manifest) {
     let isCanvas = rootNode == range.parentRange;
     let isClickable = false;
     let isEmpty = false;
+    let summary = undefined;
     if (canvases.length > 0 && canvasesInfo?.length > 0) {
       let canvasInfo = canvasesInfo
         .filter((c) => c.canvasId === getCanvasId(canvases[0]))[0];
@@ -580,9 +581,16 @@ export function getStructureRanges(manifest) {
       if (isCanvas && canvasInfo.range != undefined) {
         duration = canvasInfo.range.end - canvasInfo.range.start;
       }
+      if (isCanvas) {
+        let summaryProperty = parseSequences(manifest)[0].getCanvasById(getCanvasId(canvases[0]))?.getProperty('summary');
+        if (summaryProperty) {
+          summary = PropertyValue.parse(summaryProperty).getValue();
+        }
+      }
     }
     let item = {
       label: label,
+      summary: summary,
       isTitle: canvases.length === 0 ? true : false,
       rangeId: range.id,
       id: canvases.length > 0

--- a/src/services/iiif-parser.test.js
+++ b/src/services/iiif-parser.test.js
@@ -588,13 +588,30 @@ describe('iiif-parser', () => {
       expect(firstStructCanvas.id).toEqual('https://example.com/manifest/lunchroom_manners/canvas/1#t=0,');
       expect(firstStructCanvas.isClickable).toBeTruthy();
       expect(firstStructCanvas.duration).toEqual('11:00');
-
     });
 
     it('returns [] when structure is not present', () => {
       const { structures, timespans } = iiifParser.getStructureRanges(manifestWoStructure);
       expect(structures).toEqual([]);
       expect(timespans).toEqual([]);
+    });
+
+    it('returns canvas summary with structure for playist manifests', () => {
+      const { structures, timespans } = iiifParser.getStructureRanges(playlistManifest);
+      expect(structures).toHaveLength(3);
+      expect(timespans).toHaveLength(3);
+
+      const firstStructCanvas = structures[1];
+      expect(firstStructCanvas.label).toEqual('Playlist Item 1');
+      expect(firstStructCanvas.summary).toEqual('Clip from Volleyball for boys');
+      expect(firstStructCanvas.items).toHaveLength(0);
+      expect(firstStructCanvas.isCanvas).toBeTruthy();
+      expect(firstStructCanvas.isEmpty).toBeFalsy();
+      expect(firstStructCanvas.isTitle).toBeFalsy();
+      expect(firstStructCanvas.rangeId).toEqual('http://example.com/manifests/playlist/range/2');
+      expect(firstStructCanvas.id).toEqual('http://example.com/manifests/playlist/canvas/2#t=0,');
+      expect(firstStructCanvas.isClickable).toBeTruthy();
+      expect(firstStructCanvas.duration).toEqual('00:32');
     });
   });
 

--- a/src/test_data/playlist.js
+++ b/src/test_data/playlist.js
@@ -77,6 +77,9 @@ export default {
       label: {
         en: ["Volleyball for boys"]
       },
+      summary: {
+        en: ['Clip from Volleyball for boys']
+      },
       placeholderCanvas: {
         id: 'http://example.com/manifests/playlist/canvas/2/placeholder',
         type: "Canvas",


### PR DESCRIPTION
Part of https://github.com/avalonmediasystem/avalon/issues/5581

Summary is rendered as a data attribute alongside the canvas label for playlist `ListItem`s.
In order to read the summary I had to parse the manifest again.  I'd hoped that there was a better way but couldn't find one.  Manifesto doesn't have a convenience method for getting the summary of a canvas and since it should be a language map the code to read summary is a little bit involved.