### PR TITLE
Disable time updates when media has ended

### DIFF
--- a/src/components/MediaPlayer/VideoJS/components/js/VideoJSProgress.js
+++ b/src/components/MediaPlayer/VideoJS/components/js/VideoJSProgress.js
@@ -264,7 +264,7 @@ function ProgressBar({ player, handleTimeUpdate, initCurrentTime, times, options
 
   // Update progress bar with timeupdate in the player
   const timeUpdateHandler = () => {
-    if (player.isDisposed()) { return; }
+    if (player.isDisposed() || player.ended()) { return; }
     const iOS = player.hasClass("vjs-ios-native-fs");
     let curTime;
     // Initially update progress from the prop passed from Ramp,


### PR DESCRIPTION
Switching our time updates to trigger on an interval caused the handler to be called continuously, even after media had ended. This resulted in undesirable behavior in the structured nav when the last item would finish. Preventing the handler from firing when the player is in the 'ended' state fixes the behavior.