### PR TITLE
Force initialization of canvas to start time specified in manifest when canvas index changes

### DIFF
--- a/src/components/MediaPlayer/MediaPlayer.js
+++ b/src/components/MediaPlayer/MediaPlayer.js
@@ -64,7 +64,7 @@ const MediaPlayer = ({ enableFileDownload = false, enablePIP = false }) => {
   React.useEffect(() => {
     if (manifest) {
       try {
-        initCanvas(canvasIndex);
+        initCanvas(canvasIndex, true);
 
         // flag to identify multiple canvases in the manifest
         // to render previous/next buttons


### PR DESCRIPTION
This resolves the issue with playlist items being skipped (#375) and may also resolve #385. 

Playlist items were being skipped because the `handleTimeUpdate` method in `VideoJSProgress` was firing a second 'ended' event while the player was in the middle of initializing the new playlist item.  This was happening because the start time of the previous playlist item was still the `currentTime` which was greater than the end time of the initializing playlist item. Setting the `fromStart` flag when calling `initCanvas` forces the player to set current time in the state to what is specified in the manifest.  This shouldn't affect structure navigation clicks across canvases because that should be handled by the `switchCanvas` method which passes along a value for `fromStart` instead of assuming a default.

Test this change with a playlist manifest with autoplay that has a start time for a playlist item later than the end time of the next playlist item.  Also test a non-playlist manifest with clicking on structure links that are on different canvases and don't start playback at 0.