### PR TITLE
Fix Video.js custom components crashing when initializing

### DIFF
--- a/src/components/MediaPlayer/VideoJS/components/js/VideoJSProgress.js
+++ b/src/components/MediaPlayer/VideoJS/components/js/VideoJSProgress.js
@@ -104,9 +104,14 @@ class VideoJSProgress extends vjsComponent {
    * @param {Number} curTime current time of the player
    */
   handleTimeUpdate(curTime) {
-    const { player, times, options } = this;
+    const { player, times, options, el_ } = this;
     const { targets, srcIndex } = options;
     const { start, end } = times;
+
+    // Avoid null player instance when Video.js is getting initialized
+    if (!el_) {
+      return;
+    }
 
     const nextItems = targets.filter((_, index) => index > srcIndex);
 

--- a/src/components/MediaPlayer/VideoJS/components/js/VideoJSTrackScrubber.js
+++ b/src/components/MediaPlayer/VideoJS/components/js/VideoJSTrackScrubber.js
@@ -25,10 +25,11 @@ class VideoJSTrackScrubber extends vjsComponent {
     this.options = options;
     this.player = player;
 
-    /* When player is ready and the trackScrubber element is initialized,
-    call method to mount React component.
+    /* 
+      When player is fully built and the trackScrubber element is initialized,
+      call method to mount React component.
     */
-    if (this.options.trackScrubberRef.current) {
+    if (this.options.trackScrubberRef.current && this.el_) {
       player.ready(() => {
         this.mount();
       });


### PR DESCRIPTION
Fix for Video.js custom components crashing sometimes when initializing the Video.js instance with Canvas switching.