### PR TITLE
Render time offsets for cues that begin exactly at 0

### DIFF
--- a/src/components/Transcript/Transcript.js
+++ b/src/components/Transcript/Transcript.js
@@ -114,7 +114,7 @@ const TranscriptLine = ({
           isFocused && 'focused'
         )}
       >
-        {item.begin && (
+        {typeof item.begin === 'number' && (
           <span
             className="ramp--transcript_time"
             data-testid="transcript_time"


### PR DESCRIPTION
In Javascript 0 evaluates to false so a begin time of 0 skips rendering the time span by accident.  I switched the guard to check that the typeof the begin time is a number.

```
0 && true // => 0
20 && true // => true
typeof 0 // => 'number'
typeof 0 === 'number' && true // => true
```

Resolves #500 