### PR TITLE
Display a message for empty manifests without crashing

### DIFF
--- a/src/components/IIIFPlayer/IIIFPlayer.js
+++ b/src/components/IIIFPlayer/IIIFPlayer.js
@@ -10,6 +10,7 @@ export default function IIIFPlayer({
   manifestUrl,
   manifest,
   customErrorMessage,
+  emptyManifestMessage,
   startCanvasId,
   startCanvasTime,
   children
@@ -25,6 +26,7 @@ export default function IIIFPlayer({
             manifestUrl={manifestUrl}
             manifest={manifest}
             customErrorMessage={customErrorMessage}
+            emptyManifestMessage={emptyManifestMessage}
             startCanvasId={startCanvasId}
             startCanvasTime={startCanvasTime}>
             {children}
@@ -40,6 +42,7 @@ IIIFPlayer.propTypes = {
   manifestUrl: PropTypes.string,
   manifest: PropTypes.object,
   customErrorMessage: PropTypes.string,
+  emptyManifestMessage: PropTypes.string,
   startCanvasId: PropTypes.string,
   startCanvasTime: PropTypes.number,
 };

--- a/src/components/IIIFPlayer/IIIFPlayer.md
+++ b/src/components/IIIFPlayer/IIIFPlayer.md
@@ -6,7 +6,8 @@ IIIFPlayer component, provides a wrapper consisting of the Context providers con
 
 ** __Either `manifestUrl` or `manifest` is REQUIRED. If both props are given then `manifest` takes *precedence* over `manifestUrl`__
 
-- `customErrorMessage`: accepts a messagge to display to the user in the unlikely event of the component crashing, this has a default error message and it is _not required_. The message can include HTML markup.
+- `customErrorMessage`: accepts a messagge to display to the user in the unlikely event of the component crashing, this has a default error message and it is _not required_. The message can include HTML markup. This prop has default value for a generic message and it is _not required_ to initialize the component.
+- `emptyManifestMessage`: accepts a message text to display to the user when the given Manifest has no canvases in it yet. An example situation: a playlist manifest without any items added to it yet. This prop has default value for a generic message and it is _not required_ to initialize the component.
 - `startCanvasId`: accepts a valid Canvas ID that exists within the given Manifest, this can specify the Canvas to show in Ramp on initialization. This can be mapped to the [`start` property](https://iiif.io/api/presentation/3.0/#start) in a IIIF Manifest.
 - `startCanvasTime`: accepts a valid number for a time in seconds to start playback  in the Canvas shown in Ramp on initialization.
 

--- a/src/components/IIIFPlayer/IIIFPlayer.md
+++ b/src/components/IIIFPlayer/IIIFPlayer.md
@@ -6,7 +6,7 @@ IIIFPlayer component, provides a wrapper consisting of the Context providers con
 
 ** __Either `manifestUrl` or `manifest` is REQUIRED. If both props are given then `manifest` takes *precedence* over `manifestUrl`__
 
-- `customErrorMessage`: accepts a messagge to display to the user in the unlikely event of the component crashing, this has a default error message and it is _not required_. The message can include HTML markup. This prop has default value for a generic message and it is _not required_ to initialize the component.
+- `customErrorMessage`: accepts a message to display to the user in the unlikely event of the component crashing. The message can include HTML markup. This prop has default value for a generic message and it is _not required_ to initialize the component.
 - `emptyManifestMessage`: accepts a message text to display to the user when the given Manifest has no canvases in it yet. An example situation: a playlist manifest without any items added to it yet. This prop has default value for a generic message and it is _not required_ to initialize the component.
 - `startCanvasId`: accepts a valid Canvas ID that exists within the given Manifest, this can specify the Canvas to show in Ramp on initialization. This can be mapped to the [`start` property](https://iiif.io/api/presentation/3.0/#start) in a IIIF Manifest.
 - `startCanvasTime`: accepts a valid number for a time in seconds to start playback  in the Canvas shown in Ramp on initialization.

--- a/src/components/IIIFPlayerWrapper.js
+++ b/src/components/IIIFPlayerWrapper.js
@@ -4,12 +4,13 @@ import { usePlayerDispatch } from '../context/player-context';
 import PropTypes from 'prop-types';
 import { getCustomStart, parseAutoAdvance } from '@Services/iiif-parser';
 import { getAnnotationService, getIsPlaylist } from '@Services/playlist-parser';
-import { setAppErrorMessage, GENERIC_ERROR_MESSAGE } from '@Services/utility-helpers';
+import { setAppErrorMessage, setAppEmptyManifestMessage } from '@Services/utility-helpers';
 import { useErrorBoundary } from "react-error-boundary";
 
 export default function IIIFPlayerWrapper({
   manifestUrl,
   customErrorMessage,
+  emptyManifestMessage,
   startCanvasId,
   startCanvasTime,
   children,
@@ -23,6 +24,8 @@ export default function IIIFPlayerWrapper({
 
   React.useEffect(() => {
     setAppErrorMessage(customErrorMessage);
+    setAppEmptyManifestMessage(emptyManifestMessage);
+
     if (manifest) {
       manifestDispatch({ manifest: manifest, type: 'updateManifest' });
     } else {
@@ -84,6 +87,7 @@ export default function IIIFPlayerWrapper({
 IIIFPlayerWrapper.propTypes = {
   manifest: PropTypes.object,
   customErrorMessage: PropTypes.string,
+  emptyManifestMessage: PropTypes.string,
   manifestUrl: PropTypes.string,
   startCanvasId: PropTypes.string,
   startCanvasTime: PropTypes.number,

--- a/src/components/MediaPlayer/MediaPlayer.js
+++ b/src/components/MediaPlayer/MediaPlayer.js
@@ -33,7 +33,7 @@ const MediaPlayer = ({ enableFileDownload = false, enablePIP = false }) => {
 
   const [ready, setReady] = React.useState(false);
   const [cIndex, setCIndex] = React.useState(canvasIndex);
-  const [isMultiSource, setIsMultiSource] = React.useState();
+  const [isMultiSourced, setIsMultiSourced] = React.useState();
   const [isMultiCanvased, setIsMultiCanvased] = React.useState(false);
   const [lastCanvasIndex, setLastCanvasIndex] = React.useState(0);
   const [isVideo, setIsVideo] = React.useState();
@@ -139,10 +139,6 @@ const MediaPlayer = ({ enableFileDownload = false, enablePIP = false }) => {
       setIsVideo(mediaType === 'video');
       manifestDispatch({ canvasTargets, type: 'canvasTargets' });
       manifestDispatch({
-        canvasDuration: canvas.duration,
-        type: 'canvasDuration',
-      });
-      manifestDispatch({
         isMultiSource,
         type: 'hasMultipleItems',
       });
@@ -161,8 +157,22 @@ const MediaPlayer = ({ enableFileDownload = false, enablePIP = false }) => {
         sources,
         tracks,
       });
-      updatePlayerSrcDetails(canvas.duration, sources, canvasId, isMultiSource);
-      setIsMultiSource(isMultiSource);
+
+      // For empty manifests, canvas property is null.
+      if (canvas) {
+        manifestDispatch({
+          canvasDuration: canvas.duration,
+          type: 'canvasDuration',
+        });
+        updatePlayerSrcDetails(canvas.duration, sources, canvasId, isMultiSource);
+      } else {
+        manifestDispatch({ type: 'setCanvasIsEmpty', isEmpty: true });
+        setPlayerConfig({
+          ...playerConfig,
+          error: error
+        });
+      }
+      setIsMultiSourced(isMultiSource || false);
 
       setCIndex(canvasId);
       error ? setReady(false) : setReady(true);
@@ -337,7 +347,7 @@ const MediaPlayer = ({ enableFileDownload = false, enablePIP = false }) => {
       // disable fullscreen toggle button for audio
       fullscreenToggle: !isVideo ? false : true,
     },
-    sources: isMultiSource
+    sources: isMultiSourced
       ? playerConfig.sources[srcIndex]
       : playerConfig.sources,
     // Enable native text track functionality in iPhones and iPads

--- a/src/services/iiif-parser.js
+++ b/src/services/iiif-parser.js
@@ -2,6 +2,7 @@ import { parseManifest, PropertyValue } from 'manifesto.js';
 import mimeDb from 'mime-db';
 import sanitizeHtml from 'sanitize-html';
 import {
+  GENERIC_EMPTY_MANIFEST_MESSAGE,
   GENERIC_ERROR_MESSAGE,
   checkSrcRange,
   getAnnotations,
@@ -142,7 +143,25 @@ export function getMediaInfo({ manifest, canvasIndex, srcIndex = 0 }) {
 
   // return empty object when canvasIndex is undefined
   if (canvasIndex === undefined || canvasIndex < 0) {
-    return { error: 'Error fetching content' };
+    return {
+      error: 'Error fetching content',
+      canvas: null,
+      sources: [],
+      tracks: [],
+      canvasTargets: []
+    };
+  }
+
+  // return an error when the given Manifest doesn't have any Canvas(es)
+  const canvases = canvasesInManifest(manifest);
+  if (canvases?.length == 0) {
+    return {
+      sources: [],
+      tracks,
+      error: GENERIC_EMPTY_MANIFEST_MESSAGE,
+      canvas: null,
+      canvasTargets: [],
+    };
   }
 
   // Get the canvas with the given canvasIndex

--- a/src/services/iiif-parser.test.js
+++ b/src/services/iiif-parser.test.js
@@ -200,7 +200,28 @@ describe('iiif-parser', () => {
           manifest: lunchroomManifest,
           canvasIndex: -1,
         })
-      ).toEqual({ error: 'Error fetching content' });
+      ).toEqual({
+        error: 'Error fetching content',
+        canvas: null,
+        sources: [],
+        tracks: [],
+        canvasTargets: []
+      });
+    });
+
+    it('returns an error when given Manifest has no items (canvases)', () => {
+      expect(
+        iiifParser.getMediaInfo({
+          manifest: emptyManifest,
+          canvasIndex: 0
+        })
+      ).toEqual({
+        sources: [],
+        tracks: [],
+        error: 'No media resource(s). Please check your Manifest.',
+        canvas: null,
+        canvasTargets: [],
+      });
     });
 
     it('returns an error when body `prop` is empty', () => {

--- a/src/services/utility-helpers.js
+++ b/src/services/utility-helpers.js
@@ -20,6 +20,9 @@ const S_ANNOTATION_TYPE = { transcript: 1, caption: 2, both: 3 };
 const DEFAULT_ERROR_MESSAGE = "Error encountered. Please check your Manifest.";
 export let GENERIC_ERROR_MESSAGE = DEFAULT_ERROR_MESSAGE;
 
+const DEFAULT_EMPTY_MANIFEST_MESSAGE = "No media resource(s). Please check your Manifest.";
+export let GENERIC_EMPTY_MANIFEST_MESSAGE = DEFAULT_EMPTY_MANIFEST_MESSAGE;
+
 // Timer for displaying placeholderCanvas text when a Canvas is empty
 const DEFAULT_TIMEOUT = 10000;
 export let CANVAS_MESSAGE_TIMEOUT = DEFAULT_TIMEOUT;
@@ -37,12 +40,23 @@ export function setCanvasMessageTimeout(timeout) {
 /**
  * Sets the generic error message in the ErrorBoundary when the
  * components fail with critical error. This defaults to the given
- * vaule when a custom message is not specified in the `customErrorMessage`
+ * value when a custom message is not specified in the `customErrorMessage`
  * prop of the IIIFPlayer component
  * @param {String} message custom error message from props
  */
 export function setAppErrorMessage(message) {
   GENERIC_ERROR_MESSAGE = message || DEFAULT_ERROR_MESSAGE;
+}
+
+/**
+ * Sets a generic error message when the given IIIF Manifest has not
+ * items in it yet. Example scenario: empty playlist. This defaults to the given
+ * value when a custom message is not specified in the `emptyManifestMessage`
+ * prop of the IIIFPlayer component
+ * @param {String} message custom error message from props
+ */
+export function setAppEmptyManifestMessage(message) {
+  GENERIC_EMPTY_MANIFEST_MESSAGE = message || DEFAULT_EMPTY_MANIFEST_MESSAGE;
 }
 
 export function parseSequences(manifest) {


### PR DESCRIPTION
Related issue: https://github.com/samvera-labs/ramp/issues/457

This PR introduces a new prop called `emptyManifestMessage` for the `IIIFPlayer` component to set a custom message to display when a given IIIF Manifest has no resources (canvases) in it.

An empty playlist manifest will be displayed as follows:

in Ramp with default value for `emptyManifestMessage` prop;

![Screenshot 2024-04-05 at 1 30 42 PM](https://github.com/samvera-labs/ramp/assets/1331659/6d4955e3-7e18-421c-9ad4-9f314c4aaffe)

in Avalon with `emptyManifestMessage='This playlist currently has no playable items.'`;

![Screenshot 2024-04-05 at 1 31 56 PM](https://github.com/samvera-labs/ramp/assets/1331659/02afe550-a559-4a72-ac71-a3a96112a2ce)
