### PR TITLE
Vtt parse fix

### DIFF
--- a/public/lunchroom_manners/lunchroom_manners.vtt
+++ b/public/lunchroom_manners/lunchroom_manners.vtt
@@ -1,6 +1,6 @@
 WEBVTT
 
-REGION
+region
 id:bill
 width:40%
 lines:3
@@ -8,16 +8,27 @@ regionanchor:100%,100%
 viewportanchor:90%,90%
 scroll:up
 
+STYLE
+::cue {
+  background-image: linear-gradient(to bottom, dimgray, lightgray);
+  color: papayawhip;
+}
+/* Style blocks cannot use blank lines nor "dash dash greater than" */
+
+NOTE
+This file was machine-generated.
+The cues and timing maybe not 100% accurate.
+
 1
 00:00:01.200 --> 00:00:21.000 region:fred align:left
 [music]
 
+NOTE End of music, and starting dialog
+
 2
 00:00:22.200 --> 00:00:26.600 region:bill align:right
-Just before lunch one day, a puppet show 
+<em>Just</em> before lunch one day, a puppet show 
 was put on at school.
-
-NOTE I’m not sure the timing is right on the following cue.
 
 3
 00:00:26.700 --> 00:00:31.500 region:fred align:left

--- a/public/lunchroom_manners/lunchroom_manners.vtt
+++ b/public/lunchroom_manners/lunchroom_manners.vtt
@@ -1,16 +1,26 @@
 WEBVTT
 
+REGION
+id:bill
+width:40%
+lines:3
+regionanchor:100%,100%
+viewportanchor:90%,90%
+scroll:up
+
 1
-00:00:01.200 --> 00:00:21.000
+00:00:01.200 --> 00:00:21.000 region:fred align:left
 [music]
 
 2
-00:00:22.200 --> 00:00:26.600
+00:00:22.200 --> 00:00:26.600 region:bill align:right
 Just before lunch one day, a puppet show 
 was put on at school.
 
+NOTE I’m not sure the timing is right on the following cue.
+
 3
-00:00:26.700 --> 00:00:31.500
+00:00:26.700 --> 00:00:31.500 region:fred align:left
 It was called "Mister Bungle Goes to Lunch".
 
 4

