### PR TITLE
Accessibility fixes to issues found in axe report

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
 
 <head>
   <title>Ramp</title>

--- a/src/components/MetadataDisplay/MetadataDisplay.js
+++ b/src/components/MetadataDisplay/MetadataDisplay.js
@@ -120,7 +120,7 @@ const MetadataDisplay = ({
         );
       });
     }
-    return metadataPairs;
+    return <dl>{metadataPairs}</dl>;
   };
 
   return (

--- a/src/components/StructuredNavigation/NavUtils/ListItem.js
+++ b/src/components/StructuredNavigation/NavUtils/ListItem.js
@@ -161,7 +161,6 @@ const ListItem = ({
             : ''
           }`
         }
-        aria-label={itemLabelRef.current}
         data-label={itemLabelRef.current}
         data-summary={itemSummaryRef.current}
       >

--- a/src/services/utility-helpers.js
+++ b/src/services/utility-helpers.js
@@ -425,7 +425,7 @@ function getResourceInfo(item, motivation) {
     };
     if (motivation === 'supplementing') {
       // Set language for captions/subtitles
-      s.srclang = item.getProperty('language') || 'eng';
+      s.srclang = item.getProperty('language') || 'en';
       // Specify kind to subtitles for VTT annotations. Without this VideoJS
       // resolves the kind to metadata for subtitles file, resulting in empty
       // subtitles lists in iOS devices' native palyers


### PR DESCRIPTION
Found these issues via a axe scan on Ramp demo site;
- Ensures `<dt>` and `<dd>` elements are contained by a `<dl>`. Description list item does not have a `<dl>` parent element in `MetadataDisplay` component
- Ensures elements with an ARIA role that require child roles contain them. Element has children which are not allowed: li[aria-label] in the `StructuredNavigation` component
- Ensures every HTML document has a lang attribute. The <html> element does not have a lang attribute in the demo implementation page