### PR TITLE
Interpret null values in metadata as empty strings

### DIFF
--- a/src/services/iiif-parser.js
+++ b/src/services/iiif-parser.js
@@ -538,7 +538,7 @@ export function parseMetadata(metadata, resourceType) {
   if (metadata?.length > 0) {
     metadata.map(md => {
       // get value and replace /n characters with <br/> to display new lines in UI
-      let value = md.getValue().replace(/\n/g, "<br />");
+      let value = md.getValue()?.replace(/\n/g, "<br />");
       let sanitizedValue = sanitizeHtml(value, { ...HTML_SANITIZE_CONFIG });
       parsedMetadata.push({
         label: md.getLabel(),

--- a/src/services/iiif-parser.test.js
+++ b/src/services/iiif-parser.test.js
@@ -559,6 +559,12 @@ describe('iiif-parser', () => {
         label: "Notes", value: "<a></a>"
       });
     });
+
+    it('interprets null value as an empty string', () => {
+      const { manifestMetadata, _ } = iiifParser.getMetadata(lunchroomManifest, false);
+      expect(manifestMetadata.length).toBeGreaterThan(0);
+      expect(manifestMetadata[9]).toEqual({ label: "Notes", value: "" });
+    });
   });
 
   describe('parseAutoAdvance()', () => {

--- a/src/test_data/lunchroom-manners.js
+++ b/src/test_data/lunchroom-manners.js
@@ -44,6 +44,10 @@ export default {
     {
       label: { en: ["Table of Contents"] },
       value: { en: ["ToC\n--\nFirst Chapter\n--\nSecond Chapter", "This is a second table of contents field.\n\nMore chapters here?"] }
+    },
+    {
+      label: { en: ["Notes"] },
+      value: null
     }
   ],
   rendering: [


### PR DESCRIPTION
With this change metadata with null values would show up in the MetadataDisplay component as below;

![Screenshot 2024-02-21 at 4 03 53 PM](https://github.com/samvera-labs/ramp/assets/1331659/35e51b26-425c-4a71-8e90-cb71c8edcae5)
![Screenshot 2024-02-21 at 4 03 21 PM](https://github.com/samvera-labs/ramp/assets/1331659/c30460c5-0392-4f11-bd82-ae1d73dc6453)

This is identical to the behavior in both Clover and UV.

@joncameron Does this look okay? Or do you think removing the metadata field in the display works better?

Related issue: https://github.com/samvera-labs/ramp/issues/379