### PR TITLE
Update structure parsing to include root-level Range in display

### DIFF
--- a/src/components/StructuredNavigation/NavUtils/ListItem.js
+++ b/src/components/StructuredNavigation/NavUtils/ListItem.js
@@ -35,6 +35,7 @@ const ListItem = ({
   label,
   summary,
   homepage,
+  isRoot,
   items,
   itemIndex,
   rangeId,
@@ -110,6 +111,7 @@ const ListItem = ({
               label={label}
               sectionRef={sectionRef}
               itemId={itemIdRef.current}
+              isRoot={isRoot}
               handleClick={handleClick}
               structureContainerRef={structureContainerRef}
             />
@@ -183,6 +185,7 @@ ListItem.propTypes = {
   label: PropTypes.string.isRequired,
   summary: PropTypes.string,
   homepage: PropTypes.string,
+  isRoot: PropTypes.bool,
   items: PropTypes.array.isRequired,
   itemIndex: PropTypes.number,
   rangeId: PropTypes.string.isRequired,

--- a/src/components/StructuredNavigation/NavUtils/SectionHeading.js
+++ b/src/components/StructuredNavigation/NavUtils/SectionHeading.js
@@ -9,6 +9,7 @@ const SectionHeading = ({
   canvasIndex,
   sectionRef,
   itemId,
+  isRoot,
   handleClick,
   structureContainerRef
 }) => {
@@ -60,7 +61,7 @@ const SectionHeading = ({
           data-testid="listitem-section-span"
           aria-label={itemLabelRef.current}
         >
-          {`${itemIndex}. `}
+          {isRoot ? '' : `${itemIndex}. `}
           {itemLabelRef.current}
           {duration != '' &&
             <span className="ramp--structured-nav__section-duration">
@@ -80,6 +81,7 @@ SectionHeading.propTypes = {
   label: PropTypes.string.isRequired,
   sectionRef: PropTypes.object.isRequired,
   itemId: PropTypes.string,
+  isRoot: PropTypes.bool,
   handleClick: PropTypes.func.isRequired,
   structureContainerRef: PropTypes.object.isRequired,
 };

--- a/src/components/StructuredNavigation/NavUtils/SectionHeading.test.js
+++ b/src/components/StructuredNavigation/NavUtils/SectionHeading.test.js
@@ -106,4 +106,27 @@ describe('SectionHeading component', () => {
     expect(screen.getByTestId('listitem-section').className)
       .toEqual('ramp--structured-nav__section active');
   });
+
+  test('renders root range as a span', () => {
+    render(
+      <SectionHeading
+        duration={'09:32'}
+        label={'Table of Contents'}
+        itemIndex={0}
+        canvasIndex={0}
+        isRoot={true}
+        sectionRef={sectionRef}
+        itemId={undefined}
+        handleClick={handleClickMock}
+        structureContainerRef={structureContainerRef}
+      />
+    );
+    expect(screen.queryAllByTestId('listitem-section-span')).toHaveLength(1);
+    expect(screen.queryAllByTestId('listitem-section-button')).toHaveLength(0);
+    expect(screen.getByTestId('listitem-section-span'))
+      .toHaveTextContent('Table of Contents09:32');
+    expect(screen.getByTestId('listitem-section')).not.toHaveAttribute('data-mediafrag');
+    expect(screen.getByTestId('listitem-section').getAttribute('data-label'))
+      .toEqual('Table of Contents');
+  });
 });

--- a/src/components/StructuredNavigation/StructuredNavigation.js
+++ b/src/components/StructuredNavigation/StructuredNavigation.js
@@ -30,6 +30,7 @@ const StructuredNavigation = () => {
   let canvasStructRef = React.useRef();
   let structureItemsRef = React.useRef();
   let canvasIsEmptyRef = React.useRef(canvasIsEmpty);
+  let hasRootRangeRef = React.useRef(false);
 
   const structureContainerRef = React.useRef();
   const scrollableStructure = React.useRef();
@@ -39,9 +40,10 @@ const StructuredNavigation = () => {
     // custom start time and(or) canvas is given in manifest
     if (manifest) {
       try {
-        let { structures, timespans } = getStructureRanges(manifest, playlist.isPlaylist);
+        let { structures, timespans, markRoot } = getStructureRanges(manifest, playlist.isPlaylist);
         structureItemsRef.current = structures;
         canvasStructRef.current = structures;
+        hasRootRangeRef.current = markRoot;
         // Remove root-level structure item from navigation calculations
         if (structures?.length > 0 && structures[0].isRoot) {
           canvasStructRef.current = structures[0].items;
@@ -186,6 +188,7 @@ const StructuredNavigation = () => {
   if (playlist?.isPlaylist) {
     divClass += " playlist-items";
   }
+  divClass += hasRootRangeRef.current ? " ramp--structured-nav-with_root" : "";
 
   /**
    * Update isScrolling flag within structure container ref, which is

--- a/src/components/StructuredNavigation/StructuredNavigation.js
+++ b/src/components/StructuredNavigation/StructuredNavigation.js
@@ -27,6 +27,7 @@ const StructuredNavigation = () => {
 
   const { showBoundary } = useErrorBoundary();
 
+  let canvasStructRef = React.useRef();
   let structureItemsRef = React.useRef();
   let canvasIsEmptyRef = React.useRef(canvasIsEmpty);
 
@@ -38,9 +39,14 @@ const StructuredNavigation = () => {
     // custom start time and(or) canvas is given in manifest
     if (manifest) {
       try {
-        let { structures, timespans } = getStructureRanges(manifest);
+        let { structures, timespans } = getStructureRanges(manifest, playlist.isPlaylist);
         structureItemsRef.current = structures;
-        manifestDispatch({ structures, type: 'setStructures' });
+        canvasStructRef.current = structures;
+        // Remove root-level structure item from navigation calculations
+        if (structures?.length > 0 && structures[0].isRoot) {
+          canvasStructRef.current = structures[0].items;
+        }
+        manifestDispatch({ structures: canvasStructRef.current, type: 'setStructures' });
         manifestDispatch({ timespans, type: 'setCanvasSegments' });
         structureContainerRef.current.isScrolling = false;
       } catch (error) {
@@ -98,7 +104,7 @@ const StructuredNavigation = () => {
             canvasIndex: currentCanvasIndex,
             type: 'switchCanvas',
           });
-          canvasIsEmptyRef.current = structureItemsRef.current[currentCanvasIndex].isEmpty;
+          canvasIsEmptyRef.current = canvasStructRef.current[currentCanvasIndex].isEmpty;
         }
       }
 

--- a/src/components/StructuredNavigation/StructuredNavigation.scss
+++ b/src/components/StructuredNavigation/StructuredNavigation.scss
@@ -20,6 +20,20 @@
   }
 }
 
+// Remove indentation for multiple Canvas structure with root Range
+.ramp--structured-nav-with_root {
+  >ul.ramp--structured-nav__list {
+    >li {
+      >ul>li {
+        padding: 0 0 0.5rem 0;
+      }
+      >ul>li:last-child {
+        padding: 0 0 0 0;
+      }
+    }
+  }
+}
+
 .ramp--structured-nav.playlist-items {
   padding: 1em 2em;
 }

--- a/src/components/StructuredNavigation/StructuredNavigation.test.js
+++ b/src/components/StructuredNavigation/StructuredNavigation.test.js
@@ -19,7 +19,7 @@ describe('StructuredNavigation component', () => {
     unobserve: jest.fn(),
   }));
 
-  window.ResizeObserver = ResizeObserver
+  window.ResizeObserver = ResizeObserver;
 
   describe('with manifest', () => {
     describe('with structures including Canvas references for sections', () => {
@@ -56,8 +56,21 @@ describe('StructuredNavigation component', () => {
         expect(screen.getAllByTestId('list').length).toBeGreaterThan(0);
       });
 
-      test('first item is a section title as a button', () => {
-        const firstItem = screen.getAllByTestId('list-item')[0];
+      test('renders root Range as a span', () => {
+        expect(screen.queryByText('Table of Contents')).not.toBeNull();
+
+        const rootRange = screen.getAllByTestId('list-item')[0];
+        expect(rootRange.children[0]).toHaveTextContent(
+          'Table of Contents'
+        );
+        expect(rootRange.children[0]).toHaveClass(
+          'ramp--structured-nav__section'
+        );
+        expect(rootRange.children[0].children[0].tagName).toBe('SPAN');
+      });
+
+      test('first Canvas item is a section title as a button', () => {
+        const firstItem = screen.getAllByTestId('list-item')[1];
         expect(firstItem.children[0]).toHaveTextContent(
           'Lunchroom Manners'
         );
@@ -96,8 +109,21 @@ describe('StructuredNavigation component', () => {
         expect(screen.getAllByTestId('list').length).toBeGreaterThan(0);
       });
 
+      test('renders root Range as a span', () => {
+        expect(screen.queryByText('Symphony no. 3 - Mahler, Gustav')).not.toBeNull();
+
+        const rootRange = screen.getAllByTestId('list-item')[0];
+        expect(rootRange.children[0]).toHaveTextContent(
+          'Symphony no. 3 - Mahler, Gustav'
+        );
+        expect(rootRange.children[0]).toHaveClass(
+          'ramp--structured-nav__section'
+        );
+        expect(rootRange.children[0].children[0].tagName).toBe('SPAN');
+      });
+
       test('first item is a section title as a span', () => {
-        const firstItem = screen.getAllByTestId('list-item')[0];
+        const firstItem = screen.getAllByTestId('list-item')[1];
         expect(firstItem.children[0]).toHaveTextContent(
           'CD1 - Mahler, Symphony No.3'
         );
@@ -117,7 +143,7 @@ describe('StructuredNavigation component', () => {
         const NavWithPlayerAndManifest = withManifestAndPlayerProvider(
           StructuredNavigation,
           {
-            initialManifestState: { manifest: manifestWithoutStructures },
+            initialManifestState: { manifest: manifestWithoutStructures, playlist: { isPlaylist: false } },
             initialPlayerState: {},
           }
         );
@@ -211,6 +237,10 @@ describe('StructuredNavigation component', () => {
     test('renders lock icon for inaccessible items', () => {
       expect(screen.queryAllByTestId('list-item')[0]).toHaveTextContent('Restricted Item');
       expect(screen.queryAllByTestId('list-item')[0].children[1]).toHaveClass('structure-item-locked');
+    });
+
+    test('does not render root Range', () => {
+      expect(screen.queryByText('Playlist Manifest')).toBeNull();
     });
 
     test('renders first item as active', () => {

--- a/src/components/StructuredNavigation/StructuredNavigation.test.js
+++ b/src/components/StructuredNavigation/StructuredNavigation.test.js
@@ -3,6 +3,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import StructuredNavigation from './StructuredNavigation';
 import manifestWoCanvasRefs from '@TestData/transcript-annotation';
 import manifest from '@TestData/lunchroom-manners';
+import singleCanvasManifest from '@TestData/single-canvas';
 import {
   withManifestProvider,
   withManifestAndPlayerProvider,
@@ -49,7 +50,10 @@ describe('StructuredNavigation component', () => {
       });
 
       test('renders successfully', () => {
-        expect(screen.getByTestId('structured-nav'));
+        expect(screen.queryByTestId('structured-nav'));
+        expect(screen.getByTestId('structured-nav')).toHaveClass(
+          'ramp--structured-nav ramp--structured-nav-with_root'
+        );
       });
 
       test('returns a List of items when structures are present in the manifest', () => {
@@ -102,28 +106,15 @@ describe('StructuredNavigation component', () => {
       });
 
       test('renders successfully', () => {
-        expect(screen.getByTestId('structured-nav'));
+        expect(screen.queryByTestId('structured-nav')).toBeInTheDocument();
       });
 
       test('returns a List of items when structures are present in the manifest', () => {
         expect(screen.getAllByTestId('list').length).toBeGreaterThan(0);
       });
 
-      test('renders root Range as a span', () => {
-        expect(screen.queryByText('Symphony no. 3 - Mahler, Gustav')).not.toBeNull();
-
-        const rootRange = screen.getAllByTestId('list-item')[0];
-        expect(rootRange.children[0]).toHaveTextContent(
-          'Symphony no. 3 - Mahler, Gustav'
-        );
-        expect(rootRange.children[0]).toHaveClass(
-          'ramp--structured-nav__section'
-        );
-        expect(rootRange.children[0].children[0].tagName).toBe('SPAN');
-      });
-
       test('first item is a section title as a span', () => {
-        const firstItem = screen.getAllByTestId('list-item')[1];
+        const firstItem = screen.getAllByTestId('list-item')[0];
         expect(firstItem.children[0]).toHaveTextContent(
           'CD1 - Mahler, Symphony No.3'
         );
@@ -131,6 +122,102 @@ describe('StructuredNavigation component', () => {
           'ramp--structured-nav__section'
         );
         expect(firstItem.children[0].children[0].tagName).toBe('SPAN');
+      });
+    });
+
+    describe('with structures with behavior=top in the root Range', () => {
+      beforeEach(() => {
+        const NavWithPlayer = withPlayerProvider(StructuredNavigation, {
+          initialState: {},
+        });
+        const NavWithManifest = withManifestProvider(NavWithPlayer, {
+          initialState: {
+            manifest: manifestWoCanvasRefs,
+            canvasIndex: 0,
+            canvasSegments: [],
+            playlist: { isPlaylist: false }
+          },
+        });
+        render(
+          <ErrorBoundary>
+            <NavWithManifest />
+          </ErrorBoundary>
+        );
+      });
+      test('renders successfully without root Range', () => {
+        expect(screen.queryByTestId('structured-nav'));
+        expect(screen.getByTestId('structured-nav')).toHaveClass(
+          'ramp--structured-nav'
+        );
+      });
+
+      test('returns a List of items when structures are present in the manifest', () => {
+        expect(screen.getAllByTestId('list').length).toBeGreaterThan(0);
+      });
+
+      test('does not render root Range with behavior set to top', () => {
+        expect(screen.queryByText('Symphony no. 3 - Mahler, Gustav')).toBeNull();
+      });
+
+      test('renders top Range\'s descendants as canvas items', () => {
+        const canvasItems = screen.queryAllByTestId('listitem-section');
+
+        expect(canvasItems).toHaveLength(2);
+        expect(canvasItems[0]).toHaveTextContent('CD1 - Mahler, Symphony No.3');
+      });
+    });
+
+    describe('with structures with root Range for a single Canvas', () => {
+      beforeEach(() => {
+        const NavWithPlayer = withPlayerProvider(StructuredNavigation, {
+          initialState: {},
+        });
+        const NavWithManifest = withManifestProvider(NavWithPlayer, {
+          initialState: {
+            manifest: singleCanvasManifest,
+            canvasIndex: 0,
+            canvasSegments: [],
+            playlist: { isPlaylist: false }
+          },
+        });
+        render(
+          <ErrorBoundary>
+            <NavWithManifest />
+          </ErrorBoundary>
+        );
+      });
+
+      test('renders successfully with root Range as a Canvas', () => {
+        expect(screen.queryByTestId('structured-nav'));
+        expect(screen.getByTestId('structured-nav')).toHaveClass(
+          'ramp--structured-nav'
+        );
+      });
+
+      test('returns a List of items when structures are present in the manifest', () => {
+        expect(screen.getAllByTestId('list').length).toBeGreaterThan(0);
+        expect(screen.queryAllByTestId('list-item')).toHaveLength(5);
+      });
+
+      test('renders root as a Canvas using a span', () => {
+        expect(screen.queryByText("Gaetano Donizetti, L'Elisir D'Amore")).not.toBeNull();
+
+        const canvasItem = screen.getAllByTestId('list-item')[0];
+        expect(canvasItem.children[0]).toHaveTextContent(
+          "Gaetano Donizetti, L'Elisir D'Amore"
+        );
+        expect(canvasItem.children[0]).toHaveClass(
+          'ramp--structured-nav__section active'
+        );
+        expect(canvasItem.children[0].children[0].tagName).toBe('SPAN');
+      });
+
+      test('renders root Range\'s descendants w/o Canvas refs as titles', () => {
+        const firstItem = screen.queryAllByTestId('list-item')[1];
+        expect(firstItem.children[0].tagName).toBe('SPAN');
+        expect(firstItem.children[0]).toHaveTextContent('Atto Primo');
+        // First title has 2 timespans nested within
+        expect(firstItem.children[1].children).toHaveLength(2);
       });
     });
 
@@ -226,6 +313,13 @@ describe('StructuredNavigation component', () => {
         <ErrorBoundary>
           <NavWithPlayerAndManifest />
         </ErrorBoundary>
+      );
+    });
+
+    test('renders successfully', () => {
+      expect(screen.queryByTestId('structured-nav'));
+      expect(screen.getByTestId('structured-nav')).toHaveClass(
+        'ramp--structured-nav playlist-items'
       );
     });
 

--- a/src/services/iiif-parser.js
+++ b/src/services/iiif-parser.js
@@ -590,8 +590,9 @@ export function parseAutoAdvance(manifest) {
  * @param {Boolean} isPlaylist
  * @returns {Object}
  *  obj.structures: a nested json object structure derived from
- * 'structures' property in the given Manifest
+ *    'structures' property in the given Manifest
  *  obj.timespans: timespan items linking to Canvas
+ *  obj.markRoot: display root Range in the UI
  */
 export function getStructureRanges(manifest, isPlaylist = false) {
   const canvasesInfo = canvasesInManifest(manifest);
@@ -681,7 +682,7 @@ export function getStructureRanges(manifest, isPlaylist = false) {
 
   const allRanges = parseManifest(manifest).getAllRanges();
   if (allRanges?.length === 0) {
-    return { structures: [], timespans: [] };
+    return { structures: [], timespans: [], markRoot: false };
   } else {
     const rootNode = allRanges[0];
     let structures = [];
@@ -711,6 +712,8 @@ export function getStructureRanges(manifest, isPlaylist = false) {
         structures.push(parseItem(rootNode, rootNode, cIndex));
       }
     }
-    return { structures, timespans };
+    // Mark root Range for a single-canvased Manifest
+    const markRoot = hasRoot && canvasesInfo?.length > 1;
+    return { structures, timespans, markRoot };
   }
 }

--- a/src/services/iiif-parser.test.js
+++ b/src/services/iiif-parser.test.js
@@ -579,19 +579,32 @@ describe('iiif-parser', () => {
   describe('getStructureRanges()', () => {
     it('returns parsed structures and timespans when structure is defined in manifest', () => {
       const { structures, timespans } = iiifParser.getStructureRanges(manifest);
-      expect(structures).toHaveLength(2);
-      expect(timespans).toHaveLength(16);
-      const firstStructCanvas = structures[0];
+      expect(structures).toHaveLength(1);
+      expect(timespans).toHaveLength(12);
+      const rootRange = structures[0];
+      expect(rootRange.label).toEqual('Symphony no. 3 - Mahler, Gustav');
+      expect(rootRange.items).toHaveLength(2);
+      expect(rootRange.isCanvas).toBeTruthy();
+      expect(rootRange.isEmpty).toBeFalsy();
+      expect(rootRange.isRoot).toBeTruthy();
+      expect(rootRange.isTitle).toBeTruthy();
+      expect(rootRange.rangeId).toEqual('https://example.com/sample/transcript-annotation/range/0');
+      expect(rootRange.id).toEqual(undefined);
+      expect(rootRange.isClickable).toBeFalsy();
+      expect(rootRange.duration).toEqual('42:37');
+      expect(rootRange.canvasDuration).toEqual(2557.034);
+
+      const firstStructCanvas = structures[0].items[0];
       expect(firstStructCanvas.label).toEqual('CD1 - Mahler, Symphony No.3');
-      expect(firstStructCanvas.items).toHaveLength(7);
+      expect(firstStructCanvas.items).toHaveLength(3);
       expect(firstStructCanvas.isCanvas).toBeTruthy();
       expect(firstStructCanvas.isEmpty).toBeFalsy();
       expect(firstStructCanvas.isTitle).toBeTruthy();
       expect(firstStructCanvas.rangeId).toEqual('https://example.com/sample/transcript-annotation/range/1');
       expect(firstStructCanvas.id).toEqual(undefined);
       expect(firstStructCanvas.isClickable).toBeFalsy();
-      expect(firstStructCanvas.duration).toEqual('33:05');
-      expect(firstStructCanvas.canvasDuration).toEqual(0);
+      expect(firstStructCanvas.duration).toEqual('09:32');
+      expect(firstStructCanvas.canvasDuration).toEqual(572.034);
 
       const firstTimespan = timespans[0];
       expect(firstTimespan.label).toEqual('Track 1. I. Kraftig');
@@ -606,33 +619,39 @@ describe('iiif-parser', () => {
       expect(firstTimespan.canvasDuration).toEqual(572.034);
     });
 
-    it('returns identical structures and timespans when structure is childless', () => {
+    it('returns empty structures and timespans when behavior is set to no-nav', () => {
       const { structures, timespans } = iiifParser.getStructureRanges(volleyballManifest);
-      expect(structures).toHaveLength(1);
-      expect(timespans).toHaveLength(1);
+      expect(structures).toHaveLength(0);
+      expect(timespans).toHaveLength(0);
+    });
 
-      const firstStructCanvas = structures[0];
-      expect(firstStructCanvas.label).toEqual('Volleyball for Boys');
+    it('returns identical structures and timespans when structure is childless', () => {
+      const { structures, timespans } = iiifParser.getStructureRanges(autoAdvanceManifest);
+      expect(structures).toHaveLength(1);
+      expect(timespans).toHaveLength(2);
+
+      const firstStructCanvas = structures[0].items[0];
+      expect(firstStructCanvas.label).toEqual('Atto Primo');
       expect(firstStructCanvas.items).toHaveLength(0);
       expect(firstStructCanvas.isCanvas).toBeTruthy();
       expect(firstStructCanvas.isEmpty).toBeFalsy();
       expect(firstStructCanvas.isTitle).toBeFalsy();
-      expect(firstStructCanvas.rangeId).toEqual('http://example.com/volleyball-for-boys/manifest/range/2');
-      expect(firstStructCanvas.id).toEqual('http://example.com/volleyball-for-boys/manifest/canvas/1#t=0,');
+      expect(firstStructCanvas.rangeId).toEqual('https://iiif.io/api/cookbook/recipe/0065-opera-multiple-canvases/range/2');
+      expect(firstStructCanvas.id).toEqual('https://iiif.io/api/cookbook/recipe/0065-opera-multiple-canvases/canvas/1#t=0,');
       expect(firstStructCanvas.isClickable).toBeTruthy();
-      expect(firstStructCanvas.duration).toEqual('11:02');
-      expect(firstStructCanvas.canvasDuration).toEqual(662.037);
+      expect(firstStructCanvas.duration).toEqual('01:06:11');
+      expect(firstStructCanvas.canvasDuration).toEqual(3971.24);
 
       const firstTimespan = timespans[0];
       expect(firstTimespan).toEqual(firstStructCanvas);
     });
 
-    it('returns mediafragment with only start time for sections with structure', () => {
+    it('returns mediafragment with only start time for structure item relevant to Canvas', () => {
       const { structures, timespans } = iiifParser.getStructureRanges(lunchroomManifest);
       expect(structures).toHaveLength(1);
       expect(timespans).toHaveLength(12);
 
-      const firstStructCanvas = structures[0];
+      const firstStructCanvas = structures[0].items[0];
       expect(firstStructCanvas.label).toEqual('Lunchroom Manners');
       expect(firstStructCanvas.items).toHaveLength(3);
       expect(firstStructCanvas.isCanvas).toBeTruthy();
@@ -652,7 +671,7 @@ describe('iiif-parser', () => {
     });
 
     it('returns canvas summary with structure for playist manifests', () => {
-      const { structures, timespans } = iiifParser.getStructureRanges(playlistManifest);
+      const { structures, timespans } = iiifParser.getStructureRanges(playlistManifest, true);
       expect(structures).toHaveLength(3);
       expect(timespans).toHaveLength(3);
 

--- a/src/services/iiif-parser.test.js
+++ b/src/services/iiif-parser.test.js
@@ -6,6 +6,7 @@ import singleSrcManifest from '@TestData/transcript-multiple-canvas';
 import autoAdvanceManifest from '@TestData/multiple-canvas-auto-advance';
 import playlistManifest from '@TestData/playlist';
 import emptyManifest from '@TestData/empty-manifest';
+import singleCanvasManifest from '@TestData/single-canvas';
 import * as iiifParser from './iiif-parser';
 import * as util from './utility-helpers';
 
@@ -578,23 +579,12 @@ describe('iiif-parser', () => {
 
   describe('getStructureRanges()', () => {
     it('returns parsed structures and timespans when structure is defined in manifest', () => {
-      const { structures, timespans } = iiifParser.getStructureRanges(manifest);
-      expect(structures).toHaveLength(1);
+      const { structures, timespans, markRoot } = iiifParser.getStructureRanges(manifest);
+      expect(structures).toHaveLength(2);
       expect(timespans).toHaveLength(12);
-      const rootRange = structures[0];
-      expect(rootRange.label).toEqual('Symphony no. 3 - Mahler, Gustav');
-      expect(rootRange.items).toHaveLength(2);
-      expect(rootRange.isCanvas).toBeTruthy();
-      expect(rootRange.isEmpty).toBeFalsy();
-      expect(rootRange.isRoot).toBeTruthy();
-      expect(rootRange.isTitle).toBeTruthy();
-      expect(rootRange.rangeId).toEqual('https://example.com/sample/transcript-annotation/range/0');
-      expect(rootRange.id).toEqual(undefined);
-      expect(rootRange.isClickable).toBeFalsy();
-      expect(rootRange.duration).toEqual('42:37');
-      expect(rootRange.canvasDuration).toEqual(2557.034);
+      expect(markRoot).toBeFalsy();
 
-      const firstStructCanvas = structures[0].items[0];
+      const firstStructCanvas = structures[0];
       expect(firstStructCanvas.label).toEqual('CD1 - Mahler, Symphony No.3');
       expect(firstStructCanvas.items).toHaveLength(3);
       expect(firstStructCanvas.isCanvas).toBeTruthy();
@@ -620,15 +610,17 @@ describe('iiif-parser', () => {
     });
 
     it('returns empty structures and timespans when behavior is set to no-nav', () => {
-      const { structures, timespans } = iiifParser.getStructureRanges(volleyballManifest);
+      const { structures, timespans, markRoot } = iiifParser.getStructureRanges(volleyballManifest);
       expect(structures).toHaveLength(0);
       expect(timespans).toHaveLength(0);
+      expect(markRoot).toBeFalsy();
     });
 
     it('returns identical structures and timespans when structure is childless', () => {
-      const { structures, timespans } = iiifParser.getStructureRanges(autoAdvanceManifest);
+      const { structures, timespans, markRoot } = iiifParser.getStructureRanges(autoAdvanceManifest);
       expect(structures).toHaveLength(1);
       expect(timespans).toHaveLength(2);
+      expect(markRoot).toBeTruthy();
 
       const firstStructCanvas = structures[0].items[0];
       expect(firstStructCanvas.label).toEqual('Atto Primo');
@@ -647,9 +639,10 @@ describe('iiif-parser', () => {
     });
 
     it('returns mediafragment with only start time for structure item relevant to Canvas', () => {
-      const { structures, timespans } = iiifParser.getStructureRanges(lunchroomManifest);
+      const { structures, timespans, markRoot } = iiifParser.getStructureRanges(lunchroomManifest);
       expect(structures).toHaveLength(1);
       expect(timespans).toHaveLength(12);
+      expect(markRoot).toBeTruthy();
 
       const firstStructCanvas = structures[0].items[0];
       expect(firstStructCanvas.label).toEqual('Lunchroom Manners');
@@ -664,16 +657,36 @@ describe('iiif-parser', () => {
       expect(firstStructCanvas.canvasDuration).toEqual(660);
     });
 
+    it('returns structure with root for a single canvas manifest', () => {
+      const { structures, timespans, markRoot } = iiifParser.getStructureRanges(singleCanvasManifest);
+      expect(structures).toHaveLength(1);
+      expect(timespans).toHaveLength(3);
+      expect(markRoot).toBeFalsy();
+
+      const firstStructCanvas = structures[0].items[0];
+      expect(firstStructCanvas.label).toEqual('Atto Primo');
+      expect(firstStructCanvas.items).toHaveLength(2);
+      expect(firstStructCanvas.isCanvas).toBeFalsy();
+      expect(firstStructCanvas.isEmpty).toBeFalsy();
+      expect(firstStructCanvas.isTitle).toBeTruthy();
+      expect(firstStructCanvas.rangeId).toEqual('http://example.com/single-canvas-manifest/range/2');
+      expect(firstStructCanvas.id).toBeUndefined();
+      expect(firstStructCanvas.isClickable).toBeFalsy();
+      expect(firstStructCanvas.canvasDuration).toEqual(7278.422);
+    });
+
     it('returns [] when structure is not present', () => {
-      const { structures, timespans } = iiifParser.getStructureRanges(manifestWoStructure);
+      const { structures, timespans, markRoot } = iiifParser.getStructureRanges(manifestWoStructure);
       expect(structures).toEqual([]);
       expect(timespans).toEqual([]);
+      expect(markRoot).toBeFalsy();
     });
 
     it('returns canvas summary with structure for playist manifests', () => {
-      const { structures, timespans } = iiifParser.getStructureRanges(playlistManifest, true);
+      const { structures, timespans, markRoot } = iiifParser.getStructureRanges(playlistManifest, true);
       expect(structures).toHaveLength(3);
       expect(timespans).toHaveLength(3);
+      expect(markRoot).toBeFalsy();
 
       const firstStructCanvas = structures[1];
       expect(firstStructCanvas.label).toEqual('Playlist Item 1');

--- a/src/test_data/multiple-canvas-auto-advance.js
+++ b/src/test_data/multiple-canvas-auto-advance.js
@@ -127,7 +127,6 @@ export default {
       type: 'AuthService0'
     }
   ],
-
   structures: [
     {
       type: 'Range',

--- a/src/test_data/multiple-canvas-auto-advance.js
+++ b/src/test_data/multiple-canvas-auto-advance.js
@@ -127,73 +127,36 @@ export default {
       type: 'AuthService0'
     }
   ],
+
   structures: [
     {
-      type: "Range",
-      id: "https://iiif.io/api/cookbook/recipe/0065-opera-multiple-canvases/range/1",
-      label: {
-        it: [
-          "Gaetano Donizetti, L'Elisir D'Amore"
-        ]
-      },
+      type: 'Range',
+      id: 'https://iiif.io/api/cookbook/recipe/0065-opera-multiple-canvases/range/1',
+      label: { it: ["Gaetano Donizetti, L'Elisir D'Amore"] },
       items: [
         {
-          type: "Range",
-          id: "https://iiif.io/api/cookbook/recipe/0065-opera-multiple-canvases/range/2",
-          label: {
-            en: [
-              "Atto Primo"
-            ]
-          },
+          type: 'Range',
+          id: 'https://iiif.io/api/cookbook/recipe/0065-opera-multiple-canvases/range/2',
+          label: { it: ['Atto Primo'] },
           items: [
             {
-              type: "Range",
-              id: "https://iiif.io/api/cookbook/recipe/0065-opera-multiple-canvases/range/3",
-              label: {
-                it: [
-                  "Preludio e Coro d'introduzione – Bel conforto al mietitore"
-                ]
-              },
-              items: [
-                {
-                  type: "Canvas",
-                  id: "https://iiif.io/api/cookbook/recipe/0065-opera-multiple-canvases/canvas/1#t=0,302.05"
-                }
-              ]
+              type: 'Canvas',
+              id: 'https://iiif.io/api/cookbook/recipe/0065-opera-multiple-canvases/canvas/1#t=0,',
             },
-            {
-              type: "Range",
-              id: "https://iiif.io/api/cookbook/recipe/0065-opera-multiple-canvases/range/4",
-              label: {
-                en: [
-                  "Remainder of Atto Primo"
-                ]
-              },
-              items: [
-                {
-                  type: "Canvas",
-                  id: "https://iiif.io/api/cookbook/recipe/0065-opera-multiple-canvases/canvas/1#t=302.05,3971.24"
-                }
-              ]
-            }
-          ]
+          ],
         },
         {
-          type: "Range",
-          id: "https://iiif.io/api/cookbook/recipe/0065-opera-multiple-canvases/range/5",
-          label: {
-            en: [
-              "Atto Secondo"
-            ]
-          },
+          type: 'Range',
+          id: 'https://iiif.io/api/cookbook/recipe/0065-opera-multiple-canvases/range/3',
+          label: { it: ['Atto Secondo'] },
           items: [
             {
-              type: "Canvas",
-              id: "https://iiif.io/api/cookbook/recipe/0065-opera-multiple-canvases/canvas/2#t=0,3307.22"
-            }
-          ]
-        }
-      ]
-    }
+              type: 'Canvas',
+              id: 'https://iiif.io/api/cookbook/recipe/0065-opera-multiple-canvases/canvas/2#t=0,',
+            },
+          ],
+        },
+      ],
+    },
   ]
 };

--- a/src/test_data/playlist.js
+++ b/src/test_data/playlist.js
@@ -322,8 +322,9 @@ export default {
     {
       id: 'http://example.com/playlists/1/range/0',
       type: 'Range',
-      behavior: 'top',
-      label: null,
+      label: {
+        en: ['Playlist Manifest'],
+      },
       items: [
         {
           id: 'http://example.com/playlists/1/range/1',

--- a/src/test_data/single-canvas.js
+++ b/src/test_data/single-canvas.js
@@ -1,0 +1,113 @@
+export default {
+  '@context': "http://iiif.io/api/presentation/3/context.json",
+  id: "http://example.com/single-canvas-manifest/manifest.json",
+  type: "Manifest",
+  label: {
+    it: [
+      "L'Elisir D'Amore"
+    ],
+    en: [
+      "The Elixir of Love"
+    ]
+  },
+  items: [
+    {
+      id: "http://example.com/single-canvas-manifest/canvas/1",
+      type: "Canvas",
+      width: 1920,
+      height: 1080,
+      duration: 7278.422,
+      items: [
+        {
+          id: "http://example.com/single-canvas-manifest/canvas/1/annotation_page/1",
+          type: "AnnotationPage",
+          items: [
+            {
+              id: "http://example.com/single-canvas-manifest/canvas/1/annotation_page/1/annotation/1",
+              type: "Annotation",
+              motivation: "painting",
+              target: "http://example.com/single-canvas-manifest/canvas/1",
+              body: {
+                id: "http://example.com/donizetti-elixir/low.mp4",
+                type: "Video",
+                format: "video/mp4",
+                height: 1080,
+                width: 1920,
+                duration: 7278.422
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  structures: [
+    {
+      type: "Range",
+      id: "http://example.com/single-canvas-manifest/range/1",
+      label: {
+        it: [
+          "Gaetano Donizetti, L'Elisir D'Amore"
+        ]
+      },
+      items: [
+        {
+          type: "Range",
+          id: "http://example.com/single-canvas-manifest/range/2",
+          label: {
+            it: [
+              "Atto Primo"
+            ]
+          },
+          items: [
+            {
+              type: "Range",
+              id: "http://example.com/single-canvas-manifest/range/3",
+              label: {
+                it: [
+                  "Preludio e Coro d'introduzione – Bel conforto al mietitore"
+                ]
+              },
+              items: [
+                {
+                  type: "Canvas",
+                  id: "http://example.com/single-canvas-manifest/canvas/1#t=0,302.05"
+                }
+              ]
+            },
+            {
+              type: "Range",
+              id: "http://example.com/single-canvas-manifest/range/4",
+              label: {
+                en: [
+                  "Remainder of Atto Primo"
+                ]
+              },
+              items: [
+                {
+                  type: "Canvas",
+                  id: "http://example.com/single-canvas-manifest/canvas/1#t=302.05,3971.24"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          type: "Range",
+          id: "http://example.com/single-canvas-manifest/range/5",
+          label: {
+            it: [
+              "Atto Secondo"
+            ]
+          },
+          items: [
+            {
+              type: "Canvas",
+              id: "http://example.com/single-canvas-manifest/canvas/1#t=3971.24"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};

--- a/src/test_data/transcript-annotation.js
+++ b/src/test_data/transcript-annotation.js
@@ -167,6 +167,7 @@ export default {
     {
       id: 'https://example.com/sample/transcript-annotation/range/0',
       type: 'Range',
+      behavior: 'top',
       label: {
         en: ['Symphony no. 3 - Mahler, Gustav'],
       },

--- a/src/test_data/transcript-annotation.js
+++ b/src/test_data/transcript-annotation.js
@@ -212,63 +212,11 @@ export default {
               },
               items: [
                 {
-                  id: 'https://example.com/sample/transcript-annotation/canvas/1#t=525,711',
+                  id: 'https://example.com/sample/transcript-annotation/canvas/1#t=525,572.034',
                   type: 'Canvas',
                 },
               ],
-            },
-            {
-              id: 'https://example.com/sample/transcript-annotation/range/1-4',
-              type: 'Range',
-              label: {
-                en: ['Track 4. Schwungvoll'],
-              },
-              items: [
-                {
-                  id: 'https://example.com/sample/transcript-annotation/canvas/1#t=711,1188',
-                  type: 'Canvas',
-                },
-              ],
-            },
-            {
-              id: 'https://example.com/sample/transcript-annotation/range/1-5',
-              type: 'Range',
-              label: {
-                en: ['Track 5. Immer dasselbe Tempo'],
-              },
-              items: [
-                {
-                  id: 'https://example.com/sample/transcript-annotation/canvas/1#t=1188,1406',
-                  type: 'Canvas',
-                },
-              ],
-            },
-            {
-              id: 'https://example.com/sample/transcript-annotation/range/1-6',
-              type: 'Range',
-              label: {
-                en: ['Track 6. Wie zu Anfang'],
-              },
-              items: [
-                {
-                  id: 'https://example.com/sample/transcript-annotation/canvas/1#t=1406,1693',
-                  type: 'Canvas',
-                },
-              ],
-            },
-            {
-              id: 'https://example.com/sample/transcript-annotation/range/1-7',
-              type: 'Range',
-              label: {
-                en: ['Track 7. Tempo I'],
-              },
-              items: [
-                {
-                  id: 'https://example.com/sample/transcript-annotation/canvas/1#t=1693,1985',
-                  type: 'Canvas',
-                },
-              ],
-            },
+            }
           ],
         },
         {


### PR DESCRIPTION
Related issue: #469 

With the changes to structure parsing structured navigation now looks as follows;

- Cookbook recipe with a single Canvas: [Table of Contents for Multiple A/V Files on a Single Canvas](https://iiif.io/api/cookbook/recipe/0064-opera-one-canvas/) and [Table of Contents for A/V Content](https://iiif.io/api/cookbook/recipe/0026-toc-opera/)

![Screenshot 2024-05-13 at 1 31 32 PM](https://github.com/samvera-labs/ramp/assets/1331659/76f63590-211f-4b78-8e52-47490cb1e34b)
- Cookbook recipe with multiple Canvases: [Table of Contents for Multiple A/V Files on Multiple Canvases](https://iiif.io/api/cookbook/recipe/0065-opera-multiple-canvases/) 

![Screenshot 2024-05-13 at 1 35 45 PM](https://github.com/samvera-labs/ramp/assets/1331659/bdc74ee5-e0b2-4999-9222-c4c7b4e558c9)
- Avalon manifest from [avalon-dev](https://avalon-dev.dlib.indiana.edu/media_objects/fn106x94r/)

![Screenshot 2024-05-13 at 1 36 31 PM](https://github.com/samvera-labs/ramp/assets/1331659/069f14c2-923e-4998-b4ab-7553090d4fce)
- Avalon playlist manifest from [avalon-dev](https://avalon-dev.dlib.indiana.edu/playlists/94/)

![Screenshot 2024-05-13 at 1 37 55 PM](https://github.com/samvera-labs/ramp/assets/1331659/0724c5a5-0995-4f7e-b6e6-ecce8b9ca937)
