### PR TITLE
Fix multiple captions being selected on initial load

### DIFF
--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -297,14 +297,17 @@ function VideoJSPlayer({
             }
           });
         }
-
-        // Turn captions on indicator via CSS on first load, when captions are ON by default
-        player.textTracks().tracks_?.map((t) => {
-          if (t.mode == 'showing') {
+        // Turn first caption/subtitle ON and turn captions ON indicator via CSS on first load
+        if (textTracks.tracks_?.length > 0) {
+          let firstSubCap = textTracks.tracks_.filter(
+            t => t.kind === 'subtitles' || t.kind === 'captions'
+          );
+          if (firstSubCap?.length > 0) {
+            firstSubCap[0].mode = 'showing';
             handleCaptionChange(true);
-            return;
           }
-        });
+        }
+
         // Add/remove CSS to indicate captions/subtitles is turned on
         textTracks.on('change', () => {
           let trackModes = [];
@@ -452,19 +455,22 @@ function VideoJSPlayer({
   };
 
   /**
-   * Add class to icon to indicate captions are on/off in player toolbar
+   * Add CSS class to icon to indicate captions are on/off in player control bar
    * @param {Boolean} subsOn flag to indicate captions are on/off
    */
   const handleCaptionChange = (subsOn) => {
-    /* For audio instances Video.js is setup to not to build the CC button in Ramp's player
-      control bar. But when captions are specified in the HLS manifest Video.js' streaming handlers
-      setup captions, causing this to crash since the CC button is not present in the control bar.
+    /* 
+      For audio instances Video.js is setup to not to build the CC button 
+      in Ramp's player control bar.
     */
-    if (!player.controlBar.subsCapsButton) return;
+    if (!player.controlBar.subsCapsButton
+      || !player.controlBar.subsCapsButton?.children_) {
+      return;
+    }
     if (subsOn) {
-      player.controlBar.subsCapsButton.addClass('captions-on');
+      player.controlBar.subsCapsButton.children_[0].addClass('captions-on');
     } else {
-      player.controlBar.subsCapsButton.removeClass('captions-on');
+      player.controlBar.subsCapsButton.children_[0].removeClass('captions-on');
     }
   };
   /**
@@ -641,30 +647,6 @@ function VideoJSPlayer({
   } else {
     videoClass = "video-js vjs-big-play-centered";
   };
-  const buildTrack = (t, index) => {
-    if (index == 0) {
-      return (
-        <track
-          key={t.key}
-          src={t.src}
-          kind={t.kind}
-          label={t.label}
-          srcLang={t.srclang}
-          default
-        />
-      );
-    } else {
-      return (
-        <track
-          key={t.key}
-          src={t.src}
-          kind={t.kind}
-          label={t.label}
-          srcLang={t.srclang}
-        />
-      );
-    }
-  };
 
   return (
     <React.Fragment>
@@ -686,7 +668,6 @@ function VideoJSPlayer({
                   kind={t.kind}
                   label={t.label}
                   srcLang={t.srclang}
-                  default={index === 0 ? true : false}
                 />
               )
             )}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -34,10 +34,6 @@
   }
 }
 
-.vjs-subs-caps-button .vjs-menu {
-  margin-bottom: 1.0em !important;
-}
-
 .video-js .vjs-control-bar {
   /* Audio: Make the controlbar visible by default */
   display: -webkit-box;
@@ -132,7 +128,7 @@ video/poster area the controls are displayed correctly. */
 
 /* captions button selection */
 .captions-on {
-  border-bottom: 0.45rem ridge $primaryGreen;
+  border-bottom: 0.45rem ridge $primaryGreen !important;
 }
 
 /* captions font for android and tablet fullscreen */
@@ -145,7 +141,7 @@ video/poster area the controls are displayed correctly. */
       font: 0px sans-serif !important;
     }
 
-    .vjs-text-track-cue > div {
+    .vjs-text-track-cue>div {
       font: 22px sans-serif;
     }
   }
@@ -158,7 +154,7 @@ video/poster area the controls are displayed correctly. */
       font: 0px sans-serif !important;
     }
 
-    .vjs-text-track-cue > div {
+    .vjs-text-track-cue>div {
       font: 32px sans-serif;
     }
   }


### PR DESCRIPTION
Related issue: #452 

On initial load programmatically select the first available caption only one caption is shown as selected in the captions menu;
<img width="951" alt="Screenshot 2024-03-18 at 12 36 59 PM" src="https://github.com/samvera-labs/ramp/assets/1331659/aaf818ba-9d86-4a73-9cd6-49ad2d136570">

Additional CSS fix to captions icon: fixed captions menu shifting down when captions are turned off;

Before:
<img width="762" alt="Screenshot 2024-03-18 at 12 41 02 PM" src="https://github.com/samvera-labs/ramp/assets/1331659/f4320a87-17e6-43a5-ae7d-dd4a2aa4d151">

After:
<img width="841" alt="Screenshot 2024-03-18 at 12 41 26 PM" src="https://github.com/samvera-labs/ramp/assets/1331659/bbf193dc-1b5d-479b-a846-a280fcbd5066">

