### PR TITLE
Rights metadata

### DIFF
--- a/public/manifests/dev/lunchroom_manners.json
+++ b/public/manifests/dev/lunchroom_manners.json
@@ -304,6 +304,7 @@
       "format": "image/jpeg"
     }
   ],
+  "rights": "http://creativecommons.org/licenses/by-sa/3.0/",
   "items": [
     {
       "id": "http://localhost:3003/dev/lunchroom_manners/canvas/1",

--- a/public/manifests/dev/playlist-manifest.json
+++ b/public/manifests/dev/playlist-manifest.json
@@ -152,7 +152,35 @@
           },
           "format": "text/html"
         }
-      ]
+      ],
+      "metadata": [
+        {
+          "label": {
+            "none": [
+              "Title"
+            ]
+          },
+          "value": {
+            "none": [
+              "Lunchroom manners - an educational video"
+            ]
+          }
+        },
+        {
+          "label": {
+            "none": [
+              "Publishers"
+            ]
+          },
+          "value": {
+            "none": [
+              "Indiana University",
+              "University Indiana"
+            ]
+          }
+        }
+      ],
+      "rights": "http://creativecommons.org/licenses/by-sa/3.0/"
     },
     {
       "type": "Canvas",

--- a/src/components/MetadataDisplay/MetadataDisplay.js
+++ b/src/components/MetadataDisplay/MetadataDisplay.js
@@ -67,7 +67,6 @@ const MetadataDisplay = ({
         setManifestMetadata(manifestMeta);
       }
       if (parsedMetadata.rights?.length > 0) {
-        console.log(parsedMetadata.rights);
         setManifestRights(parsedMetadata.rights);
       }
     }
@@ -88,15 +87,17 @@ const MetadataDisplay = ({
    * Set canvas metadata in state
    */
   const setCanvasMetadataInState = () => {
-    let { metadata, rights } = canvasesMetadataRef.current
-      .filter((m) => m.canvasindex === canvasIndex)[0] || [];
-    console.log(metadata, rights);
-    if (!displayTitle) {
-      metadata = metadata.filter(md => md.label.toLowerCase() != 'title');
-    }
-    setCanvasMetadata(metadata);
-    if (rights && rights?.length > 0) {
-      setCanvasRights(rights);
+    const canvasData = canvasesMetadataRef.current
+      .filter((m) => m.canvasindex === canvasIndex)[0];
+    if (canvasData != undefined) {
+      let { metadata, rights } = canvasData;
+      if (!displayTitle && metadata != undefined) {
+        metadata = metadata.filter(md => md.label.toLowerCase() != 'title');
+      }
+      setCanvasMetadata(metadata);
+      if (rights != undefined && rights?.length > 0) {
+        setCanvasRights(rights);
+      }
     }
   };
   /**
@@ -138,7 +139,11 @@ const MetadataDisplay = ({
               {displayAllMetadata && <span>{itemHeading}</span>}
               {buildMetadata(manifestMetadata)}
               {manifestRights?.length > 0 && (
-                <span className="ramp--metadata-rights-heading">Rights</span>
+                <span
+                  className="ramp--metadata-rights-heading"
+                  data-testid="manifest-rights">
+                  Rights
+                </span>
               )}
               {buildMetadata(manifestRights)}
             </React.Fragment>
@@ -148,7 +153,11 @@ const MetadataDisplay = ({
               {displayAllMetadata && <span>{sectionHeaading}</span>}
               {buildMetadata(canvasMetadata)}
               {canvasRights?.length > 0 && (
-                <span className="ramp--metadata-rights-heading">Rights</span>
+                <span
+                  className="ramp--metadata-rights-heading"
+                  data-testid="canvas-rights">
+                  Rights
+                </span>
               )}
               {buildMetadata(canvasRights)}
             </React.Fragment>

--- a/src/components/MetadataDisplay/MetadataDisplay.js
+++ b/src/components/MetadataDisplay/MetadataDisplay.js
@@ -30,6 +30,9 @@ const MetadataDisplay = ({
   const [showManifestMetadata, setShowManifestMetadata] = React.useState();
   const [showCanvasMetadata, setShowCanvasMetadata] = React.useState();
 
+  const [manifestRights, setManifestRights] = React.useState();
+  const [canvasRights, setCanvasRights] = React.useState();
+
   let canvasesMetadataRef = React.useRef();
   const setCanvasesMetadata = (m) => {
     _setCanvasesMetadata(m);
@@ -63,6 +66,10 @@ const MetadataDisplay = ({
         }
         setManifestMetadata(manifestMeta);
       }
+      if (parsedMetadata.rights?.length > 0) {
+        console.log(parsedMetadata.rights);
+        setManifestRights(parsedMetadata.rights);
+      }
     }
   }, [manifest]);
 
@@ -81,12 +88,16 @@ const MetadataDisplay = ({
    * Set canvas metadata in state
    */
   const setCanvasMetadataInState = () => {
-    let canvasData = canvasesMetadataRef.current
-      .filter((m) => m.canvasindex === canvasIndex)[0]?.metadata || [];
+    let { metadata, rights } = canvasesMetadataRef.current
+      .filter((m) => m.canvasindex === canvasIndex)[0] || [];
+    console.log(metadata, rights);
     if (!displayTitle) {
-      canvasData = canvasData.filter(md => md.label.toLowerCase() != 'title');
+      metadata = metadata.filter(md => md.label.toLowerCase() != 'title');
     }
-    setCanvasMetadata(canvasData);
+    setCanvasMetadata(metadata);
+    if (rights && rights?.length > 0) {
+      setCanvasRights(rights);
+    }
   };
   /**
    * Distinguish whether there is any metadata to be displayed
@@ -94,6 +105,21 @@ const MetadataDisplay = ({
    */
   const hasMetadata = () => {
     return canvasMetadata?.length > 0 || manifestMetadata?.length > 0;
+  };
+
+  const buildMetadata = (metadata) => {
+    let metadataPairs = [];
+    if (metadata?.length > 0) {
+      metadata.map((md, index) => {
+        metadataPairs.push(
+          <React.Fragment key={index}>
+            <dt>{md.label}</dt>
+            <dd dangerouslySetInnerHTML={{ __html: md.value }}></dd>
+          </React.Fragment>
+        );
+      });
+    }
+    return metadataPairs;
   };
 
   return (
@@ -109,28 +135,22 @@ const MetadataDisplay = ({
         <div className="ramp--metadata-display-content">
           {showManifestMetadata && manifestMetadata?.length > 0 && (
             <React.Fragment>
-              {displayAllMetadata && <p>{itemHeading}</p>}
-              {manifestMetadata.map((md, index) => {
-                return (
-                  <React.Fragment key={index}>
-                    <dt>{md.label}</dt>
-                    <dd dangerouslySetInnerHTML={{ __html: md.value }}></dd>
-                  </React.Fragment>
-                );
-              })}
+              {displayAllMetadata && <span>{itemHeading}</span>}
+              {buildMetadata(manifestMetadata)}
+              {manifestRights?.length > 0 && (
+                <span className="ramp--metadata-rights-heading">Rights</span>
+              )}
+              {buildMetadata(manifestRights)}
             </React.Fragment>
           )}
           {showCanvasMetadata && canvasMetadata?.length > 0 && (
             <React.Fragment>
-              {displayAllMetadata && <p>{sectionHeaading}</p>}
-              {canvasMetadata.map((md, index) => {
-                return (
-                  <React.Fragment key={index}>
-                    <dt>{md.label}</dt>
-                    <dd dangerouslySetInnerHTML={{ __html: md.value }}></dd>
-                  </React.Fragment>
-                );
-              })}
+              {displayAllMetadata && <span>{sectionHeaading}</span>}
+              {buildMetadata(canvasMetadata)}
+              {canvasRights?.length > 0 && (
+                <span className="ramp--metadata-rights-heading">Rights</span>
+              )}
+              {buildMetadata(canvasRights)}
             </React.Fragment>
           )}
         </div>

--- a/src/components/MetadataDisplay/MetadataDisplay.scss
+++ b/src/components/MetadataDisplay/MetadataDisplay.scss
@@ -28,12 +28,21 @@
     max-height: 30rem;
     overflow-y: auto;
 
-    p {
-      font-weight: normal;
-      padding: 0.5rem 0;
+    >span {
+      font-weight: bold;
+      font-style: italic;
+      padding: 0.5rem 0 0.5rem 1.5rem;
       margin: 00 0 0.75rem;
       color: $primaryDarker;
       border-bottom: 0.1rem solid $primaryDark;
+      display: block;
+      margin: 0 -1.5rem 0.5rem -1.5rem;
+    }
+
+    .ramp--metadata-rights-heading {
+      border-bottom: 0.1rem solid $primary;
+      margin: 0;
+      padding: 0.5rem 0;
     }
 
     dt {

--- a/src/components/MetadataDisplay/MetadataDisplay.test.js
+++ b/src/components/MetadataDisplay/MetadataDisplay.test.js
@@ -4,6 +4,7 @@ import MetadataDisplay from './MetadataDisplay';
 import manifest from '@TestData/lunchroom-manners';
 import manifestWoMetadata from '@TestData/volleyball-for-boys';
 import manifestWoCanvases from '@TestData/empty-playlist';
+import noRightsManifest from '@TestData/transcript-annotation';
 import playlistManifest from '@TestData/playlist';
 import { withManifestProvider } from '../../services/testing-helpers';
 
@@ -50,6 +51,7 @@ describe('MetadataDisplay component', () => {
         render(<MetadataDisp />);
         expect(screen.queryByTestId('metadata-display')).toBeInTheDocument();
         expect(screen.queryByTestId('metadata-display-title')).toBeInTheDocument();
+        expect(screen.queryByTestId('manifest-rights')).toBeInTheDocument();
       });
 
       it('set to false doesn\'t display Details heading', () => {
@@ -75,12 +77,12 @@ describe('MetadataDisplay component', () => {
         // Has one title field with Manifest metadata
         expect(screen.queryAllByText('Title')).toHaveLength(1);
         expect(screen.queryByText('Playlist Manifest [Playlist]')).toBeInTheDocument();
-        expect(screen.queryByText('First Playlist Item')).not.toBeInTheDocument();
+        expect(screen.queryByText('Second Playlist Item')).not.toBeInTheDocument();
       });
 
       it('set to true displays only Canvas metadata', () => {
         const MetadataDisp = withManifestProvider(MetadataDisplay, {
-          initialState: { manifest: playlistManifest, canvasIndex: 0 },
+          initialState: { manifest: playlistManifest, canvasIndex: 1 },
           displayOnlyCanvasMetadata: true
         });
         render(<MetadataDisp />);
@@ -90,15 +92,14 @@ describe('MetadataDisplay component', () => {
         // Has one title field with Manifest metadata
         expect(screen.queryAllByText('Title')).toHaveLength(1);
         expect(screen.queryByText('Playlist Manifest [Playlist]')).not.toBeInTheDocument();
-        expect(screen.queryByText('First Playlist Item')).toBeInTheDocument();
+        expect(screen.queryByText('Second Playlist Item')).toBeInTheDocument();
 
-        // console.log is called twice for the 2 canvases without metadata
-        expect(console.log).toBeCalledTimes(2);
+        expect(console.log).toBeCalled();
       });
 
       it('set to true with displayTitle set to false displays Canvas metadata w/o title', () => {
         const MetadataDisp = withManifestProvider(MetadataDisplay, {
-          initialState: { manifest: playlistManifest, canvasIndex: 0 },
+          initialState: { manifest: playlistManifest, canvasIndex: 1 },
           displayOnlyCanvasMetadata: true,
           displayTitle: false
         });
@@ -108,14 +109,13 @@ describe('MetadataDisplay component', () => {
 
         // Doesn't display title
         expect(screen.queryByText('Title')).not.toBeInTheDocument();
-        expect(screen.queryByText('First Playlist Item')).not.toBeInTheDocument();
+        expect(screen.queryByText('Second Playlist Item')).not.toBeInTheDocument();
 
         // Displays other metadata
         expect(screen.queryByText('Date')).toBeInTheDocument();
         expect(screen.queryByText('2023')).toBeInTheDocument();
 
-        // console.log is called twice for the 2 canvases without metadata
-        expect(console.log).toBeCalledTimes(2);
+        expect(console.log).toBeCalled();
       });
     });
 
@@ -136,7 +136,7 @@ describe('MetadataDisplay component', () => {
 
       it('set to true displays both Manifest and Canvas metadata', () => {
         const MetadataDisp = withManifestProvider(MetadataDisplay, {
-          initialState: { manifest: playlistManifest, canvasIndex: 0 },
+          initialState: { manifest: playlistManifest, canvasIndex: 1 },
           displayAllMetadata: true
         });
         render(<MetadataDisp />);
@@ -146,15 +146,14 @@ describe('MetadataDisplay component', () => {
         // Has two title fields with both Manifest and Canvas metadata
         expect(screen.queryAllByText('Title')).toHaveLength(2);
         expect(screen.queryByText('Playlist Manifest [Playlist]')).toBeInTheDocument();
-        expect(screen.queryByText('First Playlist Item')).toBeInTheDocument();
+        expect(screen.queryByText('Second Playlist Item')).toBeInTheDocument();
 
-        // console.log is called twice for the 2 canvases without metadata
-        expect(console.log).toBeCalledTimes(2);
+        expect(console.log).toBeCalled();
       });
 
       it('set to true with displayTitle set to false hides title in all metadata', () => {
         const MetadataDisp = withManifestProvider(MetadataDisplay, {
-          initialState: { manifest: playlistManifest, canvasIndex: 0 },
+          initialState: { manifest: playlistManifest, canvasIndex: 1 },
           displayAllMetadata: true,
           displayTitle: false
         });
@@ -167,8 +166,85 @@ describe('MetadataDisplay component', () => {
         expect(screen.queryByText('Playlist Manifest [Playlist]')).not.toBeInTheDocument();
         expect(screen.queryByText('First Playlist Item')).not.toBeInTheDocument();
 
-        // console.log is called twice for the 2 canvases without metadata
-        expect(console.log).toBeCalledTimes(2);
+        expect(console.log).toBeCalled();
+      });
+    });
+
+    describe('rights section', () => {
+      describe('displays when rights/requiredStatement is present', () => {
+        test('with manifest metadata', () => {
+          const MetadataDisp = withManifestProvider(MetadataDisplay, {
+            initialState: { manifest }
+          });
+          render(<MetadataDisp />);
+          expect(screen.queryByTestId('metadata-display')).toBeInTheDocument();
+          expect(screen.queryByTestId('metadata-display-title')).toBeInTheDocument();
+          expect(screen.queryByTestId('manifest-rights')).toBeInTheDocument();
+          expect(screen.getByText('License')).toBeInTheDocument();
+          expect(screen.queryByTestId('canvas-rights')).not.toBeInTheDocument();
+        });
+
+        test('with canvas metadata', () => {
+          const MetadataDisp = withManifestProvider(MetadataDisplay, {
+            initialState: { manifest: playlistManifest, canvasIndex: 1 },
+            displayOnlyCanvasMetadata: true,
+          });
+          render(<MetadataDisp />);
+          expect(screen.queryByTestId('metadata-display')).toBeInTheDocument();
+          expect(screen.queryByTestId('metadata-display-title')).toBeInTheDocument();
+          expect(screen.queryByTestId('manifest-rights')).not.toBeInTheDocument();
+          expect(screen.queryByTestId('canvas-rights')).toBeInTheDocument();
+          expect(screen.getByText('Attribution')).toBeInTheDocument();
+        });
+
+        test('with manifest and canvas metadata', () => {
+          const MetadataDisp = withManifestProvider(MetadataDisplay, {
+            initialState: { manifest: playlistManifest, canvasIndex: 1 },
+            displayAllMetadata: true,
+          });
+          render(<MetadataDisp />);
+          expect(screen.queryByTestId('metadata-display')).toBeInTheDocument();
+          expect(screen.queryByTestId('metadata-display-title')).toBeInTheDocument();
+          expect(screen.queryByTestId('manifest-rights')).toBeInTheDocument();
+          expect(screen.getByText('License')).toBeInTheDocument();
+          expect(screen.queryByTestId('canvas-rights')).toBeInTheDocument();
+          expect(screen.getByText('Attribution')).toBeInTheDocument();
+        });
+      });
+
+      describe('does not display when rights/requiredStatement is not present', () => {
+        test('with manifest metadata', () => {
+          const MetadataDisp = withManifestProvider(MetadataDisplay, {
+            initialState: { manifest: noRightsManifest }
+          });
+          render(<MetadataDisp />);
+          expect(screen.queryByTestId('metadata-display')).toBeInTheDocument();
+          expect(screen.queryByTestId('metadata-display-title')).toBeInTheDocument();
+          expect(screen.queryByTestId('manifest-rights')).not.toBeInTheDocument();
+        });
+
+        test('with canvas metadata', () => {
+          const MetadataDisp = withManifestProvider(MetadataDisplay, {
+            initialState: { manifest: noRightsManifest, canvasIndex: 0 },
+            displayOnlyCanvasMetadata: true,
+          });
+          render(<MetadataDisp />);
+          expect(screen.queryByTestId('metadata-display')).toBeInTheDocument();
+          expect(screen.queryByTestId('metadata-display-title')).toBeInTheDocument();
+          expect(screen.queryByTestId('canvas-rights')).not.toBeInTheDocument();
+        });
+
+        test('with manifest and canvas metadata', () => {
+          const MetadataDisp = withManifestProvider(MetadataDisplay, {
+            initialState: { manifest: noRightsManifest, canvasIndex: 0 },
+            displayAllMetadata: true,
+          });
+          render(<MetadataDisp />);
+          expect(screen.queryByTestId('metadata-display')).toBeInTheDocument();
+          expect(screen.queryByTestId('metadata-display-title')).toBeInTheDocument();
+          expect(screen.queryByTestId('manifest-rights')).not.toBeInTheDocument();
+          expect(screen.queryByTestId('canvas-rights')).not.toBeInTheDocument();
+        });
       });
     });
   });

--- a/src/services/iiif-parser.js
+++ b/src/services/iiif-parser.js
@@ -1,4 +1,4 @@
-import { parseManifest, PropertyValue } from 'manifesto.js';
+import { LabelValuePair, parseManifest, PropertyValue } from 'manifesto.js';
 import mimeDb from 'mime-db';
 import sanitizeHtml from 'sanitize-html';
 import {
@@ -524,6 +524,7 @@ export function getSupplementingAnnotations(manifest) {
 }
 
 /**
+ * Read metadata from both Manifest and Canvas levels as needed
  * @param {Object} manifest
  * @param {Boolean} readCanvasMetadata read metadata from Canvas level
  * @return {Array} list of key value pairs for each metadata item in the manifest
@@ -532,21 +533,29 @@ export function getMetadata(manifest, readCanvasMetadata) {
   try {
     let canvasMetadata = [];
     let allMetadata = { canvasMetadata: canvasMetadata, manifestMetadata: [] };
-    const manifestMetadata = parseManifest(manifest).getMetadata();
+    const parsedManifest = parseManifest(manifest);
+    // Parse Canvas-level metadata blocks for each Canvas
     if (readCanvasMetadata) {
       let canvases = parseSequences(manifest)[0].getCanvases();
       for (const i in canvases) {
         let canvasindex = parseInt(i);
+        const rightsMetadata = parseRightsAsMetadata(canvases[canvasindex], 'Canvas');
         canvasMetadata.push({
           canvasindex: canvasindex,
           metadata: parseMetadata(
             canvases[canvasindex].getMetadata(), 'Canvas'
-          )
+          ),
+          rights: rightsMetadata
         });
       };
       allMetadata.canvasMetadata = canvasMetadata;
     }
-    allMetadata.manifestMetadata = parseMetadata(manifestMetadata, 'Manifest');
+    // Parse Manifest-level metadata block
+    const manifestMetadata = parsedManifest.getMetadata();
+    const parsedManifestMetadata = parseMetadata(manifestMetadata, 'Manifest');
+    const rightsMetadata = parseRightsAsMetadata(parsedManifest, 'Manifest');
+    allMetadata.manifestMetadata = parsedManifestMetadata;
+    allMetadata.rights = rightsMetadata;
     return allMetadata;
   } catch (e) {
     console.error('iiif-parser -> getMetadata() -> cannot parse manifest, ', e);
@@ -577,6 +586,29 @@ export function parseMetadata(metadata, resourceType) {
     console.log('iiif-parser -> parseMetadata() -> no metadata in ', resourceType);
     return parsedMetadata;
   }
+}
+
+/**
+ * Parse requiredStatement and rights information as metadata
+ * @param {Object} resource Canvas or Manifest JSON-ld
+ * @param {String} resourceType resource type (Manifest/Canvas) for metadata
+ * @returns {Array<JSON Object>}
+ */
+function parseRightsAsMetadata(resource, resourceType) {
+  let otherMetadata = [];
+  const requiredStatement = resource.getRequiredStatement();
+  if (requiredStatement != undefined && requiredStatement.value?.length > 0) {
+    otherMetadata = parseMetadata([requiredStatement], resourceType);
+  }
+  const rights = resource.getProperty('rights') || undefined;
+  if (rights != undefined) {
+    const isURL = (/^(https?:\/\/[^\s]+)|(www\.[^\s]+)/).test(rights);
+    otherMetadata.push({
+      label: 'License',
+      value: isURL ? `<a href=${rights}>${rights}</a>` : rights
+    });
+  }
+  return otherMetadata;
 }
 
 /**

--- a/src/services/iiif-parser.test.js
+++ b/src/services/iiif-parser.test.js
@@ -534,9 +534,9 @@ describe('iiif-parser', () => {
         const { manifestMetadata, canvasMetadata } = iiifParser.getMetadata(playlistManifest, true);
         expect(manifestMetadata.length).toBeGreaterThan(0);
         expect(canvasMetadata.length).toEqual(3);
-        expect(canvasMetadata[0].metadata[0]).toEqual({ label: "Title", value: "First Playlist Item" });
-        expect(canvasMetadata[0]).toHaveProperty('rights');
-        expect(canvasMetadata[0].rights[0]).toEqual(
+        expect(canvasMetadata[1].metadata[0]).toEqual({ label: "Title", value: "Second Playlist Item" });
+        expect(canvasMetadata[1]).toHaveProperty('rights');
+        expect(canvasMetadata[1].rights[0]).toEqual(
           {
             label: "Attribution",
             value: "<span>Creative commons <a href=\"https://creativecommons.org/licenses/by-sa/3.0\">CC BY-SA 3.0</a></span>"
@@ -550,7 +550,7 @@ describe('iiif-parser', () => {
         const { manifestMetadata, canvasMetadata } = iiifParser.getMetadata(playlistManifest, true);
         expect(manifestMetadata.length).toBeGreaterThan(0);
         expect(canvasMetadata.length).toEqual(3);
-        expect(canvasMetadata[1].metadata).toEqual([]);
+        expect(canvasMetadata[0].metadata).toEqual([]);
         // console.log is called twice for the 2 canvases without metadata
         expect(console.log).toBeCalledTimes(2);
       });

--- a/src/services/iiif-parser.test.js
+++ b/src/services/iiif-parser.test.js
@@ -505,16 +505,20 @@ describe('iiif-parser', () => {
       console.log = jest.fn();
     });
     afterAll(() => {
-      // Clen up mock
+      // Clean up mock
       console.log = originalLogger;
     });
 
     describe('reading only manifest-level metadata', () => {
       it('manifest with metadata returns a list of key, value pairs', () => {
-        const { manifestMetadata, canvasMetadata } = iiifParser.getMetadata(lunchroomManifest, false);
+        const { manifestMetadata, canvasMetadata, rights } = iiifParser.getMetadata(lunchroomManifest, false);
         expect(manifestMetadata.length).toBeGreaterThan(0);
         expect(canvasMetadata.length).toEqual(0);
         expect(manifestMetadata[0]).toEqual({ label: "Title", value: "This is the title of the item!" });
+        expect(rights).toEqual([{
+          label: 'License',
+          value: "<a href=http://creativecommons.org/licenses/by-sa/3.0/>http://creativecommons.org/licenses/by-sa/3.0/</a>"
+        }]);
       });
 
       it('manifest without metadata returns []', () => {
@@ -531,6 +535,12 @@ describe('iiif-parser', () => {
         expect(manifestMetadata.length).toBeGreaterThan(0);
         expect(canvasMetadata.length).toEqual(3);
         expect(canvasMetadata[0].metadata[0]).toEqual({ label: "Title", value: "First Playlist Item" });
+        expect(canvasMetadata[0]).toHaveProperty('rights');
+        expect(canvasMetadata[0].rights[0]).toEqual(
+          {
+            label: "Attribution",
+            value: "<span>Creative commons <a href=\"https://creativecommons.org/licenses/by-sa/3.0\">CC BY-SA 3.0</a></span>"
+          });
         // console.log is called twice for the 2 canvases without metadata
         expect(console.log).toBeCalledTimes(2);
       });
@@ -693,5 +703,4 @@ describe('iiif-parser', () => {
       expect(firstStructCanvas.canvasDuration).toEqual(32);
     });
   });
-
 });

--- a/src/test_data/lunchroom-manners.js
+++ b/src/test_data/lunchroom-manners.js
@@ -58,6 +58,7 @@ export default {
       format: 'text/vtt',
     }
   ],
+  rights: "http://creativecommons.org/licenses/by-sa/3.0/",
   start: {
     id: 'https://example.com/manifest/lunchroom_manners',
     type: 'SpecificResource',

--- a/src/test_data/playlist.js
+++ b/src/test_data/playlist.js
@@ -80,6 +80,12 @@ export default {
           value: { none: ["Coronet Films"] }
         }
       ],
+      requiredStatement: {
+        label: { en: ["Attribution"] },
+        value: {
+          none: ["<span>Creative commons <a href=\"https://creativecommons.org/licenses/by-sa/3.0\">CC BY-SA 3.0</a></span>"]
+        }
+      },
     },
     {
       id: 'http://example.com/playlists/1/canvas/2',

--- a/src/test_data/playlist.js
+++ b/src/test_data/playlist.js
@@ -20,6 +20,7 @@ export default {
       type: 'AnnotationService0'
     }
   ],
+  rights: "http://creativecommons.org/licenses/by-sa/3.0/",
   items: [
     {
       id: 'http://example.com/playlists/1/canvas/1',
@@ -68,24 +69,6 @@ export default {
         },
       ],
       annotations: [],
-      metadata: [
-        {
-          label: { en: ["Title"] },
-          value: { none: ["First Playlist Item"] }
-        }, {
-          label: { en: ["Date"] },
-          value: { none: ["2023"] }
-        }, {
-          label: { en: ["Main Contributor"] },
-          value: { none: ["Coronet Films"] }
-        }
-      ],
-      requiredStatement: {
-        label: { en: ["Attribution"] },
-        value: {
-          none: ["<span>Creative commons <a href=\"https://creativecommons.org/licenses/by-sa/3.0\">CC BY-SA 3.0</a></span>"]
-        }
-      },
     },
     {
       id: 'http://example.com/playlists/1/canvas/2',
@@ -105,6 +88,24 @@ export default {
           format: 'text/html'
         }
       ],
+      metadata: [
+        {
+          label: { en: ["Title"] },
+          value: { none: ["Second Playlist Item"] }
+        }, {
+          label: { en: ["Date"] },
+          value: { none: ["2023"] }
+        }, {
+          label: { en: ["Main Contributor"] },
+          value: { none: ["Coronet Films"] }
+        }
+      ],
+      requiredStatement: {
+        label: { en: ["Attribution"] },
+        value: {
+          none: ["<span>Creative commons <a href=\"https://creativecommons.org/licenses/by-sa/3.0\">CC BY-SA 3.0</a></span>"]
+        }
+      },
       placeholderCanvas: {
         id: 'http://example.com/playlists/1/canvas/2/placeholder',
         type: "Canvas",

--- a/src/test_data/transcript-annotation.js
+++ b/src/test_data/transcript-annotation.js
@@ -5,6 +5,20 @@ export default {
   label: {
     en: ['Manifest with transcript as annotation'],
   },
+  metadata: [
+    {
+      label: { none: ["Title"] },
+      value: { none: ["This is the <pre>title</pre> of the item!"] }
+    },
+    {
+      label: { en: ["Date"] },
+      value: { en: ["2023 (Creation date: 2023)"] }
+    },
+    {
+      label: { en: ["Notes"] },
+      value: null
+    }
+  ],
   start: {
     id: 'https://example.com/sample/transcript-annotation/canvas/1',
     type: 'Canvas',


### PR DESCRIPTION
Related issue: #331 

When displaying both Manifest and Canvas metadata;
![Screenshot 2024-04-18 at 2 03 27 PM](https://github.com/samvera-labs/ramp/assets/1331659/106f4d6d-3549-4c9f-bb81-dae2dcee2453)

When displaying only Manifest metadata (default behavior);
![Screenshot 2024-04-18 at 2 01 49 PM](https://github.com/samvera-labs/ramp/assets/1331659/36c584ef-758f-405d-882e-ba01ffa96d59)

When displaying only Canvas metadata (e.g. playlist page `Source Item Details` panel);
![Screenshot 2024-04-18 at 1 57 59 PM](https://github.com/samvera-labs/ramp/assets/1331659/17990eb0-f1e5-44e9-8d99-c276915a523f)

By default, adds a rights section at the end of the metadata to for Manifest to display `rights` and `requiredStatment` if one of the properties is specified.

If canvas related metadata are display is turned on via either `displayAllMetadata` or `displayOnlyCanvasMetadata` it adds a rights section to end of  metadata.

`rights` property in the IIIF Manifest is displayed with the label `License`.