### PR TITLE
Override VJS caption font to prevent double spacing

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -142,6 +142,7 @@ video/poster area the controls are displayed correctly. */
     .vjs-text-track-cue {
       inset: auto 0px 20px !important;
       height: auto !important;
+      font: 0px sans-serif !important;
     }
 
     .vjs-text-track-cue > div {
@@ -154,6 +155,7 @@ video/poster area the controls are displayed correctly. */
     .vjs-text-track-cue {
       inset: auto 0px 20px !important;
       height: auto !important;
+      font: 0px sans-serif !important;
     }
 
     .vjs-text-track-cue > div {


### PR DESCRIPTION
I am not sure why the rule was not rendering in Ramp, but when loaded into Avalon there was a larger font CSS on `.vjs-text-track-cue` that was rendering. This caused the smaller font on the child div to display as if the captions were double spaced because the child font was not filling the allotted space from the parent. Setting the parent font to 0px and using solely the child font seems to fix the rendering.