### PR TITLE
Prevent structure items getting highlighted for inaccessible items

### DIFF
--- a/src/components/StructuredNavigation/NavUtils/ListItem.js
+++ b/src/components/StructuredNavigation/NavUtils/ListItem.js
@@ -136,7 +136,7 @@ const ListItem = ({
         ref={liRef}
         className={
           `ramp--structured-nav__list-item
-          ${((currentNavItem?.id === itemIdRef.current) && (isPlaylist || !isCanvas))
+          ${(itemIdRef.current != undefined && (currentNavItem?.id === itemIdRef.current) && (isPlaylist || !isCanvas))
             ? ' active'
             : ''
           }`


### PR DESCRIPTION
This PR fix a regression from the work done in https://github.com/samvera-labs/ramp/pull/447.
Regression: for inaccessible items all structure items are getting highlighted since there are not active items. Because of this, the check for setting active items in the styling was inaccurately evaluating the condition to be true and highlighting all the structure items as active when none of them are.

Before: 
![Screenshot 2024-03-22 at 11 18 06 AM](https://github.com/samvera-labs/ramp/assets/1331659/d250a4de-e872-4679-86d3-7ad393a0e4b1)

After:
![Screenshot 2024-03-22 at 11 17 37 AM](https://github.com/samvera-labs/ramp/assets/1331659/32493eac-44d0-44dd-b3d4-bd5698b3b2e2)
