### PR TITLE
Force text track font size in mobile contexts

### DIFF
--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -20,7 +20,7 @@ import {
   getCanvasIndex,
 } from '@Services/iiif-parser';
 import { checkSrcRange, getMediaFragment, playerHotKeys } from '@Services/utility-helpers';
-import { IS_IPAD, IS_MOBILE } from '@Services/browser';
+import { IS_ANDROID, IS_IPAD, IS_MOBILE, IS_TOUCH_ONLY } from '@Services/browser';
 import { useLocalStorage } from '@Services/local-storage';
 
 /** VideoJS custom components */
@@ -584,6 +584,18 @@ function VideoJSPlayer({
     return null;
   };
 
+  // Classes for setting caption size based on device
+  // Not all Android tablets return 'Android' in the useragent, so assume touch 
+  // devices are tablets. This should be safe because iPhones use the native player.
+  let videoClass = '';
+  if (IS_ANDROID) { 
+    videoClass = "video-js vjs-big-play-centered android";
+  } else if (IS_TOUCH_ONLY) {
+    videoClass = "video-js vjs-big-play-centered tablet"
+  } else { 
+    videoClass = "video-js vjs-big-play-centered"; 
+  };
+
   return (
     <React.Fragment>
       <div data-vjs-player>
@@ -592,7 +604,7 @@ function VideoJSPlayer({
             data-testid="videojs-video-element"
             data-canvasindex={cIndex}
             ref={(node) => (playerRef.current = node)}
-            className="video-js vjs-big-play-centered"
+            className={videoClass}
             onTouchStart={saveTouchStartCoords}
             onTouchEnd={mobilePlayToggle}
           >

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -586,7 +586,6 @@ function VideoJSPlayer({
 
   // Classes for setting caption size based on device
   let videoClass = '';
-  console.log(IS_IPAD);
   if (IS_ANDROID) { 
     videoClass = "video-js vjs-big-play-centered android";
   // Not all Android tablets return 'Android' in the useragent so assume non-android,

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -20,7 +20,7 @@ import {
   getCanvasIndex,
 } from '@Services/iiif-parser';
 import { checkSrcRange, getMediaFragment, playerHotKeys } from '@Services/utility-helpers';
-import { IS_ANDROID, IS_IPAD, IS_MOBILE, IS_TOUCH_ONLY } from '@Services/browser';
+import { IS_ANDROID, IS_IOS, IS_IPAD, IS_MOBILE, IS_TOUCH_ONLY } from '@Services/browser';
 import { useLocalStorage } from '@Services/local-storage';
 
 /** VideoJS custom components */
@@ -585,13 +585,16 @@ function VideoJSPlayer({
   };
 
   // Classes for setting caption size based on device
-  // Not all Android tablets return 'Android' in the useragent, so assume touch 
-  // devices are tablets. This should be safe because iPhones use the native player.
   let videoClass = '';
+  console.log(IS_IPAD);
   if (IS_ANDROID) { 
     videoClass = "video-js vjs-big-play-centered android";
-  } else if (IS_TOUCH_ONLY) {
-    videoClass = "video-js vjs-big-play-centered tablet"
+  // Not all Android tablets return 'Android' in the useragent so assume non-android,
+  // non-iOS touch devices are tablets.
+  } else if (IS_TOUCH_ONLY && !IS_IOS) {
+    videoClass = "video-js vjs-big-play-centered tablet";
+  } else if (IS_IPAD) {
+    videoClass = "video-js vjs-big-play-centered tablet";
   } else { 
     videoClass = "video-js vjs-big-play-centered"; 
   };

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -134,6 +134,33 @@ video/poster area the controls are displayed correctly. */
   border-bottom: 0.45rem ridge $primaryGreen;
 }
 
+/* captions font for android and tablet fullscreen */
+@media screen and (orientation:portrait) {
+  .vjs-fullscreen.android {
+    // Force text track to bottom of screen but not overlapping control bar
+    .vjs-text-track-cue {
+      inset: auto 0px 20px !important;
+      height: auto !important;
+    }
+
+    .vjs-text-track-cue > div {
+      font: 22px sans-serif;
+    }
+  }
+
+  .vjs-fullscreen.tablet {
+    // Force text track to bottom of screen but not overlapping control bar
+    .vjs-text-track-cue {
+      inset: auto 0px 20px !important;
+      height: auto !important;
+    }
+
+    .vjs-text-track-cue > div {
+      font: 32px sans-serif;
+    }
+  }
+}
+
 /** End - Overrides for VideoJS related styling **/
 
 // Webkit override for scroll bars for always-on display in Chrome and Safari


### PR DESCRIPTION
Text tracks were generating with an exceedingly large font in full screen portrait mode on mobile browsers. Overriding the native VideoJS styling and explicitly defining a font size remedies the issue.