### PR TITLE
Use localStorage to make volume and quality settings sticky

### DIFF
--- a/src/services/local-storage.js
+++ b/src/services/local-storage.js
@@ -1,0 +1,27 @@
+// Adapted from https://blog.logrocket.com/using-localstorage-react-hooks/
+
+import { useState, useEffect } from "react";
+
+function getValue(key, defaultValue) {
+  try {
+    return JSON.parse(localStorage.getItem(key)) || defaultValue;
+  } catch(e) {
+    return defaultValue;
+  }
+}
+
+export const useLocalStorage = (key, defaultValue) => {
+  const [value, setValue] = useState(() => {
+    return getValue(key, defaultValue);
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(key, JSON.stringify(value));
+    } catch(e) {
+      ; // no-op
+    }
+  }, [key, value]);
+
+  return [value, setValue];
+};

--- a/src/services/local-storage.test.js
+++ b/src/services/local-storage.test.js
@@ -1,0 +1,27 @@
+import * as util from './utility-helpers';
+import { useLocalStorage } from '@Services/local-storage';
+import * as React from 'react';
+import { render } from '@testing-library/react';
+
+describe.skip('local storage', () => {
+  describe('useLocalStorage', () => {
+    test('default value', () => {
+      let settingRef = React.createRef();
+
+      function TestComponent() {
+        const [setting, setSetting] = useLocalStorage('setting', {});
+
+        React.useEffect(() => {
+          settingRef.currrent = setting;
+        });
+
+        return null;
+      }
+      render(<TestComponent/>);
+
+      expect(settingRef.current).toEqual({});
+      setSetting({'key': 'value'})
+      expect(setting).toEqual({'key': 'value'});
+    });
+  });
+});


### PR DESCRIPTION
Resolves #390 

This PR adds a helper service to make it easy to use localStorage as a React hook.  (It is adapted from https://blog.logrocket.com/using-localstorage-react-hooks/)  The `useLocalStorage` then gets used to store and retrieve volume and quality selections.  Volume is then set on player ready.  Quality is set by adjusting the `selected` attribute on sources right before instantiating the videojs player.  I thought keeping the storing/retrieving/setting all in the VideoJSPlayer component was simpler and kept it contained instead of trying to change the parser code to include the quality selection from localStorage.

I tried to write tests for the helper service but wasn't able to figure out how to setup the test.  I also tried adding tests of the rendered VideoJSPlayer component to check that setting volume or quality wrote the setting into the localStorage and that a setting in localStorage would be restored when the player rendered.  A couple problems I ran into with the VideoJSPlayer component testing were the player not getting to the ready state so not emitting events like `ready`, `volumechanged`, and `qualityRequested` and the `startQuality` value not getting set in the localStorage mock hash for an unknown reason (it was always present but null :shrug:).  I have committed all of these tests and marked them as skip so we can try to make them work in the future.  @Dananji suggested that it could be that the approach to testing the `VideoJSPlayer` component needs to change to be at a lower level: mock VideoJS entirely and simulate the events being emitted so we don't need to rely on the player initializing and getting to the ready state.