### PR TITLE
Disable volume slider for mobile devices

### DIFF
--- a/src/components/MediaPlayer/MediaPlayer.js
+++ b/src/components/MediaPlayer/MediaPlayer.js
@@ -304,7 +304,7 @@ const MediaPlayer = ({ enableFileDownload = false, enablePIP = false }) => {
         'durationDisplay',
         hasStructure ? 'videoJSTrackScrubber' : '',
         playerConfig.tracks.length > 0 ? 'subsCapsButton' : '',
-        'volumePanel',
+        IS_MOBILE ? 'muteToggle' : 'volumePanel',
         'qualitySelector',
         enablePIP ? 'pictureInPictureToggle' : '',
         enableFileDownload ? 'videoJSFileDownload' : '',
@@ -322,8 +322,6 @@ const MediaPlayer = ({ enableFileDownload = false, enablePIP = false }) => {
         targets,
         currentTime: currentTime || 0,
       },
-      // make the volume slider horizontal for audio
-      volumePanel: { inline: isVideo ? false : true },
       // disable fullscreen toggle button for audio
       fullscreenToggle: !isVideo ? false : true,
     },
@@ -336,6 +334,17 @@ const MediaPlayer = ({ enableFileDownload = false, enablePIP = false }) => {
       nativeTextTracks: false
     }
   } : {}; // Empty configurations for empty canvases
+
+  // Make the volume slider horizontal for audio in non-mobile browsers
+  if (!IS_MOBILE) {
+    videoJsOptions = {
+      ...videoJsOptions,
+      controlBar: {
+        ...videoJsOptions.controlBar,
+        volumePanel: { inline: isVideo ? false : true }
+      }
+    };
+  }
 
   // Add file download to toolbar when it is enabled via props
   if (enableFileDownload && !canvasIsEmpty) {

--- a/src/services/browser.js
+++ b/src/services/browser.js
@@ -133,6 +133,14 @@ export let IS_IPAD = false;
 export let IS_MOBILE = false;
 
 /**
+ * Whether or not this is a touch only device.
+ * 
+ * @static
+ * @type {Boolean}
+ */
+export let IS_TOUCH_ONLY = false;
+
+/**
  * Whether or not this device is an iPhone.
  *
  * @static
@@ -182,6 +190,11 @@ if (UAD && UAD.platform && UAD.brands) {
     IS_CHROME = !IS_EDGE && IS_CHROMIUM;
     CHROMIUM_VERSION = CHROME_VERSION = (UAD.brands.find(b => b.brand === 'Chromium') || {}).version || null;
     IS_WINDOWS = UAD.platform === 'Windows';
+    // Assume that any device with touch functionality and no mouse/touchpad is a tablet or phone.
+    // This check is needed because tablets were encountered in testing that did not include "Android"
+    // or "Mobile" in their useragent and lacked any other info that could be used to distinguish them.
+    IS_TOUCH_ONLY = navigator.maxTouchPoints && navigator.maxTouchPoints > 2 && !window.matchMedia("(pointer: fine").matches;
+    IS_MOBILE = UAD.mobile || IS_ANDROID || IS_TOUCH_ONLY;
 }
 
 // If the browser is not Chromium, either userAgentData is not present which could be an old Chromium browser,
@@ -266,7 +279,9 @@ if (!IS_CHROMIUM) {
 
     IS_IOS = IS_IPHONE || IS_IPAD || IS_IPOD;
 
-    IS_MOBILE = IS_ANDROID || IS_IOS || IS_IPHONE || (/Mobi/i).test(USER_AGENT);
+    IS_TOUCH_ONLY = navigator.maxTouchPoints && navigator.maxTouchPoints > 2 && !window.matchMedia("(pointer: fine").matches;
+
+    IS_MOBILE = IS_ANDROID || IS_IOS || IS_IPHONE || IS_TOUCH_ONLY || (/Mobi/i).test(USER_AGENT);
 }
 
 /**


### PR DESCRIPTION
Phones and tablets lack the ability to :hover, so the behavior of the volume slider is inconsistent and confusing on such devices. We can provide consistent behavior by disabling the slider and only providing a toggle for mute/unmute.

Resolves #352 