### PR TITLE
Use safe navigator when setting quality

### DIFF
--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -407,8 +407,8 @@ function VideoJSPlayer({
   const setSelectedQuality = (sources) => {
     //iterate through sources and find source that matches startQuality and source currently marked selected
     //if found set selected attribute on matching source then remove from currently marked one
-    const originalQuality = sources.find((source) => source.selected == true);
-    const selectedQuality = sources.find((source) => source.label == startQuality);
+    const originalQuality = sources?.find((source) => source.selected == true);
+    const selectedQuality = sources?.find((source) => source.label == startQuality);
     if (selectedQuality) {
       originalQuality.selected = false;
       selectedQuality.selected = true;


### PR DESCRIPTION
The `sources` variable is not set when there is a blank canvas, causing an error. This breaks generation of the dummied out player instance that we rely on for certain actions within Avalon. Using the safe navigator prevents the error, allowing generation of the player to finish.