### PR TITLE
Test audiannotate

### DIFF
--- a/src/components/SupplementalFiles/SupplementalFiles.js
+++ b/src/components/SupplementalFiles/SupplementalFiles.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useManifestState } from '../../context/manifest-context';
-import { getRenderingFiles, getSupplementingFiles } from '@Services/iiif-parser';
+import { getRenderingFiles, getSupplementingAnnotations } from '@Services/iiif-parser';
 import { fileDownload } from '@Services/utility-helpers';
 import { useErrorBoundary } from "react-error-boundary";
 import './SupplementalFiles.scss';
@@ -21,7 +21,7 @@ const SupplementalFiles = ({ itemHeading = "Item files", sectionHeading = "Secti
         let manifestFiles = renderings.manifest;
         setManifestSupplementalFiles(manifestFiles);
 
-        let annotations = getSupplementingFiles(manifest);
+        let annotations = getSupplementingAnnotations(manifest);
         let canvasFiles = renderings.canvas;
         canvasFiles.map((canvas, index) => canvas.files = canvas.files.concat(annotations[index].files));
         canvasFiles = canvasFiles.filter(canvasFiles => canvasFiles.files.length > 0);

--- a/src/services/iiif-parser.js
+++ b/src/services/iiif-parser.js
@@ -460,7 +460,7 @@ export function getRenderingFiles(manifest) {
   }
 }
 
-export function getSupplementingFiles(manifest) {
+export function getSupplementingAnnotations(manifest) {
   let canvasFiles = [];
   try {
     let canvases = parseSequences(manifest)[0]
@@ -474,7 +474,10 @@ export function getSupplementingFiles(manifest) {
         if (annotationJSON?.length) {
           const annotationPage = annotationJSON[0];
           if (annotationPage && annotationPage.items != undefined) {
-            annotations = annotationPage.items.filter(annotation => annotation.motivation == "supplementing" && annotation.body.id);
+            annotations = annotationPage.items
+              .filter(
+                annotation => annotation.motivation == "supplementing" && annotation.body.id
+              );
           }
         }
 

--- a/src/services/iiif-parser.js
+++ b/src/services/iiif-parser.js
@@ -473,7 +473,7 @@ export function getSupplementingFiles(manifest) {
         let annotations = [];
         if (annotationJSON?.length) {
           const annotationPage = annotationJSON[0];
-          if (annotationPage) {
+          if (annotationPage && annotationPage.items != undefined) {
             annotations = annotationPage.items.filter(annotation => annotation.motivation == "supplementing" && annotation.body.id);
           }
         }

--- a/src/services/iiif-parser.test.js
+++ b/src/services/iiif-parser.test.js
@@ -6,6 +6,7 @@ import singleSrcManifest from '@TestData/transcript-multiple-canvas';
 import autoAdvanceManifest from '@TestData/multiple-canvas-auto-advance';
 import playlistManifest from '@TestData/playlist';
 import emptyManifest from '@TestData/empty-manifest';
+import audiAnnotateManifest from '@TestData/audiannotate-test';
 import * as iiifParser from './iiif-parser';
 import * as util from './utility-helpers';
 
@@ -458,25 +459,34 @@ describe('iiif-parser', () => {
     });
   });
 
-  describe('getSupplementingFiles()', () => {
+  describe('getSupplementingAnnotations()', () => {
     it('with `TextualBody` supplementing annotations', () => {
-      const files = iiifParser.getSupplementingFiles(manifest);
-      expect(files.length).toBe(2);
-      expect(files[0].label).toBe('Section 1');
-      expect(files[0].files.length).toBe(0);
-      expect(files[1].label).toBe('Section 2');
-      expect(files[1].files.length).toBe(0);
+      const annotations = iiifParser.getSupplementingAnnotations(manifest);
+      expect(annotations.length).toBe(2);
+      expect(annotations[0].label).toBe('Section 1');
+      expect(annotations[0].files.length).toBe(0);
+      expect(annotations[1].label).toBe('Section 2');
+      expect(annotations[1].files.length).toBe(0);
     });
 
     it('with supplementing annotations', () => {
-      const files = iiifParser.getSupplementingFiles(lunchroomManifest);
-      expect(files.length).toBe(2);
-      expect(files[0].label).toBe('Lunchroom Manners');
-      expect(files[0].files.length).toBe(1);
-      expect(files[0].files[0].label).toEqual('Captions in WebVTT format (.vtt)');
-      expect(files[0].files[0].filename).toEqual('Captions in WebVTT format');
-      expect(files[1].label).toBe('Section 2');
-      expect(files[1].files.length).toBe(2);
+      const annotations = iiifParser.getSupplementingAnnotations(lunchroomManifest);
+      expect(annotations.length).toBe(2);
+      expect(annotations[0].label).toBe('Lunchroom Manners');
+      expect(annotations[0].files.length).toBe(1);
+      expect(annotations[0].files[0].label).toEqual('Captions in WebVTT format (.vtt)');
+      expect(annotations[0].files[0].filename).toEqual('Captions in WebVTT format');
+      expect(annotations[1].label).toBe('Section 2');
+      expect(annotations[1].files.length).toBe(2);
+    });
+
+    it('without supplementing annotations', () => {
+      const annotations = iiifParser.getSupplementingAnnotations(audiAnnotateManifest);
+      expect(annotations.length).toBe(2);
+      expect(annotations[0].label).toBe('Section 1');
+      expect(annotations[0].files.length).toBe(0);
+      expect(annotations[1].label).toBe('Section 2');
+      expect(annotations[1].files.length).toBe(0);
     });
   });
 

--- a/src/services/utility-helpers.js
+++ b/src/services/utility-helpers.js
@@ -336,7 +336,7 @@ export function getResourceItems(annotations, duration, motivation) {
        * Is that okay or would that mess things up?
        * Maybe this is an impossible edge case that doesn't need to be worried about?
        */
-      source.length > 0 && resources.push(source[0]);
+      (source.length > 0 && source[0].src) && resources.push(source[0]);
     });
   }
   // Multiple Choices avalibale
@@ -344,7 +344,8 @@ export function getResourceItems(annotations, duration, motivation) {
     const annoQuals = annotations[0].getBody();
     annoQuals.map((a) => {
       const source = getResourceInfo(a, motivation);
-      source.length > 0 && resources.push(source[0]);
+      // Check if the parsed sources has a resource URL
+      (source.length > 0 && source[0].src) && resources.push(source[0]);
     });
   }
   // No resources

--- a/src/test_data/audiannotate-test.js
+++ b/src/test_data/audiannotate-test.js
@@ -1,0 +1,90 @@
+export default {
+  '@context': 'http://iiif.io/api/presentation/3/context.json',
+  id: 'https://example.com/audiannotate-test/manifest.json',
+  type: 'Manifest',
+  label: { en: ['AudiAnnotate Test Manifest'] },
+  homepage: [
+    {
+      id: 'archive.org',
+      type: 'Text',
+      label: { en: ['AudiAnnotate Test'] },
+      format: 'text/html'
+    }
+  ],
+  provider: [
+    {
+      id: 'archive.org',
+      type: 'Agent',
+      label: { en: ['Internet Archive'] }
+    }
+  ],
+  items: [
+    {
+      id: 'https://example.com/audiannotate-test/canvas-1/canvas',
+      type: 'Canvas',
+      duration: 809.0,
+      annotations: [
+        {
+          type: 'AnnotationPage',
+          id: 'https://example.com/audiannotate-test/annotations/audiannotate-test-canvas-1-shadow.json',
+          label: { none: ['Shadow'] }
+        }
+      ],
+      items: [
+        {
+          id: 'https://example.com/audiannotate-test/canvas-1/paintings',
+          type: 'AnnotationPage',
+          items: [
+            {
+              id: 'https://example.com/audiannotate-test/canvas-1/painting',
+              type: 'Annotation',
+              motivation: 'painting',
+              body: {
+                id: 'https://example.com/audiannotate-test.mp4',
+                type: 'Video',
+                format: 'video/mp4',
+                duration: 809.0
+              },
+              target: 'https://example.com/audiannotate-test/canvas-1/canvas'
+            }
+          ]
+        }
+      ]
+    },
+    {
+      id: 'https://example.com/audiannotate-test/canvas-2/canvas',
+      type: 'Canvas',
+      duration: 3204.0,
+      annotations: [
+        {
+          type: 'AnnotationPage',
+          id: 'https://example.com/audiannotate-test/annotations/audiannotate-test-canvas-2-carvel-collins.json',
+          label: { none: ['Carvel Collins'] }
+        },
+        {
+          type: 'AnnotationPage',
+          id: 'https://example.com/audiannotate-test/annotations/audiannotate-test-canvas-2-audience.json',
+          label: { none: ['Audience'] }
+        }
+      ],
+      items: [
+        {
+          id: 'https://example.com/audiannotate-test/canvas-2/paintings',
+          type: 'AnnotationPage',
+          items: [
+            {
+              id: 'https://example.com/audiannotate-test/canvas-2/painting',
+              type: 'Annotation',
+              motivation: 'painting',
+              body: {
+                id: '',
+                duration: 3204.0
+              },
+              target: 'https://example.com/audiannotate-test/canvas-2/canvas'
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};


### PR DESCRIPTION
Related issue: https://github.com/samvera-labs/ramp/issues/346

Changes in the parser:
- Fail gracefully for empty canvases when represented with a body but no URIs in it
- Fix condition for reading `items` list under `AnnotationPage` property, handle cases when there are no `items` list

These changes are related to reading AudiAnnotate manifests in Ramp. 