### PR TITLE
Filter duplicated captions instead of switching off native text track behavior in VideoJS

### DIFF
--- a/src/components/MediaPlayer/MediaPlayer.js
+++ b/src/components/MediaPlayer/MediaPlayer.js
@@ -326,10 +326,6 @@ const MediaPlayer = ({ enableFileDownload = false, enablePIP = false }) => {
       ? playerConfig.sources[srcIndex]
       : playerConfig.sources,
     tracks: playerConfig.tracks,
-    // Omit captions in the HLS manifest from loading
-    html5: {
-      nativeTextTracks: true,
-    },
   } : {}; // Empty configurations for empty canvases
 
   // Add file download to toolbar when it is enabled via props
@@ -416,6 +412,7 @@ const MediaPlayer = ({ enableFileDownload = false, enablePIP = false }) => {
           switchPlayer={switchPlayer}
           trackScrubberRef={trackScrubberRef}
           scrubberTooltipRef={timeToolRef}
+          tracks={playerConfig.tracks}
           {...videoJsOptions}
         />
       </div>

--- a/src/services/iiif-parser.test.js
+++ b/src/services/iiif-parser.test.js
@@ -183,6 +183,7 @@ describe('iiif-parser', () => {
             src: 'https://example.com/manifest/lunchroom_manners.vtt',
             kind: 'Text',
             type: 'text/vtt',
+            srclang: 'en',
             label: 'Captions in WebVTT format',
             value: '',
           };
@@ -198,6 +199,7 @@ describe('iiif-parser', () => {
             src: 'https://example.com/manifest/lunchroom_manners/captions',
             kind: 'Text',
             type: 'text/vtt',
+            srclang: 'en',
             label: 'Captions in WebVTT format',
             value: '',
           };

--- a/src/services/utility-helpers.js
+++ b/src/services/utility-helpers.js
@@ -387,6 +387,7 @@ function getResourceInfo(item, motivation) {
       src: item.id,
       type: item.getProperty('format'),
       kind: item.getProperty('type'),
+      srclang: item.getProperty('language') || 'en',
       label: item.getLabel().getValue() || 'auto',
       value: item.getProperty('value') ? item.getProperty('value') : '',
     };

--- a/src/services/utility-helpers.js
+++ b/src/services/utility-helpers.js
@@ -387,10 +387,13 @@ function getResourceInfo(item, motivation) {
       src: item.id,
       type: item.getProperty('format'),
       kind: item.getProperty('type'),
-      srclang: item.getProperty('language') || 'en',
       label: item.getLabel().getValue() || 'auto',
       value: item.getProperty('value') ? item.getProperty('value') : '',
     };
+    // Set language for captions/subtitles
+    if (motivation === 'supplementing') {
+      s.srclang = item.getProperty('language') || 'en';
+    }
     source.push(s);
   }
   return source;

--- a/src/services/utility-helpers.test.js
+++ b/src/services/utility-helpers.test.js
@@ -113,7 +113,7 @@ describe('util helper', () => {
                 })
               },
               {
-                id: 'http://example.com/manifest/Italian',
+                id: 'http://example.com/manifest/Italian.vtt',
                 getProperty: jest.fn((prop) => {
                   return annotations[0].__jsonld.body.items[1][prop];
                 }),
@@ -136,7 +136,16 @@ describe('util helper', () => {
         src: 'http://example.com/manifest/English.vtt',
         type: 'text/vtt',
         kind: 'Text',
+        srclang: 'en',
         label: 'Captions in WebVTT format',
+        value: '',
+      });
+      expect(resources[1]).toEqual({
+        src: 'http://example.com/manifest/Italian.vtt',
+        type: 'text/vtt',
+        kind: 'Text',
+        srclang: 'it',
+        label: 'Sottotitoli in formato WebVTT',
         value: '',
       });
       expect(isMultiSource).toBeFalsy();


### PR DESCRIPTION
With Avalon IIIF Manifests, Ramp receives identical captions/subtitles information from both IIIF Manifest and HLS manifest. When VideoJS in Ramp is using its normal text track handling with these IIIF Manifests, captions/subtitles get duplicated in the player's captions/subtitles menu because it uses captions/subtitles information in both manifests. 

Using VideoJS option `html5: { nativeTextTracks: true }` prevents captions/subtitles duplication for Avalon IIIF Manifests, but this hides text tracks for other IIIF Manifests where there are no HLS manifests with captions/subtitles information.

Therefore in this PR; `html5: { nativeTextTracks: true }` is removed and added a filter in the JS code to programmatically remove the duplicated captions/subtitles in the player's captions/subtitles menu.

Related issue: #325 