### PR TITLE
Revert to label so toggling works and include aria-labelledby

### DIFF
--- a/src/components/AutoAdvanceToggle/AutoAdvanceToggle.js
+++ b/src/components/AutoAdvanceToggle/AutoAdvanceToggle.js
@@ -19,7 +19,7 @@ const AutoAdvanceToggle = ({ label = "Autoplay", showLabel = true }) => {
           {label}
         </span>
       )}
-      <div className="ramp--auto-advance-toggle">
+      <label className="ramp--auto-advance-toggle" aria-labelledby="auto-advance-toggle-label">
         <input
           data-testid="auto-advance-toggle"
           name="auto-advance-toggle"
@@ -29,7 +29,7 @@ const AutoAdvanceToggle = ({ label = "Autoplay", showLabel = true }) => {
           onChange={e => manifestDispatch({ autoAdvance: e.target.checked, type: "setAutoAdvance" })}
         />
         <span className="slider round"></span>
-      </div>
+      </label>
     </div>
   );
 };


### PR DESCRIPTION
Labels wrapping inputs includes a standard behavior for toggling checkboxes.  I tried to mimic this behavior with an onclick event handler for the div but then the checkbox was appearing as readOnly so react gave warnings and I assume screen readers might not think it interactive.  Because of this I tried reverting to a label and including the aria-labelledby attribute even though it appeared to possibly be problematic due to either duplicating the aria-label on the checkbox input or for referencing an element which may or may not be rendered, but SiteImprove appears to be happy with it in either case. WAVE doesn't like it when the aria-labelledby reference doesn't exist but maybe we can treat this as an edge-case now since the label is shown by default.