--- a/src/components/Transcript/Transcript.scss
+++ b/src/components/Transcript/Transcript.scss
@@ -105,6 +105,7 @@ a.ramp--transcript_item {
 .ramp--transcript_machine_generated {
   flex-basis: 100%;
   margin: 0;
+  line-height: 1.5em;
 }
 
 .ramp--transcript_auto_scroll_check {

--- a/src/services/transcript-parser.js
+++ b/src/services/transcript-parser.js
@@ -736,8 +736,8 @@ function parseTimedTextLine({ times, line, tag }, isSRT) {
   switch (tag) {
     case TRANSCRIPT_CUE_TYPES.note:
       return {
-        begin: '00:00:00.000',
-        end: '00:00:00.000',
+        begin: 0,
+        end: 0,
         text: line,
         tag
       };

--- a/src/services/transcript-parser.test.js
+++ b/src/services/transcript-parser.test.js
@@ -360,26 +360,30 @@ describe('transcript-parser', () => {
       });
 
       const parsedData = [
-        { end: 21, begin: 1.2, text: '[music]' },
+        { end: 21, begin: 1.2, text: '[music]', tag: 'TIMED_CUE' },
         {
           end: 26.6,
           begin: 22.2,
           text: 'Just before lunch one day, a puppet show was put on at school.',
+          tag: 'TIMED_CUE'
         },
         {
           end: 31.5,
           begin: 26.7,
           text: 'It was called "Mister Bungle Goes to Lunch".',
+          tag: 'TIMED_CUE'
         },
         {
           end: 34.5,
           begin: 31.6,
           text: 'It was fun to watch.',
+          tag: 'TIMED_CUE'
         },
         {
           end: 41.3,
           begin: 36.1,
           text: "In the puppet show, Mr. Bungle came to the boys' room on his way to lunch.",
+          tag: 'TIMED_CUE'
         },
       ];
 
@@ -405,26 +409,30 @@ describe('transcript-parser', () => {
         });
 
         const parsedData = [
-          { end: 21, begin: 1.2, text: '[music]' },
+          { end: 21, begin: 1.2, text: '[music]', tag: 'TIMED_CUE' },
           {
             end: 26.6,
             begin: 22.2,
             text: 'Just before lunch one day, a puppet show was put on at school.',
+            tag: 'TIMED_CUE'
           },
           {
             end: 31.5,
             begin: 26.7,
             text: 'It was called "Mister Bungle Goes to Lunch".',
+            tag: 'TIMED_CUE'
           },
           {
             end: 34.5,
             begin: 31.6,
             text: 'It was fun to watch.',
+            tag: 'TIMED_CUE'
           },
           {
             end: 41.3,
             begin: 36.1,
             text: "In the puppet show, Mr. Bungle came to the boys' room on his way to lunch.",
+            tag: 'TIMED_CUE'
           },
         ];
 
@@ -449,26 +457,30 @@ describe('transcript-parser', () => {
         });
 
         const parsedData = [
-          { end: 21, begin: 1.2, text: '[music]' },
+          { end: 21, begin: 1.2, text: '[music]', tag: 'TIMED_CUE' },
           {
             end: 26.6,
             begin: 22.2,
             text: 'Just before lunch one day, a puppet show was put on at school.',
+            tag: 'TIMED_CUE'
           },
           {
             end: 31.5,
             begin: 26.7,
             text: 'It was called "Mister Bungle Goes to Lunch".',
+            tag: 'TIMED_CUE'
           },
           {
             end: 34.5,
             begin: 31.6,
             text: 'It was fun to watch.',
+            tag: 'TIMED_CUE'
           },
           {
             end: 41.3,
             begin: 36.1,
             text: "In the puppet show, Mr. Bungle came to the boys' room on his way to lunch.",
+            tag: 'TIMED_CUE'
           },
         ];
 
@@ -587,7 +599,7 @@ describe('transcript-parser', () => {
         test('as a linked resource', async () => {
           // mock fetch request
           const mockResponse =
-            'WEBVTT\r\n\r\n1\r\n00:00:01.200 --> 00:00:21.000\n[music]\n2\r\n00:00:22.200 --> 00:00:26.600\nJust before lunch one day, a puppet show \nwas put on at school.\n\r\n3\r\n00:00:26.700 --> 00:00:31.500\nIt was called "Mister Bungle Goes to Lunch".\n\r\n4\r\n00:00:31.600 --> 00:00:34.500\nIt was fun to watch.\r\n\r\n5\r\n00:00:36.100 --> 00:00:41.300\nIn the puppet show, Mr. Bungle came to the \nboys\' room on his way to lunch.\n';
+            'WEBVTT\r\n\r\n1\r\n00:00:01.200 --> 00:00:21.000\n[music]\n2\r\n00:00:22.200 --> 00:00:26.600\nJust before lunch one day, a puppet show \nwas put on at school.\n\r\n3\r\n00:00:26.700 --> 00:00:31.500\nIt was called "Mister Bungle Goes to Lunch".\n\r\n4\r\n00:00:31.600 --> 00:00:34.500\nIt was fun to watch.\n\r\n5\r\n00:00:36.100 --> 00:00:41.300\nIn the puppet show, Mr. Bungle came to the \nboys\' room on his way to lunch.\n';
           const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({
             text: jest.fn().mockResolvedValue(mockResponse),
           });
@@ -607,6 +619,7 @@ describe('transcript-parser', () => {
             text: '[music]',
             begin: 1.2,
             end: 21.0,
+            tag: 'TIMED_CUE'
           });
           expect(tUrl).toEqual('https://example.com/sample/subtitles.vtt');
           expect(tFileExt).toEqual('vtt');
@@ -626,6 +639,7 @@ describe('transcript-parser', () => {
             format: 'text/plain',
             begin: 22.2,
             end: 26.6,
+            tag: 'TIMED_CUE'
           });
           expect(tUrl).toEqual('https://example.com/transcript-annotation.json');
           expect(tFileExt).toEqual('json');
@@ -647,60 +661,133 @@ describe('transcript-parser', () => {
   });
 
   describe('parses WebVTT data', () => {
-    describe('when valid', () => {
-      test('with hh:mm:ss.ms format timestamps', () => {
-        // mock fetch request
-        const mockResponse =
-          'WEBVTT\r\n\r\n1\r\n00:00:01.200 --> 00:00:21.000\n[music]\n2\r\n00:00:22.200 --> 00:00:26.600\nJust before lunch one day, a puppet show \nwas put on at school.\n\r\n3\r\n00:00:26.700 --> 00:00:31.500\nIt was called "Mister Bungle Goes to Lunch".\n\r\n4\r\n00:00:31.600 --> 00:00:34.500\nIt was fun to watch.\r\n\r\n5\r\n00:00:36.100 --> 00:00:41.300\nIn the puppet show, Mr. Bungle came to the \nboys\' room on his way to lunch.\n';
+    describe('with valid', () => {
+      describe('timestamps in cues', () => {
+        test('with hh:mm:ss.ms format timestamps', () => {
+          // mock fetch request
+          const mockResponse =
+            'WEBVTT\r\n\r\n1\r\n00:00:01.200 --> 00:00:21.000\n[music]\n2\r\n00:00:22.200 --> 00:00:26.600\nJust before lunch one day, a puppet show \nwas put on at school.\n\r\n3\r\n00:00:26.700 --> 00:00:31.500\nIt was called "Mister Bungle Goes to Lunch".\n\r\n4\r\n00:00:31.600 --> 00:00:34.500\nIt was fun to watch.\r\n\r\n5\r\n00:00:36.100 --> 00:00:41.300\nIn the puppet show, Mr. Bungle came to the \nboys\' room on his way to lunch.\n';
 
-        const tData = transcriptParser.parseTimedText(mockResponse);
+          const { tData, tType } = transcriptParser.parseTimedText(mockResponse);
 
-        expect(tData).toHaveLength(5);
-        expect(tData[0]).toEqual({
-          text: '[music]',
-          begin: 1.2,
-          end: 21,
+          expect(tData).toHaveLength(5);
+          expect(tData[0]).toEqual({
+            text: '[music]',
+            begin: 1.2,
+            end: 21,
+            tag: 'TIMED_CUE'
+          });
+          expect(tData[4]).toEqual({
+            text: "In the puppet show, Mr. Bungle came to the boys' room on his way to lunch.",
+            begin: 36.1,
+            end: 41.3,
+            tag: 'TIMED_CUE'
+          });
+          expect(tType).toEqual(transcriptParser.TRANSCRIPT_TYPES.timedText);
         });
-        expect(tData[4]).toEqual({
-          text: "In the puppet show, Mr. Bungle came to the boys' room on his way to lunch.",
-          begin: 36.1,
-          end: 41.3,
+
+        test('with mm:ss.ms format timestamps', () => {
+          // mock fetch request
+          const mockResponse =
+            'WEBVTT\r\n\r\n1\r\n00:01.200 --> 00:21.000\n[music]\n2\r\n00:22.200 --> 00:26.600\nJust before lunch one day, a puppet show \nwas put on at school.\n\r\n3\r\n00:26.700 --> 00:31.500\nIt was called "Mister Bungle Goes to Lunch".\n\r\n4\r\n00:31.600 --> 00:34.500\nIt was fun to watch.\r\n\r\n5\r\n00:36.100 --> 00:41.300\nIn the puppet show, Mr. Bungle came to the \nboys\' room on his way to lunch.\n';
+
+          const { tData, tType } = transcriptParser.parseTimedText(mockResponse);
+
+          expect(tData).toHaveLength(5);
+          expect(tData[0]).toEqual({
+            text: '[music]',
+            begin: 1.2,
+            end: 21,
+            tag: 'TIMED_CUE'
+          });
+          expect(tData[4]).toEqual({
+            text: "In the puppet show, Mr. Bungle came to the boys' room on his way to lunch.",
+            begin: 36.1,
+            end: 41.3,
+            tag: 'TIMED_CUE'
+          });
+          expect(tType).toEqual(transcriptParser.TRANSCRIPT_TYPES.timedText);
         });
       });
 
-      test('with mm:ss.ms format timestamps', () => {
-        // mock fetch request
-        const mockResponse =
-          'WEBVTT\r\n\r\n1\r\n00:01.200 --> 00:21.000\n[music]\n2\r\n00:22.200 --> 00:26.600\nJust before lunch one day, a puppet show \nwas put on at school.\n\r\n3\r\n00:26.700 --> 00:31.500\nIt was called "Mister Bungle Goes to Lunch".\n\r\n4\r\n00:31.600 --> 00:34.500\nIt was fun to watch.\r\n\r\n5\r\n00:36.100 --> 00:41.300\nIn the puppet show, Mr. Bungle came to the \nboys\' room on his way to lunch.\n';
+      describe('text in the header block', () => {
+        test('with comment followed by NOTE keyword in the header', () => {
+          const mockResponse =
+            'WEBVTT\r\n\r\nNOTE\nThis is a webvtt file\n\n1\r\n00:00:01.200 --> 00:00:21.000\n[music]\n2\r\n00:00:22.200 --> 00:00:26.600\nJust before lunch one day, a puppet show \nwas put on at school.\n\r\n3\r\n00:00:26.700 --> 00:00:31.500\nIt was called "Mister Bungle Goes to Lunch".\n\r\n4\r\n00:00:31.600 --> 00:00:34.500\nIt was fun to watch.\r\n\r\n5\r\n00:00:36.100 --> 00:00:41.300\nIn the puppet show, Mr. Bungle came to the \nboys\' room on his way to lunch.\n';
 
-        const tData = transcriptParser.parseTimedText(mockResponse);
+          const { tData, tType } = transcriptParser.parseTimedText(mockResponse);
 
-        expect(tData).toHaveLength(5);
-        expect(tData[0]).toEqual({
-          text: '[music]',
-          begin: 1.2,
-          end: 21,
+          expect(tData).toHaveLength(6);
+          expect(tData[0]).toEqual({
+            tag: 'NOTE',
+            begin: '00:00:00.000',
+            end: '00:00:00.000',
+            text: 'NOTE<br />This is a webvtt file'
+          });
+          expect(tType).toEqual(transcriptParser.TRANSCRIPT_TYPES.timedText);
         });
-        expect(tData[4]).toEqual({
-          text: "In the puppet show, Mr. Bungle came to the boys' room on his way to lunch.",
-          begin: 36.1,
-          end: 41.3,
+
+        test('with header block for REGION', () => {
+          const mockResponse =
+            'WEBVTT\r\n\r\nregion\nid:bill\nwidth:40%\nlines:3\nregionanchor:100%,100%\nviewportanchor:90%,90%\nscroll:up\n\n1\r\n00:00:01.200 --> 00:00:21.000\n[music]\n2\r\n00:00:22.200 --> 00:00:26.600\nJust before lunch one day, a puppet show \nwas put on at school.\n\r\n3\r\n00:00:26.700 --> 00:00:31.500\nIt was called "Mister Bungle Goes to Lunch".\n\r\n4\r\n00:00:31.600 --> 00:00:34.500\nIt was fun to watch.\r\n\r\n5\r\n00:00:36.100 --> 00:00:41.300\nIn the puppet show, Mr. Bungle came to the \nboys\' room on his way to lunch.\n';
+
+          const { tData, tType } = transcriptParser.parseTimedText(mockResponse);
+
+          expect(tData).toHaveLength(5);
+          expect(tData[0]).toEqual({
+            text: '[music]',
+            begin: 1.2,
+            end: 21,
+            tag: 'TIMED_CUE'
+          });
+          expect(tType).toEqual(transcriptParser.TRANSCRIPT_TYPES.timedText);
+        });
+
+        test('with header block for STYLE', () => {
+          const mockResponse =
+            'WEBVTT\r\n\r\nSTYLE\n::cue {\nbackground-image: linear-gradient(to bottom, dimgray, lightgray);\ncolor: papayawhip;\n}\n/* Style blocks cannot use blank lines nor "dash dash greater than" */\n\n1\r\n00:00:01.200 --> 00:00:21.000\n[music]\n2\r\n00:00:22.200 --> 00:00:26.600\nJust before lunch one day, a puppet show \nwas put on at school.\n\r\n3\r\n00:00:26.700 --> 00:00:31.500\nIt was called "Mister Bungle Goes to Lunch".\n\r\n4\r\n00:00:31.600 --> 00:00:34.500\nIt was fun to watch.\r\n\r\n5\r\n00:00:36.100 --> 00:00:41.300\nIn the puppet show, Mr. Bungle came to the \nboys\' room on his way to lunch.\n';
+
+          const { tData, tType } = transcriptParser.parseTimedText(mockResponse);
+
+          expect(tData).toHaveLength(5);
+          expect(tData[0]).toEqual({
+            text: '[music]',
+            begin: 1.2,
+            end: 21,
+            tag: 'TIMED_CUE'
+          });
+          expect(tType).toEqual(transcriptParser.TRANSCRIPT_TYPES.timedText);
         });
       });
     });
 
-    describe('when invalid', () => {
-      test('without WEBVTT header', () => {
+    describe('with invalid file', () => {
+      test('without WEBVTT in the header', () => {
         // mock console.error
         console.error = jest.fn();
         const mockResponse =
           '1\r\n00:00:01.200 --> 00:00:21.000\n[music]\n2\r\n00:00:22.200 --> 00:00:26.600\nJust before lunch one day, a puppet show \nwas put on at school.\n\r\n3\r\n00:00:26.700 --> 00:00:31.500\nIt was called "Mister Bungle Goes to Lunch".\n\r\n4\r\n00:00:31.600 --> 00:00:34.500\nIt was fun to watch.\r\n\r\n5\r\n00:00:36.100 --> 00:00:41.300\nIn the puppet show, Mr. Bungle came to the \nboys\' room on his way to lunch.\n';
 
-        const tData = transcriptParser.parseTimedText(mockResponse);
+        const { tData, tType } = transcriptParser.parseTimedText(mockResponse);
 
         expect(tData).toHaveLength(0);
         expect(console.error).toHaveBeenCalledTimes(1);
         expect(console.error).toHaveBeenCalledWith('Invalid WebVTT file');
+        expect(tType).toEqual(transcriptParser.TRANSCRIPT_TYPES.invalidTimedText);
+      });
+
+      test('with random text in the header', () => {
+        // mock console.error
+        console.error = jest.fn();
+        const mockResponse =
+          'WEBVTT\r\n\r\nThis is a webvtt file1\r\n00:00:01.200 --> 00:00:21.000\n[music]\n2\r\n00:00:22.200 --> 00:00:26.600\nJust before lunch one day, a puppet show \nwas put on at school.\n\r\n3\r\n00:00:26.700 --> 00:00:31.500\nIt was called "Mister Bungle Goes to Lunch".\n\r\n4\r\n00:00:31.600 --> 00:00:34.500\nIt was fun to watch.\r\n\r\n5\r\n00:00:36.100 --> 00:00:41.300\nIn the puppet show, Mr. Bungle came to the \nboys\' room on his way to lunch.\n';
+
+        const { tData, tType } = transcriptParser.parseTimedText(mockResponse);
+
+        expect(tData).toHaveLength(0);
+        expect(console.error).toHaveBeenCalledTimes(1);
+        expect(console.error).toHaveBeenCalledWith('Invalid WebVTT file');
+        expect(tType).toEqual(transcriptParser.TRANSCRIPT_TYPES.invalidTimedText);
       });
 
       test('with incorrect timestamp', () => {
@@ -709,7 +796,7 @@ describe('transcript-parser', () => {
         const mockResponse =
           'WEBVTT\r\n\r\n1\r\n00:00:01.200 --> 00:00:.000\n[music]\n2\r\n00:00:22.200 --> 00:00:26.600\nJust before lunch one day, a puppet show \nwas put on at school.\n\r\n3\r\n00:00:26.700 --> 00:00:31.500\nIt was called "Mister Bungle Goes to Lunch".\n\r\n4\r\n00:00:31.600 --> 00:00:34.500\nIt was fun to watch.\r\n\r\n5\r\n00:00:36.100 --> 00:00:41.300\nIn the puppet show, Mr. Bungle came to the \nboys\' room on his way to lunch.\n';
 
-        const tData = transcriptParser.parseTimedText(mockResponse);
+        const { tData, tType } = transcriptParser.parseTimedText(mockResponse);
 
         expect(tData).toHaveLength(4);
         expect(console.error).toHaveBeenCalledTimes(1);
@@ -717,6 +804,7 @@ describe('transcript-parser', () => {
           'Invalid timestamp in line with text; ',
           '[music]'
         );
+        expect(tType).toEqual(transcriptParser.TRANSCRIPT_TYPES.timedText);
       });
     });
   });

--- a/src/services/transcript-parser.test.js
+++ b/src/services/transcript-parser.test.js
@@ -720,8 +720,8 @@ describe('transcript-parser', () => {
           expect(tData).toHaveLength(6);
           expect(tData[0]).toEqual({
             tag: 'NOTE',
-            begin: '00:00:00.000',
-            end: '00:00:00.000',
+            begin: 0,
+            end: 0,
             text: 'NOTE<br />This is a webvtt file'
           });
           expect(tType).toEqual(transcriptParser.TRANSCRIPT_TYPES.timedText);


### PR DESCRIPTION
Related issue: #440 

The following WebVTT file is displayed in the transcript component with comments:
```
WEBVTT

region
id:bill
width:40%
lines:3
regionanchor:100%,100%
viewportanchor:90%,90%
scroll:up

STYLE
::cue {
  background-image: linear-gradient(to bottom, dimgray, lightgray);
  color: papayawhip;
}
/* Style blocks cannot use blank lines nor "dash dash greater than" */

NOTE
This file was machine-generated.
The cues and timing maybe not 100% accurate.

1
00:00:01.200 --> 00:00:21.000 region:fred align:left
[music]

NOTE End of music, and starting dialog

2
00:00:22.200 --> 00:00:26.600 region:bill align:right
<em>Just</em> before lunch one day, a puppet show 
was put on at school.
```

![Screenshot 2024-04-09 at 10 54 14 AM](https://github.com/samvera-labs/ramp/assets/1331659/27af7824-3990-41db-b13b-ef9f587cbed8)
