### PR TITLE
Fix auto advance and player crashing on Canvas change

### DIFF
--- a/src/components/MediaPlayer/MediaPlayer.js
+++ b/src/components/MediaPlayer/MediaPlayer.js
@@ -59,6 +59,9 @@ const MediaPlayer = ({ enableFileDownload = false, enablePIP = false }) => {
   const autoAdvanceRef = React.useRef();
   autoAdvanceRef.current = autoAdvance;
 
+  const lastCanvasIndexRef = React.useRef();
+  lastCanvasIndexRef.current = lastCanvasIndex;
+
   const trackScrubberRef = React.useRef();
   const timeToolRef = React.useRef();
 
@@ -251,7 +254,7 @@ const MediaPlayer = ({ enableFileDownload = false, enablePIP = false }) => {
    */
   const createCanvasMessageTimer = () => {
     canvasMessageTimerRef.current = setTimeout(() => {
-      if (canvasIndexRef.current < lastCanvasIndex) {
+      if (canvasIndexRef.current < lastCanvasIndexRef.current) {
         manifestDispatch({
           canvasIndex: canvasIndexRef.current + 1,
           type: 'switchCanvas',
@@ -278,7 +281,7 @@ const MediaPlayer = ({ enableFileDownload = false, enablePIP = false }) => {
    * next or previous buttons with keyboard
    */
   const switchPlayer = (index, fromStart, focusElement = '') => {
-    if (canvasIndexRef.current != index && index <= lastCanvasIndex) {
+    if (canvasIndexRef.current != index && index <= lastCanvasIndexRef.current) {
       manifestDispatch({
         canvasIndex: index,
         type: 'switchCanvas',
@@ -402,7 +405,7 @@ const MediaPlayer = ({ enableFileDownload = false, enablePIP = false }) => {
         },
         videoJSNextButton: {
           canvasIndex,
-          lastCanvasIndex,
+          lastCanvasIndex: lastCanvasIndexRef.current,
           switchPlayer,
           playerFocusElement,
         },

--- a/src/components/MediaPlayer/VideoJS/components/js/VideoJSProgress.js
+++ b/src/components/MediaPlayer/VideoJS/components/js/VideoJSProgress.js
@@ -117,7 +117,7 @@ class VideoJSProgress extends vjsComponent {
     // Some items, particularly in playlists, were not having `player.ended()` properly
     // set by the 'ended' event. Providing a fallback check that the player is already
     // paused prevents undesirable behavior from excess state changes after play ending.
-    if (curTime >= end && !player.paused()) {
+    if (curTime >= end && player && !player.paused()) {
       if (nextItems.length == 0) options.nextItemClicked(0, targets[0].start);
       player.pause();
       player.trigger('ended');


### PR DESCRIPTION
Fixes in the PR:
- Auto advance not working when the first Canvas in the Manifest is empty
- Video.js instance crashing when switching between canvases due to the `player.paused()` check referring to a null instance for a fraction of a second