### PR TITLE
Remove transition when horizontal volume becomes inactive

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -68,6 +68,12 @@
   width: 4em !important;
 }
 
+/* Prevent horizontal volume panel from attempting to close for audio */
+.video-js .vjs-volume-panel.vjs-volume-panel-horizontal {
+  transition: none !important;
+  width: 8em !important;
+}
+
 /* Make player height minimum to the controls height so when we hide
 video/poster area the controls are displayed correctly. */
 .video-js.vjs-audio {


### PR DESCRIPTION
We had previously disabled the transition animation for when the horizontal slider becomes active, but there was another transition that would activate when the slider returned to inactive. Overriding this transition resolves #377.