### PR TITLE
Fix a couple of minor bugs

### DIFF
--- a/src/components/MediaPlayer/VideoJS/components/js/VideoJSTrackScrubber.js
+++ b/src/components/MediaPlayer/VideoJS/components/js/VideoJSTrackScrubber.js
@@ -215,14 +215,9 @@ function TrackScrubberButton({ player, trackScrubberRef, timeToolRef, isPlaylist
       In playlists, markers are timepoint information representing highlighting annotations, 
       therefore omit reading markers information for track scrubber in playlist contexts. 
     */
-    if (player.markers && typeof player.markers !== 'function' && !isPlaylist) {
-      const markers = player.markers.getMarkers();
-      if (markers.length) {
-        const track = markers.filter(m => m.class == 'ramp--track-marker--fragment');
-        if (track?.length > 0 && track[0].key !== currentTrack?.key) {
-          setCurrentTrack(track[0]);
-        }
-      }
+    if (player.markers && typeof player.markers !== 'function' && typeof player.markers.getMarkers === 'function'
+      && player.markers.getMarkers()?.length > 0 && !isPlaylist) {
+      readPlayerMarkers();
     }
     /*
       When playhead is outside a time range marker (track) or in playlist contexts, display 
@@ -278,12 +273,9 @@ function TrackScrubberButton({ player, trackScrubberRef, timeToolRef, isPlaylist
    */
   const updateTrackScrubberProgressBar = (currentTime, player) => {
     // Handle Safari which emits the timeupdate event really quickly
-    if (!currentTrackRef.current) {
-      if (player.markers && player.markers.getMarkers()?.length > 0) {
-        const track = player.markers.getMarkers()[0];
-        if (track.key != currentTrack?.key) {
-          setCurrentTrack(track);
-        }
+    if (!currentTrackRef.current || currentTrackRef.current === undefined) {
+      if (player.markers && typeof player.markers.getMarkers === 'function') {
+        readPlayerMarkers();
       }
     }
 
@@ -298,6 +290,13 @@ function TrackScrubberButton({ player, trackScrubberRef, timeToolRef, isPlaylist
     );
 
     populateTrackScrubber(trackoffset, trackpercent);
+  };
+
+  const readPlayerMarkers = () => {
+    const tracks = player.markers.getMarkers().filter(m => m.class == 'ramp--track-marker--fragment');
+    if (tracks?.length > 0 && tracks[0].key != currentTrack?.key) {
+      setCurrentTrack(tracks[0]);
+    }
   };
 
   /**

--- a/src/services/iiif-parser.js
+++ b/src/services/iiif-parser.js
@@ -365,7 +365,7 @@ export function getCustomStart(manifest, startCanvasId, startCanvasTime) {
   const canvases = canvasesInManifest(manifest);
   // Map given information in start property or user props to
   // Canvas information in the given Manifest
-  let getCanvasInfo = (canvasId, time) => {
+  let getCanvasInfo = (canvasId, type, time) => {
     let startTime = time;
     let currentIndex;
 
@@ -385,7 +385,7 @@ export function getCustomStart(manifest, startCanvasId, startCanvasTime) {
         return { currentIndex: 0, startTime: 0 };
       } else {
         const currentCanvas = canvases[currentIndex];
-        if (currentCanvas.range != undefined) {
+        if (currentCanvas.range != undefined && type === 'SpecificResource') {
           const { start, end } = currentCanvas.range;
           if (!(time >= start && time <= end)) {
             console.error(
@@ -407,11 +407,11 @@ export function getCustomStart(manifest, startCanvasId, startCanvasTime) {
   if (startProp != undefined) {
     switch (startProp.type) {
       case 'Canvas':
-        let canvasInfo = getCanvasInfo(startProp.id, 0);
+        let canvasInfo = getCanvasInfo(startProp.id, startProp.type, 0);
         return { type: 'C', canvas: canvasInfo.currentIndex, time: canvasInfo.startTime };
       case 'SpecificResource':
         let customStart = startProp.selector.t;
-        canvasInfo = getCanvasInfo(startProp.source, customStart);
+        canvasInfo = getCanvasInfo(startProp.source, startProp.type, customStart);
         return { type: 'SR', canvas: canvasInfo.currentIndex, time: canvasInfo.startTime };
     }
   }


### PR DESCRIPTION
Fixes the following bugs;
1. Player marker filtering bug in track scrubber with the addition of transcript search hit markers on the progress bar. The player crashes when switching from a Canvas without structure to a Canvas without structure, because `currentTrackRef` variable in track scrubber component is not getting setup properly. This is a regression of the work done in #497.
2. Avoid unnecessary `console.error` message in the console when using `startCanvasId` prop without specifying a value for `startCanvasTime` prop when Ramp is initialized.