### PR TITLE
Use alternate CSS properties to set the Canvas message height

### DIFF
--- a/src/components/MediaPlayer/MediaPlayer.scss
+++ b/src/components/MediaPlayer/MediaPlayer.scss
@@ -3,19 +3,43 @@
 .ramp--no-media-message {
   aspect-ratio: 16/9;
   background-color: $primaryDarkest;
-  width: 80%;
+  width: 100%;
   margin: auto;
 
+  /*
+    This handles the height of the message display div when aspect-ratio CSS 
+    property is not supported. Specific to iOS versions < 14.
+  */
+  @supports not (aspect-ratio: 16 / 9) {
+    height: 40vh;
+
+    @media screen and (orientation: landscape) {
+      height: 70vh;
+    }
+    @media only screen and (max-device-width: 480px) {
+      height: 25vh;
+    }
+
+    @media screen and (max-device-width: 480px) and (orientation: landscape) {
+      height: 100vh;
+    }
+  }
+
   .message-display {
-    transform: translate(60%, 80%);
-    position: absolute;
-    margin: 0;
+    margin: auto;
     color: white;
-    width: 25%;
+    // Place the message in the center both vertically and horizontally in the div
+    padding: 20% 30%;
     z-index: 50;
+    font-size: medium;
 
     a {
       color: $primaryGreen;
+    }
+
+    // Override vertical and horizontal spacing for smaller devices
+    @media only screen and (max-device-width: 480px) {
+      padding: 20% 25%;
     }
   }
 


### PR DESCRIPTION
In iOS versions < 14 `aspect-ratio` CSS property is not supported, and this caused the placeholder canvas message to not to display in Safari browsers.

Related issue: https://github.com/samvera-labs/ramp/issues/347