### PR TITLE
Fix a couple of demo data bugs

### DIFF
--- a/public/manifests/dev/lunchroom_manners.json
+++ b/public/manifests/dev/lunchroom_manners.json
@@ -453,10 +453,6 @@
           },
           "items": [
             {
-              "id": "http://localhost:3003/dev/lunchroom_manners/canvas/1#t=0,572.034",
-              "type": "Canvas"
-            },
-            {
               "id": "http://localhost:3003/dev/lunchroom_manners/range/1-1",
               "type": "Range",
               "label": {

--- a/public/manifests/dev/playlist-manifest.json
+++ b/public/manifests/dev/playlist-manifest.json
@@ -76,7 +76,7 @@
                     }
                   },
                   {
-                    "id": "http://localhost:3003/lunchroom_manners/low/lunchroom_manners_1024kb.mp4#t=0.0,572.0",
+                    "id": "http://localhost:3003/lunchroom_manners/high/lunchroom_manners_1024kb.mp4#t=0.0,572.0",
                     "type": "Video",
                     "height": 360,
                     "width": 480,
@@ -109,7 +109,7 @@
                 "value": "Marker 1"
               },
               "id": "http://localhost:3003/avalon_marker/35",
-              "target": "http://localhost:3003/playlists/5/manifest/canvas/46#t=2.836"
+              "target": "http://localhost:3003/playlists/5/manifest/canvas/46#t=369.811"
             },
             {
               "type": "Annotation",
@@ -121,7 +121,7 @@
                 "value": "Marker 2"
               },
               "id": "http://localhost:3003/avalon_marker/54",
-              "target": "http://localhost:3003/playlists/5/manifest/canvas/5#t=369.811"
+              "target": "http://localhost:3003/playlists/5/manifest/canvas/5#t=430.236"
             }
           ]
         }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -74,6 +74,10 @@
   width: 8em !important;
 }
 
+.vjs-slider-horizontal .vjs-volume-level .vjs-svg-icon {
+  margin-top: 0.1em;
+}
+
 /* Make player height minimum to the controls height so when we hide
 video/poster area the controls are displayed correctly. */
 .video-js.vjs-audio {


### PR DESCRIPTION
Fixes the following;
- resource URL of one of the canvases in the sample manifest for playlist in demo app
- remove canvas reference for first structure item in the demo manifest, since it uses the display with root range
- update CSS for thumb of the horizontal volume panel