### PR TITLE
Prevent iOS rejected promise from raising error boundary

### DIFF
--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -251,6 +251,16 @@ function VideoJSPlayer({
         isEnded ? player.currentTime(0) : player.currentTime(currentTime);
 
         if (isEnded || isPlaying) {
+          /*
+            iOS devices lockdown the ability for unmuted audio and video media to autoplay.
+            They accomplish this by capturing any programmatic play events and returning
+            a rejected Promise. In certain versions of iOS, this rejected promise would
+            cause a runtime error within Ramp. This error would cause the error boundary
+            handling to trigger, forcing a user to reload the player/page. By silently 
+            catching the rejected Promise we are able to provide a more seamless user
+            experience, where the user can manually play the media or change to a different
+            section.
+           */
           var promise = player.play();
 
           if (promise !== undefined) {

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -251,7 +251,15 @@ function VideoJSPlayer({
         isEnded ? player.currentTime(0) : player.currentTime(currentTime);
 
         if (isEnded || isPlaying) {
-          player.play();
+          var promise = player.play();
+
+          if (promise !== undefined) {
+            promise.then(_ => {
+              // Autoplay
+            }).catch(error => {
+              // Prevent error from triggering error boundary
+            });
+          }
         }
 
         // Reset isEnded flag


### PR DESCRIPTION
In investigation for #422 I was unable to find a way to force autoplay of all items because iOS locks down that functionality as tight as they can (I am unsure why autoplay of videos works on some devices, probably something to do with them using the native player). However, I did find that certain versions of iOS triggered a runtime error within Ramp by the method of how they prevent/cancel the play event. This error catch should prevent that error from triggering the error boundary and allow users to interact regularly with the Ramp components.