### PR TITLE
Only force canvases to start from begining in playlist contexts

### DIFF
--- a/src/components/MediaPlayer/MediaPlayer.js
+++ b/src/components/MediaPlayer/MediaPlayer.js
@@ -66,7 +66,13 @@ const MediaPlayer = ({ enableFileDownload = false, enablePIP = false }) => {
   React.useEffect(() => {
     if (manifest) {
       try {
-        initCanvas(canvasIndex, true);
+        /*
+          Always start from the start time relevant to the Canvas only in playlist contexts,
+          because canvases related to playlist items always start from the given start.
+          With regular manifests, the start time could be different when using structured 
+          navigation to switch between canvases.
+        */
+        initCanvas(canvasIndex, playlist.isPlaylist);
 
         // flag to identify multiple canvases in the manifest
         // to render previous/next buttons


### PR DESCRIPTION
With the fix in https://github.com/samvera-labs/ramp/pull/386, player's time doesn't set to the clicked structure item's start time when using structured navigation to switch between canvases.
This PR restricts the behavior in https://github.com/samvera-labs/ramp/pull/386 only to playlist manifests.