### PR TITLE
Add key to track map in VideoJS initializer

### DIFF
--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -571,7 +571,7 @@ function VideoJSPlayer({
             onTouchEnd={mobilePlayToggle}
           >
             {tracks?.length > 0 && (
-              tracks.map(t => <track src={t.src} kind={t.kind} label={t.label} default />)
+              tracks.map(t => <track key={t.key} src={t.src} kind={t.kind} label={t.label} default />)
             )}
           </video>
         ) : (

--- a/src/services/iiif-parser.test.js
+++ b/src/services/iiif-parser.test.js
@@ -119,6 +119,7 @@ describe('iiif-parser', () => {
         expect(error).toBeNull();
         expect(sources[0]).toEqual({
           src: 'https://example.com/manifest/high/lunchroom_manners_1024kb.mp4',
+          key: 'https://example.com/manifest/high/lunchroom_manners_1024kb.mp4',
           type: 'video/mp4',
           label: 'High',
           kind: 'Video',
@@ -134,6 +135,7 @@ describe('iiif-parser', () => {
         expect(sources).toHaveLength(3);
         expect(sources[2]).toEqual({
           src: 'https://example.com/manifest/low/lunchroom_manners_256kb.mp4',
+          key: 'https://example.com/manifest/low/lunchroom_manners_256kb.mp4',
           label: 'auto',
           type: 'video/mp4',
           selected: true,
@@ -181,6 +183,7 @@ describe('iiif-parser', () => {
         it('with generic ids', () => {
           const expectedObject = {
             src: 'https://example.com/manifest/lunchroom_manners.vtt',
+            key: 'https://example.com/manifest/lunchroom_manners.vtt',
             kind: 'Text',
             type: 'text/vtt',
             srclang: 'en',
@@ -197,6 +200,7 @@ describe('iiif-parser', () => {
         it('with captions in the id', () => { // Avalon-specific
           const expectedObject = {
             src: 'https://example.com/manifest/lunchroom_manners/captions',
+            key: 'https://example.com/manifest/lunchroom_manners/captions',
             kind: 'Text',
             type: 'text/vtt',
             srclang: 'en',

--- a/src/services/utility-helpers.js
+++ b/src/services/utility-helpers.js
@@ -385,6 +385,7 @@ function getResourceInfo(item, motivation) {
   if (aType != S_ANNOTATION_TYPE.transcript) {
     let s = {
       src: item.id,
+      key: item.id,
       type: item.getProperty('format'),
       kind: item.getProperty('type'),
       label: item.getLabel().getValue() || 'auto',

--- a/src/services/utility-helpers.test.js
+++ b/src/services/utility-helpers.test.js
@@ -134,6 +134,7 @@ describe('util helper', () => {
       expect(canvasTargets).toHaveLength(0);
       expect(resources[0]).toEqual({
         src: 'http://example.com/manifest/English.vtt',
+        key: 'http://example.com/manifest/English.vtt',
         type: 'text/vtt',
         kind: 'Text',
         srclang: 'en',
@@ -142,6 +143,7 @@ describe('util helper', () => {
       });
       expect(resources[1]).toEqual({
         src: 'http://example.com/manifest/Italian.vtt',
+        key: 'http://example.com/manifest/Italian.vtt',
         type: 'text/vtt',
         kind: 'Text',
         srclang: 'it',
@@ -229,6 +231,7 @@ describe('util helper', () => {
       expect(canvasTargets).toHaveLength(2);
       expect(resources[0]).toEqual({
         src: 'http://example.com/manifest/media_part1.mp4',
+        key: 'http://example.com/manifest/media_part1.mp4',
         type: 'video/mp4',
         kind: 'Video',
         label: 'Part 1',


### PR DESCRIPTION
We were getting a console error about list children requiring a key. This was related to our caption tracks array. I think we were seeing this because [JSX elements in a `map()`](https://react.dev/learn/rendering-lists#keeping-list-items-in-order-with-key) always require keys. Adding a key attribute to the track element within the map in VideoJS initialization resolves the error.