### PR TITLE
Wrap overflowing metadata text into new lines to avoid horizontal scroll

### DIFF
--- a/src/components/MetadataDisplay/MetadataDisplay.scss
+++ b/src/components/MetadataDisplay/MetadataDisplay.scss
@@ -51,6 +51,7 @@
 
     dd {
       padding-bottom: 1rem;
+      word-break: break-word;
     }
 
     a {


### PR DESCRIPTION
Related issue: #486 