### PR TITLE
Build active structure item classname into a single line

### DIFF
--- a/src/components/StructuredNavigation/NavUtils/ListItem.js
+++ b/src/components/StructuredNavigation/NavUtils/ListItem.js
@@ -142,8 +142,8 @@ const ListItem = ({
         data-testid="list-item"
         ref={liRef}
         className={
-          `ramp--structured-nav__list-item
-          ${(itemIdRef.current != undefined && (currentNavItem?.id === itemIdRef.current) && (isPlaylist || !isCanvas))
+          'ramp--structured-nav__list-item' +
+          `${(itemIdRef.current != undefined && (currentNavItem?.id === itemIdRef.current) && (isPlaylist || !isCanvas))
             ? ' active'
             : ''
           }`

--- a/src/components/StructuredNavigation/NavUtils/ListItem.test.js
+++ b/src/components/StructuredNavigation/NavUtils/ListItem.test.js
@@ -259,6 +259,7 @@ describe('ListItem component', () => {
       fireEvent.click(listItem.children[1]);
       waitFor(() => {
         expect(listItem).toHaveClass('active');
+        expect(listItem.className).toEqual('ramp--structured-nav__list-item active');
       });
     });
 

--- a/src/components/StructuredNavigation/NavUtils/SectionHeading.test.js
+++ b/src/components/StructuredNavigation/NavUtils/SectionHeading.test.js
@@ -103,5 +103,7 @@ describe('SectionHeading component', () => {
     );
     expect(screen.queryAllByTestId('listitem-section')).toHaveLength(1);
     expect(screen.getByTestId('listitem-section')).toHaveClass('active');
+    expect(screen.getByTestId('listitem-section').className)
+      .toEqual('ramp--structured-nav__section active');
   });
 });


### PR DESCRIPTION
This PR fixes a bug introduced in https://github.com/samvera-labs/ramp/pull/447.

This bug was released in version 3.1.0, and possibly breaks add to playlist functionality for current track option in Avalon 7.7.1.