### PR TITLE
iOS double captions fix

### DIFF
--- a/src/components/MediaPlayer/MediaPlayer.js
+++ b/src/components/MediaPlayer/MediaPlayer.js
@@ -13,7 +13,7 @@ import {
 } from '../../context/player-context';
 import { useErrorBoundary } from "react-error-boundary";
 import './MediaPlayer.scss';
-import { IS_IOS, IS_IPHONE, IS_MOBILE, IS_SAFARI, IS_TOUCH_ONLY } from '@Services/browser';
+import { IS_ANDROID, IS_MOBILE, IS_SAFARI, IS_TOUCH_ONLY } from '@Services/browser';
 
 const PLAYER_ID = "iiif-media-player";
 
@@ -340,9 +340,9 @@ const MediaPlayer = ({ enableFileDownload = false, enablePIP = false }) => {
     sources: isMultiSource
       ? playerConfig.sources[srcIndex]
       : playerConfig.sources,
-    // Enable native text track functionality in iPhones when not using HLS streams
+    // Enable native text track functionality in iPhones and iPads when not using HLS streams
     html5: {
-      nativeTextTracks: IS_IOS && IS_IPHONE && !isStream
+      nativeTextTracks: IS_MOBILE && !isStream && !IS_ANDROID
     },
     // Setting this option helps to override VideoJS's default 'keydown' event handler, whenever
     // the focus is on a native VideoJS control icon (e.g. play toggle).

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -628,6 +628,7 @@ VideoJSPlayer.propTypes = {
   trackScrubberRef: PropTypes.object,
   scrubberTooltipRef: PropTypes.object,
   videoJSOptions: PropTypes.object,
+  tracks: PropTypes.array,
 };
 
 export default VideoJSPlayer;

--- a/src/services/iiif-parser.js
+++ b/src/services/iiif-parser.js
@@ -154,7 +154,14 @@ export function getMediaInfo({ manifest, canvasIndex, srcIndex = 0 }) {
     });
     // Set default src to auto
     sources = setDefaultSrc(resources, isMultiSource, srcIndex);
