### PR TITLE
Fix seeking in safari

### DIFF
--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -232,6 +232,8 @@ function VideoJSPlayer({
   };
 
   const updatePlayer = (player) => {
+    player.addClass('vjs-disabled');
+
     player.src(options.sources);
     player.poster(options.poster);
     player.canvasIndex = cIndexRef.current;
@@ -348,6 +350,8 @@ function VideoJSPlayer({
   const playerLoadedMetadata = (player) => {
     player.one('loadedmetadata', () => {
       videojs.log('Player loadedmetadata');
+
+      player.removeClass('vjs-disabled');
 
       player.duration(canvasDurationRef.current);
 
@@ -844,7 +848,7 @@ function VideoJSPlayer({
           data-testid={`videojs-${isVideo ? 'video' : 'audio'}-element`}
           data-canvasindex={cIndexRef.current}
           ref={videoJSRef}
-          className='video-js vjs-big-play-centered'
+          className='video-js vjs-big-play-centered vjs-disabled'
           onTouchStart={saveTouchStartCoords}
           onTouchEnd={mobilePlayToggle}
           style={{ display: `${canvasIsEmptyRef.current ? 'none' : ''}` }}

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -192,6 +192,9 @@ function VideoJSPlayer({
       // Update the existing Video.js player on consecutive Canvas changes
       const player = playerRef.current;
 
+      // Block player while metadata is loaded
+      player.addClass('vjs-disabled');
+
       setIsReady(false);
       updatePlayer(player);
       playerLoadedMetadata(player);
@@ -232,8 +235,6 @@ function VideoJSPlayer({
   };
 
   const updatePlayer = (player) => {
-    player.addClass('vjs-disabled');
-
     player.src(options.sources);
     player.poster(options.poster);
     player.canvasIndex = cIndexRef.current;
@@ -351,9 +352,10 @@ function VideoJSPlayer({
     player.one('loadedmetadata', () => {
       videojs.log('Player loadedmetadata');
 
-      player.removeClass('vjs-disabled');
-
       player.duration(canvasDurationRef.current);
+
+      // Reveal player once metadata is loaded
+      player.removeClass('vjs-disabled');
 
       isEndedRef.current ? player.currentTime(0) : player.currentTime(currentTime);
 

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -16,7 +16,7 @@ import {
   useManifestDispatch,
 } from '../../../context/manifest-context';
 import { checkSrcRange, getMediaFragment, playerHotKeys } from '@Services/utility-helpers';
-import { IS_ANDROID, IS_IOS, IS_IPAD, IS_MOBILE, IS_TOUCH_ONLY } from '@Services/browser';
+import { IS_ANDROID, IS_IOS, IS_IPAD, IS_MOBILE } from '@Services/browser';
 import { useLocalStorage } from '@Services/local-storage';
 
 /** VideoJS custom components */

--- a/src/components/MediaPlayer/VideoJS/components/styles/VideoJSProgress.scss
+++ b/src/components/MediaPlayer/VideoJS/components/styles/VideoJSProgress.scss
@@ -80,6 +80,10 @@
   z-index: 1001;
 }
 
+.vjs-custom-progress.is-safari::-webkit-slider-thumb {
+  margin-top: -0.25em;
+}
+
 // For Firefox browsers
 .vjs-custom-progress::-moz-range-thumb {
   -moz-appearance: none;

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -125,6 +125,10 @@ video/poster area the controls are displayed correctly. */
   scale: 2;
 }
 
+.vjs-disabled {
+  pointer-events: none;
+}
+
 /* Reduce media height to prevent media overlapping player boundaries */
 .video-js .vjs-tech {
   height: 99.75% !important;


### PR DESCRIPTION
Related issue: #494

Changes in the PR:
- Block player until `loadedmetadata` event is fired, so that the user cannot start scrubbing which can lead to player freeze
- Use a cancellable interval for time updates in Safari browsers