### PR TITLE
Display previous/next buttons and timer for inaccessible canvases

### DIFF
--- a/src/components/MediaPlayer/MediaPlayer.js
+++ b/src/components/MediaPlayer/MediaPlayer.js
@@ -285,6 +285,11 @@ const MediaPlayer = ({
     }
   };
 
+  const cancelDisplayTimer = () => {
+    clearCanvasMessageTimer();
+    manifestDispatch({ autoAdvance: false, type: "setAutoAdvance" });
+  };
+
   /**
    * Switch player when navigating across canvases
    * @param {Number} index canvas index to be loaded into the player
@@ -443,6 +448,7 @@ const MediaPlayer = ({
           placeholderText={playerConfig.error}
           renderingFiles={renderingFiles}
           enableFileDownload={enableFileDownload}
+          cancelAutoAdvance={cancelDisplayTimer}
           options={options}
         />
       </div>

--- a/src/components/MediaPlayer/MediaPlayer.js
+++ b/src/components/MediaPlayer/MediaPlayer.js
@@ -293,7 +293,7 @@ const MediaPlayer = ({
    * @param {String} focusElement element to be focused within the player when using
    * next or previous buttons with keyboard
    */
-  const switchPlayer = (index, fromStart, checkAutoAdvance = false, focusElement = '') => {
+  const switchPlayer = (index, fromStart, focusElement = '', checkAutoAdvance = false) => {
     if (canvasIndexRef.current != index && index <= lastCanvasIndexRef.current) {
       if (!checkAutoAdvance || (checkAutoAdvance && autoAdvanceRef.current)) {
         manifestDispatch({

--- a/src/components/MediaPlayer/MediaPlayer.js
+++ b/src/components/MediaPlayer/MediaPlayer.js
@@ -289,18 +289,15 @@ const MediaPlayer = ({
    * Switch player when navigating across canvases
    * @param {Number} index canvas index to be loaded into the player
    * @param {Boolean} fromStart flag to indicate set player start time to zero or not
-   * @param {Boolean} checkAutoAdvance flag to indicate to check value of autoadvance in state
    * @param {String} focusElement element to be focused within the player when using
    * next or previous buttons with keyboard
    */
-  const switchPlayer = (index, fromStart, focusElement = '', checkAutoAdvance = false) => {
+  const switchPlayer = (index, fromStart, focusElement = '') => {
     if (canvasIndexRef.current != index && index <= lastCanvasIndexRef.current) {
-      if (!checkAutoAdvance || (checkAutoAdvance && autoAdvanceRef.current)) {
-        manifestDispatch({
-          canvasIndex: index,
-          type: 'switchCanvas',
-        });
-      }
+      manifestDispatch({
+        canvasIndex: index,
+        type: 'switchCanvas',
+      });
       initCanvas(index, fromStart);
       playerDispatch({ element: focusElement, type: 'setPlayerFocusElement' });
     }
@@ -354,9 +351,8 @@ const MediaPlayer = ({
             duration: canvasDuration,
             srcIndex,
             targets,
-            currentTime: currentTimeRef.current || 0,
-            nextItemClicked,
-            switchPlayer
+            currentTime: currentTime || 0,
+            nextItemClicked
           },
           videoJSCurrentTime: { srcIndex, targets, currentTime: currentTime || 0 },
         },

--- a/src/components/MediaPlayer/MediaPlayer.js
+++ b/src/components/MediaPlayer/MediaPlayer.js
@@ -285,11 +285,6 @@ const MediaPlayer = ({
     }
   };
 
-  const cancelDisplayTimer = () => {
-    clearCanvasMessageTimer();
-    manifestDispatch({ autoAdvance: false, type: "setAutoAdvance" });
-  };
-
   /**
    * Switch player when navigating across canvases
    * @param {Number} index canvas index to be loaded into the player
@@ -448,7 +443,8 @@ const MediaPlayer = ({
           placeholderText={playerConfig.error}
           renderingFiles={renderingFiles}
           enableFileDownload={enableFileDownload}
-          cancelAutoAdvance={cancelDisplayTimer}
+          loadPrevOrNext={switchPlayer}
+          lastCanvasIndex={lastCanvasIndex}
           options={options}
         />
       </div>

--- a/src/components/MediaPlayer/MediaPlayer.test.js
+++ b/src/components/MediaPlayer/MediaPlayer.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { withManifestAndPlayerProvider } from '../../services/testing-helpers';
 import MediaPlayer from './MediaPlayer';
 import { ErrorBoundary } from 'react-error-boundary';
@@ -182,137 +182,141 @@ describe('MediaPlayer component', () => {
     });
   });
 
-  describe('does not render previous/next section buttons', () => {
-    test('with a single Canvas Manifest', () => {
-      const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
-        initialManifestState: { ...manifestState, manifest: audioManifest, canvasIndex: 0 },
-        initialPlayerState: {},
+  describe('previous/next section buttons', () => {
+    describe('renders', () => {
+      test('with a multi-Canvas regualr Manifest', async () => {
+        const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
+          initialManifestState: { ...manifestState, manifest: videoManifest, canvasIndex: 0 },
+          initialPlayerState: {},
+        });
+        await act(async () => render(
+          <ErrorBoundary>
+            <PlayerWithManifest />
+          </ErrorBoundary>
+        ));
+        expect(screen.queryByTestId('videojs-next-button')).toBeInTheDocument();
+        expect(screen.queryByTestId('videojs-previous-button')).toBeInTheDocument();
       });
-      render(
-        <ErrorBoundary>
-          <PlayerWithManifest />
-        </ErrorBoundary>
-      );
-      expect(screen.queryByTestId('videojs-next-button')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('videojs-previous-button')).not.toBeInTheDocument();
-    });
 
-    test('with a single Canvas with multiple sources', () => {
-      const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
-        initialManifestState: { ...manifestState, manifest: audioManifest, canvasIndex: 0 },
-        initialPlayerState: {},
-      });
-      render(
-        <ErrorBoundary>
-          <PlayerWithManifest />
-        </ErrorBoundary>
-      );
-      expect(screen.queryByTestId('videojs-next-button')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('videojs-previous-button')).not.toBeInTheDocument();
-    });
-
-  });
-
-  describe('renders previous/next section buttons', () => {
-    test('with a multi-Canvas regualr Manifest', async () => {
-      const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
-        initialManifestState: { ...manifestState, manifest: videoManifest, canvasIndex: 0 },
-        initialPlayerState: {},
-      });
-      await act(async () => render(
-        <ErrorBoundary>
-          <PlayerWithManifest />
-        </ErrorBoundary>
-      ));
-      expect(screen.queryByTestId('videojs-next-button')).toBeInTheDocument();
-      expect(screen.queryByTestId('videojs-previous-button')).toBeInTheDocument();
-    });
-
-    test('with a multi-Canvas playlist Manifest', async () => {
-      const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
-        initialManifestState: {
-          manifest: playlistManifest,
-          canvasIndex: 1,
-          playlist: { isPlaylist: true }
-        },
-        initialPlayerState: {},
-      });
-      await act(async () => render(
-        <ErrorBoundary>
-          <PlayerWithManifest />
-        </ErrorBoundary>
-      ));
-      expect(screen.queryByTestId('videojs-previous-button')).toBeInTheDocument();
-      expect(screen.queryByTestId('videojs-next-button')).toBeInTheDocument();
-    });
-  });
-
-  describe('renders captions button', () => {
-    test('with a video canvas with supplementing annotations', async () => {
-      const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
-        initialManifestState: { ...manifestState, manifest: videoManifest, canvasIndex: 0 },
-        initialPlayerState: {},
-      });
-      render(
-        <ErrorBoundary>
-          <PlayerWithManifest />
-        </ErrorBoundary>
-      );
-      expect(
-        screen.queryAllByTestId('videojs-video-element').length
-      ).toBeGreaterThan(0);
-      await waitFor(() => {
-        expect(screen.queryByTitle('Captions')).toBeInTheDocument();
+      test('with a multi-Canvas playlist Manifest', async () => {
+        const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
+          initialManifestState: {
+            manifest: playlistManifest,
+            canvasIndex: 1,
+            playlist: { isPlaylist: true }
+          },
+          initialPlayerState: {},
+        });
+        await act(async () => render(
+          <ErrorBoundary>
+            <PlayerWithManifest />
+          </ErrorBoundary>
+        ));
+        expect(screen.queryByTestId('videojs-previous-button')).toBeInTheDocument();
+        expect(screen.queryByTestId('videojs-next-button')).toBeInTheDocument();
       });
     });
 
-    test('with a video canvas with supplementing annotations in playlist context', async () => {
-      const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
-        initialManifestState: { ...manifestState, manifest: playlistManifest, canvasIndex: 3 },
-        initialPlayerState: {},
+    describe('does not render', () => {
+      test('with a single Canvas Manifest', () => {
+        const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
+          initialManifestState: { ...manifestState, manifest: audioManifest, canvasIndex: 0 },
+          initialPlayerState: {},
+        });
+        render(
+          <ErrorBoundary>
+            <PlayerWithManifest />
+          </ErrorBoundary>
+        );
+        expect(screen.queryByTestId('videojs-next-button')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('videojs-previous-button')).not.toBeInTheDocument();
       });
-      render(
-        <ErrorBoundary>
-          <PlayerWithManifest />
-        </ErrorBoundary>
-      );
-      expect(
-        screen.queryAllByTestId('videojs-video-element').length
-      ).toBeGreaterThan(0);
-      await waitFor(() => {
-        expect(screen.queryByTitle('Captions')).toBeInTheDocument();
+
+      test('with a single Canvas with multiple sources', () => {
+        const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
+          initialManifestState: { ...manifestState, manifest: audioManifest, canvasIndex: 0 },
+          initialPlayerState: {},
+        });
+        render(
+          <ErrorBoundary>
+            <PlayerWithManifest />
+          </ErrorBoundary>
+        );
+        expect(screen.queryByTestId('videojs-next-button')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('videojs-previous-button')).not.toBeInTheDocument();
       });
+
     });
   });
 
-  describe('does not render captions button', () => {
-    test('with an audio canvas', () => {
-      const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
-        initialManifestState: { ...manifestState, manifest: audioManifest, canvasIndex: 0 },
-        initialPlayerState: {},
+  describe('captions button', () => {
+    describe('renders', () => {
+      test('with a video canvas with supplementing annotations', async () => {
+        const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
+          initialManifestState: { ...manifestState, manifest: videoManifest, canvasIndex: 0 },
+          initialPlayerState: {},
+        });
+        render(
+          <ErrorBoundary>
+            <PlayerWithManifest />
+          </ErrorBoundary>
+        );
+        expect(
+          screen.queryAllByTestId('videojs-video-element').length
+        ).toBeGreaterThan(0);
+        await waitFor(() => {
+          expect(screen.queryByTitle('Captions')).toBeInTheDocument();
+        });
       });
-      render(
-        <ErrorBoundary>
-          <PlayerWithManifest />
-        </ErrorBoundary>
-      );
-      expect(screen.queryByTitle('Captions')).not.toBeInTheDocument();
+
+      test('with a video canvas with supplementing annotations in playlist context', async () => {
+        const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
+          initialManifestState: { ...manifestState, manifest: playlistManifest, canvasIndex: 3 },
+          initialPlayerState: {},
+        });
+        render(
+          <ErrorBoundary>
+            <PlayerWithManifest />
+          </ErrorBoundary>
+        );
+        expect(
+          screen.queryAllByTestId('videojs-video-element').length
+        ).toBeGreaterThan(0);
+        await waitFor(() => {
+          expect(screen.queryByTitle('Captions')).toBeInTheDocument();
+        });
+      });
     });
 
-    test('with a video canvas w/o supplementing annotations', () => {
-      const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
-        initialManifestState: { ...manifestState, manifest: noCaptionManifest, canvasIndex: 0 },
-        initialPlayerState: {},
+    describe('does not render', () => {
+      test('with an audio canvas', () => {
+        const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
+          initialManifestState: { ...manifestState, manifest: audioManifest, canvasIndex: 0 },
+          initialPlayerState: {},
+        });
+        render(
+          <ErrorBoundary>
+            <PlayerWithManifest />
+          </ErrorBoundary>
+        );
+        expect(screen.queryByTitle('Captions')).not.toBeInTheDocument();
       });
-      render(
-        <ErrorBoundary>
-          <PlayerWithManifest />
-        </ErrorBoundary>
-      );
-      expect(
-        screen.queryAllByTestId('videojs-video-element').length
-      ).toBeGreaterThan(0);
-      expect(screen.queryByTitle('Captions')).not.toBeInTheDocument();
+
+      test('with a video canvas w/o supplementing annotations', () => {
+        const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
+          initialManifestState: { ...manifestState, manifest: noCaptionManifest, canvasIndex: 0 },
+          initialPlayerState: {},
+        });
+        render(
+          <ErrorBoundary>
+            <PlayerWithManifest />
+          </ErrorBoundary>
+        );
+        expect(
+          screen.queryAllByTestId('videojs-video-element').length
+        ).toBeGreaterThan(0);
+        expect(screen.queryByTitle('Captions')).not.toBeInTheDocument();
+      });
     });
   });
 
@@ -391,7 +395,7 @@ describe('MediaPlayer component', () => {
         </ErrorBoundary>
       );
       expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
-      expect(screen.getByTestId('inaccessible-message-display').textContent)
+      expect(screen.getByTestId('inaccessible-message-content').textContent)
         .toEqual('You do not have permission to playback this item. \nPlease ' +
           'contact support to report this error: admin-list@example.com.\n');
     });
@@ -415,6 +419,59 @@ describe('MediaPlayer component', () => {
       );
       expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
       expect(screen.getByText('You do not have permission to playback this item.')).toBeInTheDocument();
+    });
+
+    test('with displays timer and previous/next buttons', () => {
+      // Stub loading HTMLMediaElement for jsdom
+      window.HTMLMediaElement.prototype.load = () => { };
+
+      const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
+        initialManifestState: {
+          manifest: playlistManifest,
+          canvasIndex: 0,
+          playlist: { isPlaylist: true }
+        },
+        initialPlayerState: {},
+      });
+      render(
+        <ErrorBoundary>
+          <PlayerWithManifest />
+        </ErrorBoundary>
+      );
+      expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
+      expect(screen.getByText('You do not have permission to playback this item.')).toBeInTheDocument();
+      expect(screen.queryByTestId('inaccessible-message-timer')).toBeInTheDocument();
+      expect(screen.queryByTestId('inaccessible-next-button')).toBeInTheDocument();
+      // Does not display previous button for first item
+      expect(screen.queryByTestId('inaccessible-previous-button')).not.toBeInTheDocument();
+    });
+
+    test('enables navigation to next item with next button', () => {
+      // Stub loading HTMLMediaElement for jsdom
+      window.HTMLMediaElement.prototype.load = () => { };
+
+      const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
+        initialManifestState: {
+          manifest: playlistManifest,
+          canvasIndex: 0,
+          playlist: { isPlaylist: true }
+        },
+        initialPlayerState: {},
+      });
+      render(
+        <ErrorBoundary>
+          <PlayerWithManifest />
+        </ErrorBoundary>
+      );
+      expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
+      expect(screen.getByText('You do not have permission to playback this item.')).toBeInTheDocument();
+      expect(screen.queryByTestId('inaccessible-message-timer')).toBeInTheDocument();
+      expect(screen.queryByTestId('inaccessible-next-button')).toBeInTheDocument();
+      fireEvent.click(screen.getByTestId('inaccessible-next-button'));
+      // Loads video player for the next item in the list
+      expect(
+        screen.queryAllByTestId('videojs-video-element').length
+      ).toBeGreaterThan(0);
     });
   });
 

--- a/src/components/MediaPlayer/MediaPlayer.test.js
+++ b/src/components/MediaPlayer/MediaPlayer.test.js
@@ -421,57 +421,118 @@ describe('MediaPlayer component', () => {
       expect(screen.getByText('You do not have permission to playback this item.')).toBeInTheDocument();
     });
 
-    test('with displays timer and previous/next buttons', () => {
-      // Stub loading HTMLMediaElement for jsdom
-      window.HTMLMediaElement.prototype.load = () => { };
+    describe('with auto-advance turned on', () => {
+      test('displays timer and previous/next buttons', () => {
+        // Stub loading HTMLMediaElement for jsdom
+        window.HTMLMediaElement.prototype.load = () => { };
 
-      const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
-        initialManifestState: {
-          manifest: playlistManifest,
-          canvasIndex: 0,
-          playlist: { isPlaylist: true }
-        },
-        initialPlayerState: {},
+        const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
+          initialManifestState: {
+            manifest: playlistManifest,
+            canvasIndex: 0,
+            playlist: { isPlaylist: true },
+            autoAdvance: true,
+          },
+          initialPlayerState: {},
+        });
+        render(
+          <ErrorBoundary>
+            <PlayerWithManifest />
+          </ErrorBoundary>
+        );
+        expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
+        expect(screen.getByText('You do not have permission to playback this item.')).toBeInTheDocument();
+        expect(screen.queryByTestId('inaccessible-message-timer')).toBeInTheDocument();
+        expect(screen.queryByTestId('inaccessible-next-button')).toBeInTheDocument();
+        // Does not display previous button for first item
+        expect(screen.queryByTestId('inaccessible-previous-button')).not.toBeInTheDocument();
       });
-      render(
-        <ErrorBoundary>
-          <PlayerWithManifest />
-        </ErrorBoundary>
-      );
-      expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
-      expect(screen.getByText('You do not have permission to playback this item.')).toBeInTheDocument();
-      expect(screen.queryByTestId('inaccessible-message-timer')).toBeInTheDocument();
-      expect(screen.queryByTestId('inaccessible-next-button')).toBeInTheDocument();
-      // Does not display previous button for first item
-      expect(screen.queryByTestId('inaccessible-previous-button')).not.toBeInTheDocument();
+
+      test('enables navigation to next item with next button', () => {
+        // Stub loading HTMLMediaElement for jsdom
+        window.HTMLMediaElement.prototype.load = () => { };
+
+        const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
+          initialManifestState: {
+            manifest: playlistManifest,
+            canvasIndex: 0,
+            playlist: { isPlaylist: true },
+            autoAdvance: true,
+          },
+          initialPlayerState: {},
+        });
+        render(
+          <ErrorBoundary>
+            <PlayerWithManifest />
+          </ErrorBoundary>
+        );
+        expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
+        expect(screen.getByText('You do not have permission to playback this item.')).toBeInTheDocument();
+        expect(screen.queryByTestId('inaccessible-message-timer')).toBeInTheDocument();
+        expect(screen.queryByTestId('inaccessible-next-button')).toBeInTheDocument();
+        fireEvent.click(screen.getByTestId('inaccessible-next-button'));
+        // Loads video player for the next item in the list
+        expect(
+          screen.queryAllByTestId('videojs-video-element').length
+        ).toBeGreaterThan(0);
+      });
     });
 
-    test('enables navigation to next item with next button', () => {
-      // Stub loading HTMLMediaElement for jsdom
-      window.HTMLMediaElement.prototype.load = () => { };
+    describe('with auto-advance turned off', () => {
+      test('dim the display timer', () => {
+        // Stub loading HTMLMediaElement for jsdom
+        window.HTMLMediaElement.prototype.load = () => { };
 
-      const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
-        initialManifestState: {
-          manifest: playlistManifest,
-          canvasIndex: 0,
-          playlist: { isPlaylist: true }
-        },
-        initialPlayerState: {},
+        const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
+          initialManifestState: {
+            manifest: playlistManifest,
+            canvasIndex: 0,
+            playlist: { isPlaylist: true },
+            autoAdvance: false,
+          },
+          initialPlayerState: {},
+        });
+        render(
+          <ErrorBoundary>
+            <PlayerWithManifest />
+          </ErrorBoundary>
+        );
+        expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
+        expect(screen.getByText('You do not have permission to playback this item.')).toBeInTheDocument();
+        expect(screen.queryByTestId('inaccessible-message-timer')).toBeInTheDocument();
+        expect(screen.getByTestId('inaccessible-message-timer')).toHaveClass('disabled');
+        expect(screen.queryByTestId('inaccessible-next-button')).toBeInTheDocument();
       });
-      render(
-        <ErrorBoundary>
-          <PlayerWithManifest />
-        </ErrorBoundary>
-      );
-      expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
-      expect(screen.getByText('You do not have permission to playback this item.')).toBeInTheDocument();
-      expect(screen.queryByTestId('inaccessible-message-timer')).toBeInTheDocument();
-      expect(screen.queryByTestId('inaccessible-next-button')).toBeInTheDocument();
-      fireEvent.click(screen.getByTestId('inaccessible-next-button'));
-      // Loads video player for the next item in the list
-      expect(
-        screen.queryAllByTestId('videojs-video-element').length
-      ).toBeGreaterThan(0);
+
+      test('enables navigation to next item with next button', () => {
+        // Stub loading HTMLMediaElement for jsdom
+        window.HTMLMediaElement.prototype.load = () => { };
+
+        const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
+          initialManifestState: {
+            manifest: playlistManifest,
+            canvasIndex: 0,
+            playlist: { isPlaylist: true },
+            autoAdvance: false,
+          },
+          initialPlayerState: {},
+        });
+        render(
+          <ErrorBoundary>
+            <PlayerWithManifest />
+          </ErrorBoundary>
+        );
+        expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
+        expect(screen.getByText('You do not have permission to playback this item.')).toBeInTheDocument();
+        expect(screen.queryByTestId('inaccessible-message-timer')).toBeInTheDocument();
+        expect(screen.getByTestId('inaccessible-message-timer')).toHaveClass('disabled');
+        expect(screen.queryByTestId('inaccessible-next-button')).toBeInTheDocument();
+        fireEvent.click(screen.getByTestId('inaccessible-next-button'));
+        // Loads video player for the next item in the list
+        expect(
+          screen.queryAllByTestId('videojs-video-element').length
+        ).toBeGreaterThan(0);
+      });
     });
   });
 

--- a/src/components/MediaPlayer/MediaPlayer.test.js
+++ b/src/components/MediaPlayer/MediaPlayer.test.js
@@ -500,7 +500,7 @@ describe('MediaPlayer component', () => {
         expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
         expect(screen.getByText('You do not have permission to playback this item.')).toBeInTheDocument();
         expect(screen.queryByTestId('inaccessible-message-timer')).toBeInTheDocument();
-        expect(screen.getByTestId('inaccessible-message-timer')).toHaveClass('disabled');
+        expect(screen.getByTestId('inaccessible-message-timer')).toHaveClass('hidden');
         expect(screen.queryByTestId('inaccessible-next-button')).toBeInTheDocument();
       });
 
@@ -525,7 +525,7 @@ describe('MediaPlayer component', () => {
         expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
         expect(screen.getByText('You do not have permission to playback this item.')).toBeInTheDocument();
         expect(screen.queryByTestId('inaccessible-message-timer')).toBeInTheDocument();
-        expect(screen.getByTestId('inaccessible-message-timer')).toHaveClass('disabled');
+        expect(screen.getByTestId('inaccessible-message-timer')).toHaveClass('hidden');
         expect(screen.queryByTestId('inaccessible-next-button')).toBeInTheDocument();
         fireEvent.click(screen.getByTestId('inaccessible-next-button'));
         // Loads video player for the next item in the list

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -876,15 +876,27 @@ function VideoJSPlayer({
               aspectRatio: !playerRef.current ? '16/9' : '',
               textAlign: 'center',
             }}>
-            <p className="ramp--media-player_inaccessible-message-content"
+            <p className="ramp--media-player_inaccessible-message-content" data-testid="inaccessible-message-content"
               dangerouslySetInnerHTML={{ __html: placeholderText }}>
             </p>
-            <p>{`Next item in ${messageTime} second${messageTime === 1 ? '' : 's'}`}</p>
+            <p data-testid="inaccessible-message-timer">
+              {`Next item in ${messageTime} second${messageTime === 1 ? '' : 's'}`}
+            </p>
             <div className="ramp--media-player_inaccessible-message-buttons">
               {canvasIndex > 1 &&
-                <button onClick={() => loadPrevOrNext(canvasIndex - 1, true)}><SectionButtonIcon flip={true} /> Previous</button>}
+                <button aria-label="Go back to previous item"
+                  onClick={() => loadPrevOrNext(canvasIndex - 1, true)}
+                  data-testid="inaccessible-previous-button">
+                  <SectionButtonIcon flip={true} /> Previous
+                </button>
+              }
               {canvasIndex != lastCanvasIndex &&
-                <button onClick={() => loadPrevOrNext(canvasIndex + 1, true)}>Next <SectionButtonIcon /></button>}
+                <button aria-label="Go to next item"
+                  onClick={() => loadPrevOrNext(canvasIndex + 1, true)}
+                  data-testid="inaccessible-next-button">
+                  Next <SectionButtonIcon />
+                </button>
+              }
             </div>
           </div>
         )}

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -880,10 +880,6 @@ function VideoJSPlayer({
             <p className="ramp--media-player_inaccessible-message-content" data-testid="inaccessible-message-content"
               dangerouslySetInnerHTML={{ __html: placeholderText }}>
             </p>
-            <p data-testid="inaccessible-message-timer"
-              className={`ramp--media-player_inaccessible-message-timer ${autoAdvanceRef.current ? '' : 'disabled'}`}>
-              {`Next item in ${messageTime} second${messageTime === 1 ? '' : 's'}`}
-            </p>
             <div className="ramp--media-player_inaccessible-message-buttons">
               {canvasIndex > 1 &&
                 <button aria-label="Go back to previous item"
@@ -900,6 +896,10 @@ function VideoJSPlayer({
                 </button>
               }
             </div>
+            <p data-testid="inaccessible-message-timer"
+              className={`ramp--media-player_inaccessible-message-timer ${autoAdvanceRef.current ? '' : 'hidden'}`}>
+              {`Next item in ${messageTime} second${messageTime === 1 ? '' : 's'}`}
+            </p>
           </div>
         )}
         <video

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -833,6 +833,7 @@ function VideoJSPlayer({
    * function as this doesn't need to change with component re-renders
    */
   const createDisplayTimeInterval = React.useCallback(() => {
+    if (!autoAdvanceRef.current) return;
     const createTime = new Date().getTime();
     messageIntervalRef.current = setInterval(() => {
       let now = new Date().getTime();
@@ -879,7 +880,8 @@ function VideoJSPlayer({
             <p className="ramp--media-player_inaccessible-message-content" data-testid="inaccessible-message-content"
               dangerouslySetInnerHTML={{ __html: placeholderText }}>
             </p>
-            <p data-testid="inaccessible-message-timer">
+            <p data-testid="inaccessible-message-timer"
+              className={`ramp--media-player_inaccessible-message-timer ${autoAdvanceRef.current ? '' : 'disabled'}`}>
               {`Next item in ${messageTime} second${messageTime === 1 ? '' : 's'}`}
             </p>
             <div className="ramp--media-player_inaccessible-message-buttons">

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.scss
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.scss
@@ -19,5 +19,8 @@
     padding: 0.5em;
     border-radius: 0.3em;
     cursor: pointer;
+    font-size: medium;
+    top: -0.1em;
+    position: relative;
   }
 }

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.scss
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.scss
@@ -24,3 +24,11 @@
     position: relative;
   }
 }
+
+.ramp--media-player_inaccessible-message-timer {
+  color: inherit;
+}
+
+.ramp--media-player_inaccessible-message-timer.disabled {
+  color: $primaryDark;
+}

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.scss
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.scss
@@ -1,0 +1,23 @@
+@import '../../../styles/vars';
+
+.ramp--media-player_inaccessible-message-content {
+  width: 50%;
+  color: $primaryLightest;
+  a {
+    color: $primaryGreen
+  }
+}
+
+.ramp--media-player_inaccessible-message-buttons {
+  display: flex;
+  gap: 0.5em;
+
+  button {
+    border: 1px solid;
+    color: white;
+    background-color: $primaryGreenDark;
+    padding: 0.5em;
+    border-radius: 0.3em;
+    cursor: pointer;
+  }
+}

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.scss
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.scss
@@ -29,6 +29,6 @@
   color: inherit;
 }
 
-.ramp--media-player_inaccessible-message-timer.disabled {
-  color: $primaryDark;
+.ramp--media-player_inaccessible-message-timer.hidden {
+  visibility: hidden
 }

--- a/src/context/manifest-context.js
+++ b/src/context/manifest-context.js
@@ -40,7 +40,7 @@ function manifestReducer(state = defaultState, action) {
     case 'switchCanvas': {
       // Update hasStructure flag when canvas changes
       const canvasStructures =
-        state.canvasSegments.length > 0
+        state.canvasSegments?.length > 0
           ? state.canvasSegments.filter((c) =>
             c.canvasIndex == action.canvasIndex + 1 && !c.isCanvas
           )


### PR DESCRIPTION
Related issue: #501 

It was not possible to implement what was described in the done looks like in the ticket, as Video.js requires at least one source to build the player and its controls. And for inaccessible items the sources list is empty in the Canvas. 

Therefore this UI was implemented, by wiring the same functions the previous/next buttons use in the player controls to the buttons in the display.

When first item is inaccessible only display the next button; (and only displays previous button when last item is inaccessible)
![Screenshot 2024-06-24 at 3 38 36 PM](https://github.com/samvera-labs/ramp/assets/1331659/5edc96e1-df4d-43e1-a05a-38abd83bd5a6)


Previous and next buttons when item is in the middle of the list;
![Screenshot 2024-06-24 at 3 39 24 PM](https://github.com/samvera-labs/ramp/assets/1331659/a1d834df-644e-4ca7-86a4-6a5c0cbffda4)

Hides the timer display when auto-advance is turned off;
![Screenshot 2024-06-24 at 3 38 06 PM](https://github.com/samvera-labs/ramp/assets/1331659/ebedec1e-99a4-429e-aad5-be97c82ec1de)