-    const isHLS = sources.map((s) => s.src.split('.')?.pop()).includes('m3u8') || false;
+
+    /*
+      Identify the media is streaming or not by testing whether the src includes .m3u8 
+      OR media format includes HLS mime types => application/x-mpegURL or vnd.apple.mpegURL
+    */
+    const isHLS = sources
+      .map(s => (/m3u8/i).test(s.src) && (/(application\/x-mpegURL)||(vnd.apple.mpegURL)/i).test(s.type))
+      .every(f => f === true);
 
     // Read supplementing resources fom annotations
     const supplementingRes = readAnnotations({

--- a/src/services/iiif-parser.js
+++ b/src/services/iiif-parser.js
@@ -160,7 +160,7 @@ export function getMediaInfo({ manifest, canvasIndex, srcIndex = 0 }) {
       OR media format includes HLS mime types => application/x-mpegURL or vnd.apple.mpegURL
     */
     const isHLS = sources
-      .map(s => (/m3u8/i).test(s.src) && (/(application\/x-mpegURL)||(vnd.apple.mpegURL)/i).test(s.type))
+      .map(s => (/m3u8/i).test(s.src) || (/(application\/x-mpegURL)|(vnd.apple.mpegURL)/i).test(s.type))
       .every(f => f === true);
 
     // Read supplementing resources fom annotations

--- a/src/services/iiif-parser.test.js
+++ b/src/services/iiif-parser.test.js
@@ -161,6 +161,14 @@ describe('iiif-parser', () => {
           });
           expect(isHLS).toBeTruthy();
         });
+
+        it('with media format as vnd.apple.mpegURL', () => {
+          const { isHLS } = iiifParser.getMediaInfo({
+            manifest: singleSrcManifest,
+            canvasIndex: 0,
+          });
+          expect(isHLS).toBeTruthy();
+        });
       });
 
       describe('identifies media as non-stream', () => {

--- a/src/services/iiif-parser.test.js
+++ b/src/services/iiif-parser.test.js
@@ -145,23 +145,41 @@ describe('iiif-parser', () => {
         expect(sources[2].selected).toBeTruthy();
       });
 
-      it('identifies media as non-stream', () => {
-        const { isHLS } = iiifParser.getMediaInfo({
-          manifest: lunchroomManifest,
-          canvasIndex: 0,
+      describe('identifies media as stream', () => {
+        it('with src ending .m3u8', () => {
+          const { isHLS } = iiifParser.getMediaInfo({
+            manifest: singleSrcManifest,
+            canvasIndex: 1,
+          });
+          expect(isHLS).toBeTruthy();
         });
-        expect(isHLS).toBeFalsy();
+
+        it('with src media fragment with .m3u8', () => {
+          const { isHLS } = iiifParser.getMediaInfo({
+            manifest: playlistManifest,
+            canvasIndex: 1,
+          });
+          expect(isHLS).toBeTruthy();
+        });
       });
 
-
-      it('identifies media as stream', () => {
-        const { isHLS } = iiifParser.getMediaInfo({
-          manifest: singleSrcManifest,
-          canvasIndex: 1,
+      describe('identifies media as non-stream', () => {
+        it('with src ending .mp4', () => {
+          const { isHLS } = iiifParser.getMediaInfo({
+            manifest: lunchroomManifest,
+            canvasIndex: 0,
+          });
+          expect(isHLS).toBeFalsy();
         });
-        expect(isHLS).toBeTruthy();
-      });
 
+        it('with media fragment with .mp4', () => {
+          const { isHLS } = iiifParser.getMediaInfo({
+            manifest: playlistManifest,
+            canvasIndex: 2,
+          });
+          expect(isHLS).toBeFalsy();
+        });
+      });
 
       it("selects the first source when quality 'auto' is not present", () => {
         const { sources } = iiifParser.getMediaInfo({

--- a/src/test_data/playlist.js
+++ b/src/test_data/playlist.js
@@ -117,9 +117,9 @@ export default {
               type: 'Annotation',
               motivation: 'painting',
               body: {
-                id: 'http://example.com/volleyball/high/volleyball-for-boys.mp4#t=0,32.0',
+                id: 'http://example.com/volleyball/high/volleyball-for-boys.m3u8#t=0,32.0',
                 type: 'Video',
-                format: 'video/mp4',
+                format: 'application/x-mpegURL',
                 label: {
                   en: ['High'],
                 },

--- a/src/test_data/transcript-multiple-canvas.js
+++ b/src/test_data/transcript-multiple-canvas.js
@@ -88,15 +88,6 @@ export default {
                     },
                   ],
                 },
-                {
-                  id: 'https://example.com/sample/subtitles.vtt',
-                  type: 'Text',
-                  format: 'text/vtt',
-                  label: {
-                    en: ['Captions in WebVTT format'],
-                  },
-                  language: 'en',
-                },
               ],
               target: 'https://example.com/sample/canvas/2',
             },

--- a/src/test_data/transcript-multiple-canvas.js
+++ b/src/test_data/transcript-multiple-canvas.js
@@ -25,7 +25,7 @@ export default {
                 {
                   id: 'https://example.com/sample/high/media.mp4',
                   type: 'Video',
-                  format: 'video/mp4',
+                  format: 'vnd.apple.mpegURL',
                   label: {
                     en: ['High'],
                   },
@@ -81,7 +81,7 @@ export default {
                     {
                       id: 'https://example.com/sample/high/media.m3u8',
                       type: 'Video',
-                      format: 'video/mp4',
+                      format: 'vnd.apple.mpegURL',
                       label: {
                         en: ['High'],
                       },


### PR DESCRIPTION
This PR fixes double captions in iOS devices in playlist contexts. 
The reason for the bug was that the check identifying HLS streams in Ramp failed to distinguish some playlist items as HLS streams.
Playlist items added as clips in Avalon's playlist manifests have the media URLs presented as media fragments and these doesn't end with `.m3u8` but has `#t=...` at the end to indicate the media fragment. And Ramp check expected all HLS stream URLs to end with `.m3u8` which failed.

| Captions menu in Ramp | Captions menu in iOS native player |
| :---         |     :---:      |
*Media object  manifest*
| ![screenshot-iPhone 15-17 3](https://github.com/samvera-labs/ramp/assets/1331659/3745745c-68bf-46d8-8819-f00c24f1ef37)  | ![screenshot-iPhone 15-17 3(1)](https://github.com/samvera-labs/ramp/assets/1331659/6483466a-2e34-497a-8c68-05250bdf37d0)    |
*Playlist manifest item*
| ![screenshot-iPhone 15-17 3(2)](https://github.com/samvera-labs/ramp/assets/1331659/388ec1d1-f53a-416c-9288-4108a9409606)    | ![screenshot-iPhone 15-17 3(3)](https://github.com/samvera-labs/ramp/assets/1331659/92ba9899-6905-4b2f-81df-28c1e42d32c9)      |
*This fix does not break Cookbook manifest*
| ![screenshot-iPhone 15-17 3(8)](https://github.com/samvera-labs/ramp/assets/1331659/6d82b100-1433-49ca-bd72-ef341527600a)     | ![screenshot-iPhone 15-17 3(9)](https://github.com/samvera-labs/ramp/assets/1331659/99abd131-fc5a-4ab2-a503-d4ba3e59fcd5)      |

Related issue: https://github.com/samvera-labs/ramp/issues/382