### PR TITLE
Fix broken hotkeys when switching Canvas and for mute in Chrome

### DIFF
--- a/src/components/MediaPlayer/MediaPlayer.js
+++ b/src/components/MediaPlayer/MediaPlayer.js
@@ -355,7 +355,7 @@ const MediaPlayer = ({ enableFileDownload = false, enablePIP = false }) => {
     userActions: {
       hotkeys: !IS_SAFARI
         ? function (e) {
-          playerHotKeys(e, PLAYER_ID);
+          playerHotKeys(e, this);
         }
         : undefined
     }

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -292,10 +292,13 @@ function VideoJSPlayer({
       player.on('timeupdate', () => {
         handleTimeUpdate();
       });
-      // This event handler helps to catch the 'keydown' events from the first page load
-      // even before the user interacts with the player
+      /*
+        This event handler helps to execute hotkeys functions related to 'keydown' events
+        before any user interactions with the player or when focused on other non-input 
+        elements on the page
+      */
       document.addEventListener('keydown', (event) => {
-        playerHotKeys(event, videoJSOptions.id);
+        playerHotKeys(event, player);
       });
     }
   }, [player]);

--- a/src/services/utility-helpers.js
+++ b/src/services/utility-helpers.js
@@ -497,9 +497,8 @@ export function autoScroll(currentItem, containerRef) {
  * @param {String} id player instance ID in VideoJS
  * @returns 
  */
-export function playerHotKeys(event, id) {
-  let player = document.getElementById(id);
-  let playerInst = player?.player;
+export function playerHotKeys(event, player) {
+  let playerInst = player?.player_;
 
   let inputs = ['input', 'textarea'];
   let activeElement = document.activeElement;
@@ -587,5 +586,16 @@ export function playerHotKeys(event, id) {
       default:
         return;
     }
+    /*
+      This function gets invoked by 2 different 'keydown' event listeners;
+      Document's 'keydown' event listener => when player is out of focus on 
+        first load and when user is interacting with other elements on the page
+      Video.js' native controls' 'keydown' event listeners => when a native player control is in focus
+        when using the pointer
+      Therefore, once a 'keydown' event is passed throught this function to invoke a hotkey function, 
+      event propogation needs to be stopped. Otherwise the hotkeys functionality gets called twice,
+      undoing the action performed in the initial call.
+    */
+    event.stopPropagation();
   }
 }


### PR DESCRIPTION
Related issue: https://github.com/avalonmediasystem/avalon/issues/5645