### PR TITLE
Adjust marker display on UI when end > canvas duration

### DIFF
--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -405,10 +405,12 @@ function VideoJSPlayer({
           type: 'setTimeFragment',
         });
         if (start != end) {
+          // Set the end to canvas duration if it's greater for marker rendering
+          let markerEnd = end > canvasDuration ? canvasDuration : end;
           player.markers.add([
             {
               time: start,
-              duration: end - start,
+              duration: markerEnd - start,
               text: currentNavItem.label,
             },
           ]);


### PR DESCRIPTION
Before:
![Screenshot 2024-04-03 at 10 05 29 AM](https://github.com/samvera-labs/ramp/assets/1331659/902e380b-8646-4f0d-b93b-10a7fa1e5ed4)

After:
![Screenshot 2024-04-03 at 10 05 04 AM](https://github.com/samvera-labs/ramp/assets/1331659/f267a7c8-8f1f-44a8-b364-dd6c023790ae)

This doesn't change the behavior but the appearance of the marker on the time rail for structure timespans that exceed the Canvas duration.
Related issue: #458
