### PR TITLE
Check if player is paused before firing ended events

### DIFF
--- a/src/components/MediaPlayer/VideoJS/components/js/VideoJSProgress.js
+++ b/src/components/MediaPlayer/VideoJS/components/js/VideoJSProgress.js
@@ -114,7 +114,10 @@ class VideoJSProgress extends vjsComponent {
     if (curTime < start) {
       player.currentTime(start);
     }
-    if (curTime >= end) {
+    // Some items, particularly in playlists, were not having `player.ended()` properly
+    // set by the 'ended' event. Providing a fallback check that the player is already
+    // paused prevents undesirable behavior from excess state changes after play ending.
+    if (curTime >= end && !player.paused()) {
       if (nextItems.length == 0) options.nextItemClicked(0, targets[0].start);
       player.pause();
       player.trigger('ended');


### PR DESCRIPTION
I was not able to track down the root cause, but not all player instances would be assigned `player.ended() === true` when we triggered the `ended` event in the time update handler. This was only seen with playlist items in my testing, but it did not seem to occur with all playlists. The `pause` event, however, does seem to be triggering consistently and assigning the proper values. When checking if we are at or past the end of the video, we can prevent continuous state updates by also checking if the player is already paused, making the assumption that this means the code within the block has already run once.