### PR TITLE
Remove z-index for player control bar in mobile devices, add an additional check for inactivity

### DIFF
--- a/src/components/MediaPlayer/MediaPlayer.js
+++ b/src/components/MediaPlayer/MediaPlayer.js
@@ -13,7 +13,7 @@ import {
 } from '../../context/player-context';
 import { useErrorBoundary } from "react-error-boundary";
 import './MediaPlayer.scss';
-import { IS_MOBILE, IS_IPAD, IS_SAFARI } from '@Services/browser';
+import { IS_MOBILE, IS_IPAD, IS_SAFARI, IS_TOUCH_ONLY } from '@Services/browser';
 
 const PLAYER_ID = "iiif-media-player";
 
@@ -288,7 +288,7 @@ const MediaPlayer = ({ enableFileDownload = false, enablePIP = false }) => {
     // Setting inactivity timeout to zero in mobile and tablet devices translates to
     // user is always active. And the control bar is not hidden when user is active.
     // With this user can always use the controls when the media is playing.
-    inactivityTimeout: (IS_MOBILE || IS_IPAD) ? 0 : 2000,
+    inactivityTimeout: (IS_MOBILE || IS_TOUCH_ONLY || IS_IPAD) ? 0 : 2000,
     poster: isVideo ? getPlaceholderCanvas(manifest, canvasIndex, true) : null,
     controls: true,
     fluid: true,

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -52,7 +52,6 @@
 .vjs-mobile-visible {
   opacity: 1 !important;
   display: inline;
-  z-index: 10001;
 }
 
 /* Make VideoJS control bar buttons smaller */


### PR DESCRIPTION
The `IS_IPAD` check is flaky when setting the VideoJS options, therefore adding an additional check.

Related issue: https://github.com/avalonmediasystem/avalon/issues/5633