### PR TITLE
Change caption filtering to always use VideoJS' tracks instead of HLS tracks

### DIFF
--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -258,8 +258,8 @@ function VideoJSPlayer({
         playerDispatch({ isEnded: false, type: 'setIsEnded' });
 
         let textTracks = player.textTracks();
-        // Get the tracks duplicated by HLS manifest's captions (if specified)
-        let duplicatedTracks = textTracks.tracks_.filter(rt => tracks.findIndex(tr => tr.src === rt.src) > -1);
+        // Filter the duplicated tracks by HLS manifest, these doesn't have a src attribute
+        let duplicatedTracks = textTracks.tracks_.filter(rt => rt.src === undefined);
         // Remove the duplicated tracks from the captions/subtitles menu
         if (tracks.length != textTracks.length && duplicatedTracks?.length > 0) {
           for (let i = 0; i < duplicatedTracks.length; i++) {
@@ -618,7 +618,16 @@ function VideoJSPlayer({
             onTouchEnd={mobilePlayToggle}
           >
             {tracks?.length > 0 && (
-              tracks.map(t => <track key={t.key} src={t.src} kind={t.kind} label={t.label} default />)
+              tracks.map(t =>
+                <track
+                  key={t.key}
+                  src={t.src}
+                  kind={t.kind}
+                  label={t.label}
+                  srcLang={t.srclang}
+                  default
+                />
+              )
             )}
           </video>
         ) : (


### PR DESCRIPTION
Related issue: https://github.com/avalonmediasystem/avalon/issues/5655

This PR changes the captions filtering in the check, to always use the tracks injected by Video.js instead of using HLS tracks. 
Reason for using Video.js tracks: sometimes the HLS' tracks can have `DEFAULT=NO` which sets the captions off by default. Video.js tracks are always created with `default` set to `true` in the Ramp code, ensuring that captions are on by default.