### PR TITLE
Only display rendering files in the supplemental files component

### DIFF
--- a/src/components/SupplementalFiles/SupplementalFiles.md
+++ b/src/components/SupplementalFiles/SupplementalFiles.md
@@ -1,4 +1,4 @@
-SupplementalFiles component reads from `rendering` property and `supplementing` annotations in the Manifest. This component reads manifest data from central state management provided by Contexts. Thus it should be wrapped by context providers using `IIIFPlayer` which is the component in Ramp providing these out of the box.
+SupplementalFiles component reads from `rendering` property both at the Manifest level and Canvas level and list the files on the page with a downloadable link. This component reads data from the central state management provided by ReactJS Contexts. Thus it should be wrapped by context providers using `IIIFPlayer` which is the component in Ramp providing these out of the box.
 
 `SupplementalFiles` component allows the following props;
 - `itemHeading`: accepts a String value, which has a default value of '`Item files`' and is _not required_. This allows to customize the title for the Manifest level file list in the component.

--- a/src/services/iiif-parser.js
+++ b/src/services/iiif-parser.js
@@ -465,45 +465,6 @@ export function getRenderingFiles(manifest) {
   }
 }
 
-export function getSupplementingAnnotations(manifest) {
-  let canvasFiles = [];
-  try {
-    let canvases = parseSequences(manifest)[0]
-      .getCanvases();
-
-    if (canvases != undefined && canvases != null) {
-      canvases.map((canvas, index) => {
-        let files = [];
-        let annotationJSON = canvas.__jsonld["annotations"];
-        let annotations = [];
-        if (annotationJSON?.length) {
-          const annotationPage = annotationJSON[0];
-          if (annotationPage && annotationPage.items != undefined) {
-            annotations = annotationPage.items
-              .filter(
-                annotation => annotation.motivation == "supplementing" && annotation.body.id
-              );
-          }
-        }
-
-        annotations.map((anno) => {
-          const r = anno.body;
-          const file = buildFileInfo(r.format, r.label, r.id);
-          files.push(file);
-        });
-
-        // Use label of canvas or fallback to canvas id
-        let canvasLabel = canvas.getLabel().getValue() || "Section " + (index + 1);
-        canvasFiles.push({ label: getLabelValue(canvasLabel), files: files });
-      });
-
-    }
-    return canvasFiles;
-  } catch (error) {
-    throw error;
-  }
-}
-
 /**
  * @param {Object} manifest
  * @param {Boolean} readCanvasMetadata read metadata from Canvas level

--- a/src/services/iiif-parser.test.js
+++ b/src/services/iiif-parser.test.js
@@ -6,7 +6,6 @@ import singleSrcManifest from '@TestData/transcript-multiple-canvas';
 import autoAdvanceManifest from '@TestData/multiple-canvas-auto-advance';
 import playlistManifest from '@TestData/playlist';
 import emptyManifest from '@TestData/empty-manifest';
-import audiAnnotateManifest from '@TestData/audiannotate-test';
 import * as iiifParser from './iiif-parser';
 import * as util from './utility-helpers';
 
@@ -419,8 +418,8 @@ describe('iiif-parser', () => {
     it('with `rendering` prop only at manifest level', () => {
       const files = iiifParser.getRenderingFiles(lunchroomManifest, 0);
       expect(files.manifest.length).toBe(1);
-      expect(files.manifest[0].label).toEqual('Transcript file (.vtt)');
-      expect(files.manifest[0].filename).toEqual('Transcript file');
+      expect(files.manifest[0].label).toEqual('Transcript rendering file (.vtt)');
+      expect(files.manifest[0].filename).toEqual('Transcript rendering file');
     });
 
     it('with `rendering` prop only at canvas level', () => {
@@ -442,37 +441,6 @@ describe('iiif-parser', () => {
       expect(files.canvas[0].files.length).toBe(1);
       expect(files.canvas[0].files[0].label).toEqual('Poster image (.jpeg)');
       expect(files.canvas[0].files[0].filename).toEqual('Poster image');
-    });
-  });
-
-  describe('getSupplementingAnnotations()', () => {
-    it('with `TextualBody` supplementing annotations', () => {
-      const annotations = iiifParser.getSupplementingAnnotations(manifest);
-      expect(annotations.length).toBe(2);
-      expect(annotations[0].label).toBe('Section 1');
-      expect(annotations[0].files.length).toBe(0);
-      expect(annotations[1].label).toBe('Section 2');
-      expect(annotations[1].files.length).toBe(0);
-    });
-
-    it('with supplementing annotations', () => {
-      const annotations = iiifParser.getSupplementingAnnotations(lunchroomManifest);
-      expect(annotations.length).toBe(2);
-      expect(annotations[0].label).toBe('Lunchroom Manners');
-      expect(annotations[0].files.length).toBe(1);
-      expect(annotations[0].files[0].label).toEqual('Captions in WebVTT format (.vtt)');
-      expect(annotations[0].files[0].filename).toEqual('Captions in WebVTT format');
-      expect(annotations[1].label).toBe('Section 2');
-      expect(annotations[1].files.length).toBe(2);
-    });
-
-    it('without supplementing annotations', () => {
-      const annotations = iiifParser.getSupplementingAnnotations(audiAnnotateManifest);
-      expect(annotations.length).toBe(2);
-      expect(annotations[0].label).toBe('Section 1');
-      expect(annotations[0].files.length).toBe(0);
-      expect(annotations[1].label).toBe('Section 2');
-      expect(annotations[1].files.length).toBe(0);
     });
   });
 

--- a/src/test_data/lunchroom-manners.js
+++ b/src/test_data/lunchroom-manners.js
@@ -54,7 +54,7 @@ export default {
     {
       id: 'https://example.com/lunchroom_manners/transcript.vtt',
       type: 'Text',
-      label: { en: ['Transcript file'] },
+      label: { en: ['Transcript rendering file'] },
       format: 'text/vtt',
     }
   ],
@@ -169,7 +169,15 @@ export default {
             }
           ]
         },
-      ]
+      ],
+      rendering: [
+        {
+          id: 'https://example.com/lunchroom_manners/transcript.vtt',
+          type: 'Text',
+          label: { en: ['Canvas - Supplement file'] },
+          format: 'text/vtt',
+        }
+      ],
     },
     {
       type: 'Canvas',

--- a/src/test_data/transcript-multiple-canvas.js
+++ b/src/test_data/transcript-multiple-canvas.js
@@ -5,6 +5,14 @@ export default {
   label: {
     en: ['Manifest with json transcript at canvas level with rendering'],
   },
+  rendering: [
+    {
+      id: 'https://example.com/lunchroom_manners/transcript.vtt',
+      type: 'Text',
+      label: { en: ['Manifest rendering file'] },
+      format: 'text/vtt',
+    }
+  ],
   items: [
     {
       id: 'https://example.com/sample/canvas/1',


### PR DESCRIPTION
> **Need` to test with a sample manifest from Avalon once the manifest generation work is deployed to `avalon-dev`** 

✅ 

In the Ramp demo site sample;

Before:
![Screenshot 2024-04-04 at 3 01 42 PM](https://github.com/samvera-labs/ramp/assets/1331659/0db8d61c-00a3-47c7-b8c3-7a2abeabf4d7)

After:
![Screenshot 2024-04-04 at 3 02 04 PM](https://github.com/samvera-labs/ramp/assets/1331659/eb74e074-7c49-411a-b4a1-9ee35ee2a95a)

Related issue: #467 