### PR TITLE
Add padding to playlist structure nav

### DIFF
--- a/src/components/StructuredNavigation/StructuredNavigation.js
+++ b/src/components/StructuredNavigation/StructuredNavigation.js
@@ -152,20 +152,23 @@ const StructuredNavigation = () => {
     } else if (!structureEnd && !sibling.classList.contains('scrollable')) {
       sibling.classList.add('scrollable');
     }
-  }
+  };
 
   if (!manifest) {
     return <p>No manifest - Please provide a valid manifest.</p>;
   }
 
   // Check for scrolling on initial render and build appropriate element class
-  let divClass = ''
-  let spanClass = ''
+  let divClass = '';
+  let spanClass = '';
   if (scrollableStructure.current) {
     divClass = "ramp--structured-nav scrollable";
     spanClass = "scrollable";
   } else {
     divClass = "ramp--structured-nav";
+  }
+  if (playlist?.isPlaylist) {
+    divClass += " playlist-items";
   }
 
   return (

--- a/src/components/StructuredNavigation/StructuredNavigation.scss
+++ b/src/components/StructuredNavigation/StructuredNavigation.scss
@@ -22,6 +22,10 @@
   }
 }
 
+.ramp--structured-nav.playlist-items {
+  padding: 1em 2em;
+}
+
 // Mask for scrollable area fadeout
 .ramp--structured-nav.scrollable {
   mask-image: linear-gradient(to bottom, black 80%, transparent 100%);
@@ -34,14 +38,16 @@
   box-sizing: border-box;
   border: 1px solid #ddd;
   border-radius: 0.25rem;
+  display: flex;
+  flex-direction: column;
 }
 
-.ramp--structured-nav__border > span {
+.ramp--structured-nav__border>span {
   display: none;
 }
 
 // Scroll to see more message
-.ramp--structured-nav__border > span.scrollable {
+.ramp--structured-nav__border>span.scrollable {
   background: $primary;
   text-align: center;
   display: block;
@@ -53,6 +59,7 @@
   border: 1px solid #ddd;
   border-radius: 0.25rem 0.25rem 0 0;
   border-bottom: none;
+  padding: 0.25em;
 }
 
 // CSS for accordion style UI in structure
@@ -69,11 +76,11 @@ ul.ramp--structured-nav__list {
     display: block;
     padding: 0 0 0.5rem 0px;
 
-    ul > li {
+    ul>li {
       padding: 0 0 0.5rem 1rem;
     }
 
-    ul > li:last-child {
+    ul>li:last-child {
       padding: 0 0 0 1rem;
     }
   }


### PR DESCRIPTION
_Playlist structure_

Before:
![Before](https://github.com/samvera-labs/ramp/assets/1331659/bca3f384-0f54-4863-aba1-01d00685da65)

After:
![After](https://github.com/samvera-labs/ramp/assets/1331659/afc8ecac-8059-4795-8019-1d47cfad79ef)

And this doesn't change the regular structure display.

Related issue: https://github.com/avalonmediasystem/avalon/issues/5589
