### PR TITLE
Update Node in Circle-CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,10 +6,10 @@ workflows:
   test-matrix:
     jobs:
       - node/test:
-          name: node-16
-          version: 16.10.0
+          name: node-20
+          version: 20.13.1
           pkg-manager: yarn
       - node/test:
-          name: node-14
-          version: 14.15.0
+          name: node-18
+          version: 18.20.0
           pkg-manager: yarn


### PR DESCRIPTION
Found that both node version in Ramp's CircleCI orb are EOL, when came across the failing tests in #505. 

So, this PR is to uppgrade Node in Circle-CI from node 14 and 16 to 18 (EOL: April 2025 according to https://endoflife.date/nodejs) and 20.

I first tried bumping up to Node 21, which failed because of [`node-sass`](https://www.npmjs.com/package/node-sass) being deprecated.
