### PR TITLE
Assign id value to empty VideoJS instance

### DIFF
--- a/src/components/MediaPlayer/MediaPlayer.js
+++ b/src/components/MediaPlayer/MediaPlayer.js
@@ -362,7 +362,7 @@ const MediaPlayer = ({ enableFileDownload = false, enablePIP = false }) => {
   } : {}; // Empty configurations for empty canvases
 
   // Make the volume slider horizontal for audio in non-mobile browsers
-  if (!IS_MOBILE) {
+  if (!IS_MOBILE && !canvasIsEmpty) {
     videoJsOptions = {
       ...videoJsOptions,
       controlBar: {
@@ -409,7 +409,7 @@ const MediaPlayer = ({ enableFileDownload = false, enablePIP = false }) => {
   }
   // Iniitialize track scrubber button when the current Canvas has 
   // structure timespans or the given Manifest is a playlist Manifest
-  if (hasStructure || playlist.isPlaylist) {
+  if ((hasStructure || playlist.isPlaylist) && !canvasIsEmpty) {
     videoJsOptions = {
       ...videoJsOptions,
       controlBar: {
@@ -436,6 +436,7 @@ const MediaPlayer = ({ enableFileDownload = false, enablePIP = false }) => {
             dangerouslySetInnerHTML={{ __html: playerConfig.error }}>
           </div>
           <VideoJSPlayer
+            id={PLAYER_ID}
             isVideo={true}
             switchPlayer={switchPlayer}
             {...videoJsOptions}

--- a/src/components/MediaPlayer/MediaPlayer.scss
+++ b/src/components/MediaPlayer/MediaPlayer.scss
@@ -12,6 +12,7 @@
     margin: 0;
     color: white;
     width: 25%;
+    z-index: 50;
 
     a {
       color: $primaryGreen;


### PR DESCRIPTION
Empty VideoJS instances were not being initialized with the 'iiif-media-player' id attribute. This broke some functionality in Avalon and prevented the proper CSS rules from being applied. This commit also adds a z-index to the empty canvas message so that if the player CSS breaks again, the message should still be layered on top of it.