### PR TITLE
Adjust content search when switching between transcripts

### DIFF
--- a/src/components/Transcript/Transcript.js
+++ b/src/components/Transcript/Transcript.js
@@ -237,6 +237,7 @@ const Transcript = ({ playerID, manifestUrl, showNotes = false, search = {}, tra
     isMachineGen: false,
     tError: null,
   });
+  const [selectedTranscript, setSelectedTranscript] = React.useState();
   const [isLoading, setIsLoading] = React.useState(true);
   // Store transcript data in state to avoid re-requesting file contents
   const [cachedTranscripts, setCachedTranscripts] = React.useState([]);
@@ -264,7 +265,7 @@ const Transcript = ({ playerID, manifestUrl, showNotes = false, search = {}, tra
     query: searchQuery,
     transcripts: transcript,
     canvasIndex: canvasIndexRef.current,
-    selectedTranscript: transcriptInfo.tUrl,
+    selectedTranscript: selectedTranscript,
   });
 
   const { focusedMatchId, setFocusedMatchId, focusedMatchIndex, setFocusedMatchIndex } = useFocusedMatch({ searchResults });
@@ -398,12 +399,12 @@ const Transcript = ({ playerID, manifestUrl, showNotes = false, search = {}, tra
     }
   };
 
-  const selectTranscript = (selectedId) => {
+  const selectTranscript = React.useCallback((selectedId) => {
     const selectedTranscript = canvasTranscripts.filter((tr) => (
       tr.id === selectedId
     ));
     setStateVar(selectedTranscript[0]);
-  };
+  }, [canvasTranscripts]);
 
   const setStateVar = async (transcript) => {
     // When selected transcript is null or undefined display error message
@@ -428,6 +429,7 @@ const Transcript = ({ playerID, manifestUrl, showNotes = false, search = {}, tra
       const { tData, tFileExt, tType, tError } = cached[0];
       setTranscript(tData);
       setTranscriptInfo({ title, filename, id, isMachineGen, tType, tUrl: url, tFileExt, tError });
+      setSelectedTranscript(url);
     } else {
       // Parse new transcript data from the given sources
       await Promise.resolve(
@@ -447,6 +449,7 @@ const Transcript = ({ playerID, manifestUrl, showNotes = false, search = {}, tra
           }
           setTranscript(tData);
           setTranscriptInfo({ title, filename, id, isMachineGen, tType, tUrl, tFileExt, tError: newError });
+          setSelectedTranscript(tUrl);
           transcript = {
             ...transcript,
             tType: tType,

--- a/src/components/Transcript/Transcript.js
+++ b/src/components/Transcript/Transcript.js
@@ -22,14 +22,7 @@ const NO_SUPPORT = 'Transcript format is not supported, please check again.';
 const buildSpeakerText = (item) => {
   let text = item.text;
   if (item.match) {
-    text = item.match.reduce((acc, match, i) => {
-      if (i % 2 === 0) {
-        acc += match;
-      } else {
-        acc += `<span class="ramp--transcript_highlight">${match}</span>`;
-      }
-      return acc;
-    }, '');
+    text = item.match;
   }
   if (item.speaker) {
     return `<u>${item.speaker}:</u> ${text}`;
@@ -270,7 +263,7 @@ const Transcript = ({ playerID, manifestUrl, showNotes = false, search = {}, tra
 
   const { focusedMatchId, setFocusedMatchId, focusedMatchIndex, setFocusedMatchIndex } = useFocusedMatch({ searchResults });
 
-  const { tanscriptHitCounts } = useSearchCounts({ searchResults, canvasTranscripts });
+  const tanscriptHitCounts = useSearchCounts({ searchResults, canvasTranscripts, searchQuery });
 
   const [isEmpty, setIsEmpty] = React.useState(true);
   const [_autoScrollEnabled, _setAutoScrollEnabled] = React.useState(true);

--- a/src/components/Transcript/TranscriptMenu/TranscriptSelector.js
+++ b/src/components/Transcript/TranscriptMenu/TranscriptSelector.js
@@ -81,4 +81,4 @@ TranscriptSelector.propTypes = {
   noTranscript: PropTypes.bool.isRequired
 };
 
-export default TranscriptSelector;
+export default React.memo(TranscriptSelector);

--- a/src/services/search.js
+++ b/src/services/search.js
@@ -2,14 +2,15 @@ import { useRef, useEffect, useState, useMemo, useCallback, useContext } from 'r
 import { PlayerDispatchContext } from '../context/player-context';
 import { ManifestStateContext } from '../context/manifest-context';
 import { getSearchService } from './iiif-parser';
-import { markMatchedParts, getMatchedTranscriptLines, parseContentSearchResponse, getHitCountForCue } from './transcript-parser';
+import { markMatchedParts, getMatchedTranscriptLines, parseContentSearchResponse, getHitCountForCue, buildQueryRegex } from './transcript-parser';
 
 export const defaultMatcherFactory = (items) => {
   const mappedItems = items.map(item => item.text.toLocaleLowerCase());
   return (query, abortController) => {
+    const queryRegex = buildQueryRegex(query);
     const qStr = query.trim().toLocaleLowerCase();
     const matchedItems = mappedItems.reduce((results, mappedText, idx) => {
-      const matchOffset = mappedText.indexOf(qStr);
+      const matchOffset = mappedText.search(queryRegex);
       if (matchOffset !== -1) {
         const matchedItem = items[idx];
         const matchCount = getHitCountForCue(matchedItem.text, query);

--- a/src/services/search.js
+++ b/src/services/search.js
@@ -96,7 +96,7 @@ export function useFilteredTranscripts({
       matcher = contentSearchFactory(searchService, itemsWithIds, selectedTranscript);
     }
     return { matcher, itemsWithIds, itemsIndexed };
-  }, [transcripts, matcherFactory]);
+  }, [transcripts, matcherFactory, selectedTranscript]);
 
   const playerDispatch = useContext(PlayerDispatchContext);
   const manifestState = useContext(ManifestStateContext);
@@ -108,6 +108,8 @@ export function useFilteredTranscripts({
       let serviceId = getSearchService(manifest, canvasIndex);
       setSearchService(serviceId);
     }
+    // Reset cached search hits on Canvas change
+    setAllSearchResults(null);
   }, [canvasIndex]);
 
   useEffect(() => {
@@ -115,46 +117,62 @@ export function useFilteredTranscripts({
     if (abortControllerRef.current) {
       abortControllerRef.current.abort('Cancelling content search request');
     }
+    // Invoke the search factory when query is changed
+    if (query) {
+      callSearchFactory();
+    }
   }, [query]);
 
   useEffect(() => {
     if (!itemsWithIds.length) {
       if (playerDispatch) playerDispatch({ type: 'setSearchMarkers', payload: [] });
-      setSearchResults({ results: {}, matchingIds: [], ids: [] });
+      // Update searchResult instead of replacing to preserve the hit count
+      setSearchResults({
+        ...searchResults,
+        results: {}, matchingIds: [], ids: []
+      });
       return;
     } else if (!enabled || !query) {
       if (playerDispatch) playerDispatch({ type: 'setSearchMarkers', payload: [] });
       const sortedIds = sorter([...itemsWithIds]).map(item => item.id);
       setSearchResults({
+        ...searchResults,
         results: itemsIndexed,
         matchingIds: [],
         ids: sortedIds
       });
-      setAllSearchResults(null);
+      // When query is cleared; clear cached search results
+      if (!query) {
+        setAllSearchResults(null);
+      }
       return;
     }
 
+    // Use cached search results to find matches when switching between transcripts with same query
     if (allSearchResults != null) {
       const transcriptSearchResults = allSearchResults[selectedTranscript];
       const searchHits = getMatchedTranscriptLines(transcriptSearchResults, query, itemsWithIds);
       markMatchedItems(searchHits, searchResults?.counts, allSearchResults);
     } else {
-      const abortController = new AbortController();
-      abortControllerRef.current = abortController;
-
-      (Promise.resolve(matcher(query, abortControllerRef.current))
-        .then(({ matchedTranscriptLines, hitCounts, allSearchHits }) => {
-          if (abortController.signal.aborted) return;
-          markMatchedItems(matchedTranscriptLines, hitCounts, allSearchHits);
-        })
-        .catch(e => {
-          console.error('search failed', e, query, transcripts);
-        })
-      );
+      // Invoke search factory call when there are no cached search results
+      callSearchFactory();
     }
-
   }, [matcher, query, enabled, sorter, matchesOnly, showMarkers, playerDispatch, selectedTranscript]);
 
+  const callSearchFactory = () => {
+    const abortController = new AbortController();
+    abortControllerRef.current = abortController;
+
+    (Promise.resolve(matcher(query, abortControllerRef.current))
+      .then(({ matchedTranscriptLines, hitCounts, allSearchHits }) => {
+        if (abortController.signal.aborted) return;
+        markMatchedItems(matchedTranscriptLines, hitCounts, allSearchHits);
+      })
+      .catch(e => {
+        console.error('search failed', e, query, transcripts);
+      })
+    );
+  };
   /**
    * Generic function to prepare a list of search hits to be displayed in the transcript 
    * component either from a reponse from a content search API call (using content search factory)
@@ -165,7 +183,25 @@ export function useFilteredTranscripts({
    * @returns 
    */
   const markMatchedItems = (matchedTranscriptLines, hitCounts = [], allSearchHits = null) => {
-    if (matchedTranscriptLines === undefined) return;
+    /**
+     * Set all search results and hit counts for each transcript before compiling the
+     * matching search hit list for transcript lines. When there are no matches for the
+     * current transcript, but there are for others this needs to be set here to avoid
+     * duplicate API requests for content search when switching between transcripts.
+     */
+    setAllSearchResults(allSearchHits);
+    let searchResults = {
+      results: itemsWithIds,
+      matchingIds: [],
+      ids: sorter([...itemsWithIds]).map(item => item.id),
+      counts: hitCounts?.length > 0 ? hitCounts : [],
+    };
+    if (matchedTranscriptLines === undefined) {
+      setSearchResults({
+        ...searchResults
+      });
+      return;
+    };
     const matchingItemsIndexed = matchedTranscriptLines.reduce((acc, match) => ({
       ...acc,
       [match.id]: match
@@ -173,9 +209,10 @@ export function useFilteredTranscripts({
     const sortedMatchIds = sorter([...matchedTranscriptLines], true).map(item => item.id);
     if (matchesOnly) {
       setSearchResults({
+        ...searchResults,
         results: matchingItemsIndexed,
         ids: sortedMatchIds,
-        matchingIds: sortedMatchIds
+        matchingIds: sortedMatchIds,
       });
     } else {
       const joinedIndexed = {
@@ -184,19 +221,13 @@ export function useFilteredTranscripts({
       };
       const sortedItemIds = sorter(Object.values(joinedIndexed), false).map(item => item.id);
 
-      const searchResults = {
+      searchResults = {
+        ...searchResults,
         results: joinedIndexed,
         ids: sortedItemIds,
-        matchingIds: sortedMatchIds
+        matchingIds: sortedMatchIds,
       };
       setSearchResults(searchResults);
-      if (hitCounts?.length > 0) {
-        setSearchResults({
-          ...searchResults,
-          counts: hitCounts,
-        });
-      }
-      setAllSearchResults(allSearchHits);
 
       if (playerDispatch) {
         if (showMarkers) {

--- a/src/services/search.test.js
+++ b/src/services/search.test.js
@@ -94,7 +94,7 @@ describe('useFilteredTranscripts', () => {
         };
         const { resultRef, Component } = createTest({ matcherFactory, query: 'Gatsby' });
         render(Component);
-        await waitFor(() => expect(resultRef.current.matchingIds).toEqual([5, 7]));
+        await waitFor(() => expect(resultRef.current.matchingIds).toEqual([1, 4, 5, 7]));
       });
     });
 
@@ -106,8 +106,8 @@ describe('useFilteredTranscripts', () => {
           matchesOnly: true
         });
         render(Component);
-        await waitFor(() => expect(resultRef.current.ids).toEqual([5, 7]));
-        expect(resultRef.current.matchingIds).toEqual([5, 7]);
+        await waitFor(() => expect(resultRef.current.ids).toEqual([4, 1, 5, 7]));
+        expect(resultRef.current.matchingIds).toEqual([4, 1, 5, 7]);
       });
       test('without matchesOnly, ids will also be sorted', async () => {
         const { resultRef, Component } = createTest({
@@ -136,7 +136,7 @@ describe('useFilteredTranscripts', () => {
         });
         render(Component);
         await waitFor(() => expect(resultRef.current.ids).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8]));
-        expect(resultRef.current.matchingIds).toEqual([5, 7]);
+        expect(resultRef.current.matchingIds).toEqual([4, 1, 5, 7]);
       });
 
     });
@@ -156,21 +156,27 @@ describe('useFilteredTranscripts', () => {
     test('when the search query is set, matchingIds will contain ids of matches', async () => {
       const { resultRef, Component } = createTest({ query: 'Gatsby' });
       render(Component);
-      await waitFor(() => expect(resultRef.current.matchingIds).toEqual([5, 7]));
+      await waitFor(() => expect(resultRef.current.matchingIds).toEqual([1, 4, 5, 7]));
     });
     test('when matchesOnly is true, only matching results are returned', async () => {
       const { resultRef, Component } = createTest({ query: 'Gatsby', matchesOnly: true });
       render(Component);
-      await waitFor(() => expect(resultRef.current.ids).toEqual([5, 7]));
+      await waitFor(() => expect(resultRef.current.ids).toEqual([1, 4, 5, 7]));
     });
     test('results included in the match set will include a match property for highlighting matches', async () => {
       const { resultRef, Component } = createTest({ query: 'Gatsby' });
       render(Component);
       await waitFor(() => {
-        expect(resultRef.current.results[5].match).toEqual(
-          'Once there they were introduced by somebody who knew <span class="ramp--transcript_highlight">Gatsby</span>,'
+        expect(resultRef.current.results[1].match).toEqual(
+          'I believe that on the first night I went to <span class="ramp--transcript_highlight">Gatsby</span>\'s house'
         );
       });
+      expect(resultRef.current.results[4].match).toEqual(
+        'and somehow they ended up at <span class="ramp--transcript_highlight">Gatsby</span>\'s door.'
+      );
+      expect(resultRef.current.results[5].match).toEqual(
+        'Once there they were introduced by somebody who knew <span class="ramp--transcript_highlight">Gatsby</span>,'
+      );
       expect(resultRef.current.results[7].match).toEqual(
         'Sometimes they came and went without having met <span class="ramp--transcript_highlight">Gatsby</span> at all,'
       );

--- a/src/services/search.test.js
+++ b/src/services/search.test.js
@@ -1,19 +1,19 @@
 import React, { useEffect } from 'react';
 import { PlayerProvider } from '../context/player-context';
-import { useFilteredTranscripts, defaultMatcherFactory } from './search';
+import { useFilteredTranscripts, defaultMatcherFactory, contentSearchFactory, useSearchCounts } from './search';
 import { render, waitFor } from '@testing-library/react';
 import { ManifestProvider } from '../context/manifest-context';
 
 const transcriptsFixture = [
-  { id: 0, text: 'The party has begun.' },
-  { id: 1, text: 'I believe that on the first night I went to Gatsby\'s house' },
-  { id: 2, text: 'I was one of the few guests who had actually been invited.' },
-  { id: 3, text: 'People were not invited-they went there. They got into automobiles which bore them out to Long Island,' },
-  { id: 4, text: 'and somehow they ended up at Gatsby\'s door.' },
-  { id: 5, text: 'Once there they were introduced by somebody who knew Gatsby,' },
-  { id: 6, text: 'and after that they conducted themselves according to the rules of behaviour associated with an amusement park.' },
-  { id: 7, text: 'Sometimes they came and went without having met Gatsby at all,' },
-  { id: 8, text: 'came for the party with a simplicity of heart that was its own ticket of admission.' }
+  { id: 0, begin: 0.0, end: 10.0, text: 'The party has begun.' },
+  { id: 1, begin: 71.9, end: 82.0, text: 'I believe that on the first night I went to Gatsby\'s house' },
+  { id: 2, begin: 83.0, end: 85.0, text: 'I was one of the few guests who had actually been invited.' },
+  { id: 3, begin: 90.4, end: 95.3, text: 'People were not invited-they went there. They got into automobiles which bore them out to Long Island,' },
+  { id: 4, begin: 96.4, end: 102.5, text: 'and somehow they ended up at Gatsby\'s door.' },
+  { id: 5, begin: 105.0, end: 109.2, text: 'Once there they were introduced by somebody who knew Gatsby,' },
+  { id: 6, begin: 112.5, end: 120.5, text: 'and after that they conducted themselves according to the rules of behaviour associated with an amusement park.' },
+  { id: 7, begin: 121.3, end: 123.9, text: 'Sometimes they came and went without having met Gatsby at all,' },
+  { id: 8, begin: 124.1, end: 125.0, text: 'came for the party with a simplicity of heart that was its own ticket of admission.' }
 ];
 const fixture = {
   results: transcriptsFixture.reduce((r, t) => ({
@@ -21,8 +21,35 @@ const fixture = {
     [t.id]: t
   }), {}),
   ids: [0, 1, 2, 3, 4, 5, 6, 7, 8],
-  matchingIds: []
+  matchingIds: [],
+  counts: [],
 };
+const transcriptListFixture = [
+  {
+    filename: 'transcript1.vtt',
+    format: 'text/vtt',
+    id: 'transcritp1.vtt-0-1',
+    isMachineGen: false,
+    title: 'transcript1.vtt',
+    url: 'http://example.com/canvas/1/transcript1.vtt'
+  },
+  {
+    filename: 'transcript2.vtt',
+    format: 'text/vtt',
+    id: 'transcritp1.vtt-0-2',
+    isMachineGen: false,
+    title: 'transcript2.vtt',
+    url: 'http://example.com/canvas/1/transcript2.vtt'
+  },
+  {
+    filename: 'transcript.pdf',
+    format: 'application/pdf',
+    id: 'transcritp.pdf-0-3',
+    isMachineGen: false,
+    title: 'transcript.pdf',
+    url: 'http://example.com/canvas/1/transcript.pdf'
+  }
+];
 
 describe('useFilteredTranscripts', () => {
   const createTest = (props = {}) => {
@@ -55,7 +82,6 @@ describe('useFilteredTranscripts', () => {
   };
 
   describe('custom behavior', () => {
-
     describe('custom matcherFactory', () => {
       test('matcher factory can be customized to customize how matches are found', async () => {
         const matcherFactory = (items) => {
@@ -125,6 +151,7 @@ describe('useFilteredTranscripts', () => {
 
     });
   });
+
   describe('default behavior', () => {
     test('when the search query is null, all results are returned with 0 matches', async () => {
       const { resultRef, Component } = createTest({ query: null });
@@ -150,29 +177,212 @@ describe('useFilteredTranscripts', () => {
       const { resultRef, Component } = createTest({ query: 'Gatsby' });
       render(Component);
       await waitFor(() => {
-        expect(resultRef.current.results[1].match).toEqual([
-          'I believe that on the first night I went to ',
-          'Gatsby',
-          '\'s house'
-        ]);
+        expect(resultRef.current.results[1].match).toEqual(
+          'I believe that on the first night I went to <span class="ramp--transcript_highlight">Gatsby</span>\'s house'
+        );
       });
-      expect(resultRef.current.results[4].match).toEqual([
-        'and somehow they ended up at ',
-        'Gatsby',
-        '\'s door.'
-      ]);
-      expect(resultRef.current.results[5].match).toEqual([
-        'Once there they were introduced by somebody who knew ',
-        'Gatsby',
-        ','
-      ]);
-      expect(resultRef.current.results[7].match).toEqual([
-        'Sometimes they came and went without having met ',
-        'Gatsby',
-        ' at all,'
-      ]);
+      expect(resultRef.current.results[4].match).toEqual(
+        'and somehow they ended up at <span class="ramp--transcript_highlight">Gatsby</span>\'s door.'
+      );
+      expect(resultRef.current.results[5].match).toEqual(
+        'Once there they were introduced by somebody who knew <span class="ramp--transcript_highlight">Gatsby</span>,'
+      );
+      expect(resultRef.current.results[7].match).toEqual(
+        'Sometimes they came and went without having met <span class="ramp--transcript_highlight">Gatsby</span> at all,'
+      );
+    });
+  });
+
+  describe('content search behavior', () => {
+    global.fetch = jest.fn().mockImplementation(() =>
+      Promise.resolve({
+        json: () => {
+          return {
+            id: 'http://example.com/1/search?q=bungle',
+            type: 'AnnotationPage',
+            items: [
+              {
+                id: 'http://example.com/canvas/1/search/1',
+                type: 'Annotation',
+                motivation: 'supplementing',
+                target: "http://example.com/canvas/1/transcript/1#t=00:01:11.900,00:01:22.000",
+                body: {
+                  type: 'TextualBody',
+                  value: "I believe that on the first night I went to <em>Gatsby</em>\'s house",
+                  format: 'text/plain'
+                }
+              },
+              {
+                id: 'http://example.com/canvas/1/search/2',
+                type: 'Annotation',
+                motivation: 'supplementing',
+                target: "http://example.com/canvas/1/transcript/1#t=00:01:36.400,00:01:42.500",
+                body: {
+                  type: 'TextualBody',
+                  value: "and somehow they ended up at <em>Gatsby</em>\'s door.",
+                  format: 'text/plain'
+                }
+              },
+              {
+                id: 'http://example.com/canvas/1/search/3',
+                type: 'Annotation',
+                motivation: 'supplementing',
+                target: "http://example.com/canvas/1/transcript/1#t=00:01:45.000,00:01:49.200",
+                body: {
+                  type: 'TextualBody',
+                  value: "Once there they were introduced by somebody who knew <em>Gatsby</em>,",
+                  format: 'text/plain'
+                }
+              },
+              {
+                id: 'http://example.com/canvas/1/search/4',
+                type: 'Annotation',
+                motivation: 'supplementing',
+                target: "http://example.com/canvas/1/transcript/1#t=00:02:01.300,00:02:03.900",
+                body: {
+                  type: 'TextualBody',
+                  value: "Sometimes they came and went without having met <em>Gatsby</em> at all,",
+                  format: 'text/plain'
+                }
+              },
+            ]
+          };
+        },
+      })
+    );
+    const matcherFactory = (items) => {
+      const matcher = contentSearchFactory('http://example.com/1/search', items, 'http://example.com/canvas/1/transcript/1');
+      return async (query, abortController) => {
+        const results = matcher(query, abortController);
+        await new Promise(r => setTimeout(r, 500));
+        return results;
+      };
+    };
+
+    test('when the search query is null, all results are returned with 0 matches', async () => {
+      const { resultRef, Component } = createTest({ matcherFactory, query: null });
+      render(Component);
+      await waitFor(() => expect(resultRef.current).toEqual(fixture));
+    });
+    test('when enabled: false is passed, all results are returned with 0 matches', async () => {
+      const { resultRef, Component } = createTest({ enabled: false });
+      render(Component);
+      await waitFor(() => expect(resultRef.current).toEqual(fixture));
+    });
+    test('when the search query is set, matchingIds will contain ids of matches', async () => {
+      const { resultRef, Component } = createTest({ matcherFactory, query: 'Gatsby' });
+      render(Component);
+      await waitFor(() => {
+        expect(resultRef.current.matchingIds).toEqual([1, 4, 5, 7]);
+        expect(resultRef.current.counts).toEqual([{
+          transcriptURL: 'http://example.com/canvas/1/transcript/1',
+          numberOfHits: 4
+        }]);
+      });
+    });
+    test('when matchesOnly is true, only matching results are returned', async () => {
+      const { resultRef, Component } = createTest({ matcherFactory, query: 'Gatsby', matchesOnly: true });
+      render(Component);
+      await waitFor(() => {
+        expect(resultRef.current.matchingIds).toEqual([1, 4, 5, 7]);
+        expect(resultRef.current.counts).toEqual([{
+          transcriptURL: 'http://example.com/canvas/1/transcript/1',
+          numberOfHits: 4
+        }]);
+      });
+    });
+    test('results included in the match set will include a match property for highlighting matches', async () => {
+      const { resultRef, Component } = createTest({ matcherFactory, query: 'Gatsby' });
+      render(Component);
+      await waitFor(() => {
+        expect(resultRef.current.results[1].match).toEqual(
+          'I believe that on the first night I went to <span class="ramp--transcript_highlight">Gatsby</span>\'s house'
+        );
+      });
+      expect(resultRef.current.results[4].match).toEqual(
+        'and somehow they ended up at <span class="ramp--transcript_highlight">Gatsby</span>\'s door.'
+      );
+      expect(resultRef.current.results[5].match).toEqual(
+        'Once there they were introduced by somebody who knew <span class="ramp--transcript_highlight">Gatsby</span>,'
+      );
+      expect(resultRef.current.results[7].match).toEqual(
+        'Sometimes they came and went without having met <span class="ramp--transcript_highlight">Gatsby</span> at all,'
+      );
 
     });
   });
 });
+
+describe('useSearchCounts', () => {
+  const createTest = (props = {}) => {
+    // not a real ref because react throws warning if we use outside a component
+    const searchResults = {
+      counts: [
+        {
+          transcriptURL: 'http://example.com/canvas/1/transcript1.vtt',
+          numberOfHits: 2
+        },
+        {
+          transcriptURL: 'http://example.com/canvas/1/transcript2.vtt',
+          numberOfHits: 15
+        },
+      ]
+    };
+    // not a real ref because react throws warning if we use outside a component
+    const resultRef = { current: null };
+    const canvasTranscripts = [...transcriptListFixture];
+    const InnerComponent = () => {
+
+      const tanscriptHitCounts = useSearchCounts({
+        searchResults, canvasTranscripts, ...props
+      });
+
+      useEffect(() => {
+        resultRef.current = tanscriptHitCounts;
+      }, [tanscriptHitCounts]);
+      return (
+        <div></div>
+      );
+    };
+    const Component = (
+      <PlayerProvider>
+        <ManifestProvider>
+          <InnerComponent />
+        </ManifestProvider>
+      </PlayerProvider>
+    );
+    return { resultRef, Component };
+  };
+  test('when the search query is not null, transcript list is returned with numberOfHits property', async () => {
+    const { resultRef, Component } = createTest({ searchQuery: 'Bungle' });
+    render(Component);
+    await waitFor(() => {
+      expect(resultRef.current.length).toEqual(transcriptListFixture.length);
+      expect(resultRef.current[0]).toEqual({
+        filename: 'transcript1.vtt',
+        format: 'text/vtt',
+        id: 'transcritp1.vtt-0-1',
+        isMachineGen: false,
+        title: 'transcript1.vtt',
+        url: 'http://example.com/canvas/1/transcript1.vtt',
+        numberOfHits: 2
+      });
+    });
+  });
+  test('when the search query is null, original transcript list is returned', async () => {
+    const { resultRef, Component } = createTest({ searchQuery: null });
+    render(Component);
+    await waitFor(() => {
+      expect(resultRef.current).toEqual(transcriptListFixture);
+      expect(resultRef.current[0]).toEqual({
+        filename: 'transcript1.vtt',
+        format: 'text/vtt',
+        id: 'transcritp1.vtt-0-1',
+        isMachineGen: false,
+        title: 'transcript1.vtt',
+        url: 'http://example.com/canvas/1/transcript1.vtt'
+      });
+    });
+  });
+})
 

--- a/src/services/search.test.js
+++ b/src/services/search.test.js
@@ -83,16 +83,6 @@ describe('useFilteredTranscripts', () => {
 
   describe('custom behavior', () => {
     describe('custom matcherFactory', () => {
-      test('matcher factory can be customized to customize how matches are found', async () => {
-        const matcherFactory = (items) => {
-          const mappedItems = items.map(item => ({ ...item, text: item.text.replaceAll(' ', '') }));
-          return defaultMatcherFactory(mappedItems);
-        };
-        const { resultRef, Component } = createTest({ matcherFactory, query: 'theparty' });
-
-        render(Component);
-        await waitFor(() => expect(resultRef.current.matchingIds).toEqual([0, 8]));
-      });
       test('matcher factory can create an async matcher', async () => {
         const matcherFactory = (items) => {
           const matcher = defaultMatcherFactory(items);
@@ -104,7 +94,7 @@ describe('useFilteredTranscripts', () => {
         };
         const { resultRef, Component } = createTest({ matcherFactory, query: 'Gatsby' });
         render(Component);
-        await waitFor(() => expect(resultRef.current.matchingIds).toEqual([1, 4, 5, 7]));
+        await waitFor(() => expect(resultRef.current.matchingIds).toEqual([5, 7]));
       });
     });
 
@@ -116,8 +106,8 @@ describe('useFilteredTranscripts', () => {
           matchesOnly: true
         });
         render(Component);
-        await waitFor(() => expect(resultRef.current.ids).toEqual([4, 1, 5, 7]));
-        expect(resultRef.current.matchingIds).toEqual([4, 1, 5, 7]);
+        await waitFor(() => expect(resultRef.current.ids).toEqual([5, 7]));
+        expect(resultRef.current.matchingIds).toEqual([5, 7]);
       });
       test('without matchesOnly, ids will also be sorted', async () => {
         const { resultRef, Component } = createTest({
@@ -146,7 +136,7 @@ describe('useFilteredTranscripts', () => {
         });
         render(Component);
         await waitFor(() => expect(resultRef.current.ids).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8]));
-        expect(resultRef.current.matchingIds).toEqual([4, 1, 5, 7]);
+        expect(resultRef.current.matchingIds).toEqual([5, 7]);
       });
 
     });
@@ -166,27 +156,21 @@ describe('useFilteredTranscripts', () => {
     test('when the search query is set, matchingIds will contain ids of matches', async () => {
       const { resultRef, Component } = createTest({ query: 'Gatsby' });
       render(Component);
-      await waitFor(() => expect(resultRef.current.matchingIds).toEqual([1, 4, 5, 7]));
+      await waitFor(() => expect(resultRef.current.matchingIds).toEqual([5, 7]));
     });
     test('when matchesOnly is true, only matching results are returned', async () => {
       const { resultRef, Component } = createTest({ query: 'Gatsby', matchesOnly: true });
       render(Component);
-      await waitFor(() => expect(resultRef.current.ids).toEqual([1, 4, 5, 7]));
+      await waitFor(() => expect(resultRef.current.ids).toEqual([5, 7]));
     });
     test('results included in the match set will include a match property for highlighting matches', async () => {
       const { resultRef, Component } = createTest({ query: 'Gatsby' });
       render(Component);
       await waitFor(() => {
-        expect(resultRef.current.results[1].match).toEqual(
-          'I believe that on the first night I went to <span class="ramp--transcript_highlight">Gatsby</span>\'s house'
+        expect(resultRef.current.results[5].match).toEqual(
+          'Once there they were introduced by somebody who knew <span class="ramp--transcript_highlight">Gatsby</span>,'
         );
       });
-      expect(resultRef.current.results[4].match).toEqual(
-        'and somehow they ended up at <span class="ramp--transcript_highlight">Gatsby</span>\'s door.'
-      );
-      expect(resultRef.current.results[5].match).toEqual(
-        'Once there they were introduced by somebody who knew <span class="ramp--transcript_highlight">Gatsby</span>,'
-      );
       expect(resultRef.current.results[7].match).toEqual(
         'Sometimes they came and went without having met <span class="ramp--transcript_highlight">Gatsby</span> at all,'
       );
@@ -201,28 +185,6 @@ describe('useFilteredTranscripts', () => {
             id: 'http://example.com/1/search?q=bungle',
             type: 'AnnotationPage',
             items: [
-              {
-                id: 'http://example.com/canvas/1/search/1',
-                type: 'Annotation',
-                motivation: 'supplementing',
-                target: "http://example.com/canvas/1/transcript/1#t=00:01:11.900,00:01:22.000",
-                body: {
-                  type: 'TextualBody',
-                  value: "I believe that on the first night I went to <em>Gatsby</em>\'s house",
-                  format: 'text/plain'
-                }
-              },
-              {
-                id: 'http://example.com/canvas/1/search/2',
-                type: 'Annotation',
-                motivation: 'supplementing',
-                target: "http://example.com/canvas/1/transcript/1#t=00:01:36.400,00:01:42.500",
-                body: {
-                  type: 'TextualBody',
-                  value: "and somehow they ended up at <em>Gatsby</em>\'s door.",
-                  format: 'text/plain'
-                }
-              },
               {
                 id: 'http://example.com/canvas/1/search/3',
                 type: 'Annotation',
@@ -273,10 +235,10 @@ describe('useFilteredTranscripts', () => {
       const { resultRef, Component } = createTest({ matcherFactory, query: 'Gatsby' });
       render(Component);
       await waitFor(() => {
-        expect(resultRef.current.matchingIds).toEqual([1, 4, 5, 7]);
+        expect(resultRef.current.matchingIds).toEqual([5, 7]);
         expect(resultRef.current.counts).toEqual([{
           transcriptURL: 'http://example.com/canvas/1/transcript/1',
-          numberOfHits: 4
+          numberOfHits: 2
         }]);
       });
     });
@@ -284,10 +246,10 @@ describe('useFilteredTranscripts', () => {
       const { resultRef, Component } = createTest({ matcherFactory, query: 'Gatsby', matchesOnly: true });
       render(Component);
       await waitFor(() => {
-        expect(resultRef.current.matchingIds).toEqual([1, 4, 5, 7]);
+        expect(resultRef.current.matchingIds).toEqual([5, 7]);
         expect(resultRef.current.counts).toEqual([{
           transcriptURL: 'http://example.com/canvas/1/transcript/1',
-          numberOfHits: 4
+          numberOfHits: 2
         }]);
       });
     });
@@ -295,20 +257,13 @@ describe('useFilteredTranscripts', () => {
       const { resultRef, Component } = createTest({ matcherFactory, query: 'Gatsby' });
       render(Component);
       await waitFor(() => {
-        expect(resultRef.current.results[1].match).toEqual(
-          'I believe that on the first night I went to <span class="ramp--transcript_highlight">Gatsby</span>\'s house'
+        expect(resultRef.current.results[5].match).toEqual(
+          'Once there they were introduced by somebody who knew <span class="ramp--transcript_highlight">Gatsby</span>,'
         );
       });
-      expect(resultRef.current.results[4].match).toEqual(
-        'and somehow they ended up at <span class="ramp--transcript_highlight">Gatsby</span>\'s door.'
-      );
-      expect(resultRef.current.results[5].match).toEqual(
-        'Once there they were introduced by somebody who knew <span class="ramp--transcript_highlight">Gatsby</span>,'
-      );
       expect(resultRef.current.results[7].match).toEqual(
         'Sometimes they came and went without having met <span class="ramp--transcript_highlight">Gatsby</span> at all,'
       );
-
     });
   });
 });

--- a/src/services/transcript-parser.js
+++ b/src/services/transcript-parser.js
@@ -10,6 +10,7 @@ import {
   identifyMachineGen,
   identifySupplementingAnnotation,
   parseSequences,
+  groupBy,
 } from './utility-helpers';
 import { getCanvasId } from './iiif-parser';
 
@@ -775,15 +776,19 @@ export const parseContentSearchResponse = (response, query, trancripts, selected
       const target = anno.getTarget();
       const targetURI = getCanvasId(target);
       const value = anno.getBody()[0].getProperty('value');
-      searchHits.push({ target, targetURI, value });
+      const hitCount = getHitCountForCue(value, query, true);
+      searchHits.push({ target, targetURI, value, hitCount });
     });
   }
   // Group search responses by transcript
-  const allSearchHits = Object.groupBy(searchHits, ({ targetURI }) => targetURI);
+  const allSearchHits = groupBy(searchHits, 'targetURI');
 
   // Calculate search hit count for each transcript in the Canvas
   for (const [key, value] of Object.entries(allSearchHits)) {
-    hitCounts.push({ transcriptURL: key, numberOfHits: value.length });
+    hitCounts.push({
+      transcriptURL: key,
+      numberOfHits: value.reduce((partialSum, a) => partialSum + a.hitCount, 0)
+    });
   }
 
   // Get all the matching transcript lines with the query in the current transcript
@@ -827,14 +832,15 @@ export const getMatchedTranscriptLines = (searchHits, query, transcripts) => {
     }
     const matchOffset = mappedText.toLocaleLowerCase().indexOf(qStr);
     if (matchOffset !== -1 && transcirptId != undefined) {
-      const matchParts = getMatchedParts(matchOffset, mappedText, qStr);
+      const match = markMatchedParts(mappedText, qStr);
 
       transcriptLines.push({
         ...hit,
         begin: start,
         end: end,
         id: transcirptId,
-        match: matchParts,
+        match,
+        matchCount: item.hitCount,
         text: value,
       });
     }
@@ -842,22 +848,39 @@ export const getMatchedTranscriptLines = (searchHits, query, transcripts) => {
   return transcriptLines;
 };
 
-// FIXME:: When there are 2 hits in the same transcript text/cue, only the first
-// match is highlighted.
 /**
- * Generic function to split the matched transcript text into 3 parts where the output is in
- * the format [text before search query, search query, text after search query]
- * @param {Number} offset character offset to the query string in the matched transcript text/cue
+ * Generic function to mark the matched transcript text in the cue where the output has
+ * <span class="ramp--transcript_highlight"></span> surrounding the matched parts
+ * within the cue.
  * @param {String} text matched transcript text/cue
  * @param {String} query current search query
- * @returns a list of parts of the given matched transcript text/cue
+ * @returns matched cue with HTML tags added for marking the hightlight 
  */
-export const getMatchedParts = (offset, text, query) => {
-  return [
-    text.slice(0, offset),
-    text.slice(offset, offset + query.length),
-    text.slice(offset + query.length)
-  ];
+export const markMatchedParts = (text, query) => {
+  const queryRegex = new RegExp(String.raw`${query}`, 'gi');
+  return text.replace(queryRegex, `<span class="ramp--transcript_highlight">$&</span>`);
+};
+
+/**
+ * Calculate hit counts for each matched transcript cue
+ * @param {String} text matched transcript cue text
+ * @param {String} query search query from UI
+ * @param {Boolean} hasHighlight flag indicating has <em> tags or not
+ * @returns 
+ */
+export const getHitCountForCue = (text, query, hasHighlight = false) => {
+  /*
+    Content search API highlights each word in the given phrase in the response.
+    Threfore, use first word in the query seperated by a white space to get the hit
+    counts for each cue.
+    Use regex with any punctuation followed by a white space to split the query.
+    e.g. query: Mr. bungle => search response: <em>Mr</em>. <em>Bungle</em>
+  */
+  const partialQ = query.split(/[.,:;!?]\s/)[0];
+  const hitTerm = hasHighlight ? `<em>${partialQ}</em>` : partialQ;
+  const hightlighedTerm = new RegExp(String.raw`${hitTerm}`, 'gi');
+  const hitCount = [...text.matchAll(hightlighedTerm)]?.length;
+  return hitCount;
 };
 
 // TODO:: Could be used for marking search hits in Word Doc transcripts?

--- a/src/services/transcript-parser.js
+++ b/src/services/transcript-parser.js
@@ -818,27 +818,27 @@ export const getMatchedTranscriptLines = (searchHits, query, transcripts) => {
     const mappedText = value.replace(/<\/?[^>]+>/gi, '');
 
     let start = 0, end = 0;
-    let transcirptId = undefined;
+    let transcriptId = undefined;
     let hit = {};
     if (timeRange != undefined) {
       // For timed-text
       start = timeRange.start; end = timeRange.end;
-      transcirptId = transcripts.findIndex((t) => t.begin == start && t.end == end);
+      transcriptId = transcripts.findIndex((t) => t.begin == start && t.end == end);
       hit.tag = TRANSCRIPT_CUE_TYPES.timedCue;
     } else {
       // For non timed-text
-      transcirptId = transcripts.findIndex((t) => t.text === mappedText);
+      transcriptId = transcripts.findIndex((t) => t.text === mappedText);
       hit.tag = TRANSCRIPT_CUE_TYPES.nonTimedLine;
     }
     const matchOffset = mappedText.toLocaleLowerCase().indexOf(qStr);
-    if (matchOffset !== -1 && transcirptId != undefined) {
+    if (matchOffset !== -1 && transcriptId != undefined) {
       const match = markMatchedParts(value, qStr, true);
 
       transcriptLines.push({
         ...hit,
         begin: start,
         end: end,
-        id: transcirptId,
+        id: transcriptId,
         match,
         matchCount: item.hitCount,
         text: value,

--- a/src/services/transcript-parser.js
+++ b/src/services/transcript-parser.js
@@ -857,7 +857,7 @@ export const getMatchedTranscriptLines = (searchHits, query, transcripts) => {
  * @returns matched cue with HTML tags added for marking the hightlight 
  */
 export const markMatchedParts = (text, query) => {
-  const queryRegex = new RegExp(String.raw`${query}`, 'gi');
+  const queryRegex = buildQueryRegex(query);
   return text.replace(queryRegex, `<span class="ramp--transcript_highlight">$&</span>`);
 };
 
@@ -876,11 +876,23 @@ export const getHitCountForCue = (text, query, hasHighlight = false) => {
     Use regex with any punctuation followed by a white space to split the query.
     e.g. query: Mr. bungle => search response: <em>Mr</em>. <em>Bungle</em>
   */
-  const partialQ = query.split(/[.,:;!?]\s/)[0];
+  const partialQ = query.split(/[\s.,!?;:]/)[0];
   const hitTerm = hasHighlight ? `<em>${partialQ}</em>` : partialQ;
   const hightlighedTerm = new RegExp(String.raw`${hitTerm}`, 'gi');
   const hitCount = [...text.matchAll(hightlighedTerm)]?.length;
   return hitCount;
+};
+
+/**
+ * Build a regular expression to omit matches including;
+ * - succeeding characters to the entered query
+ * - word contractions when query is used with auxiliary verbs
+ * @param {String} query search query entered by user
+ * @returns a regular expression
+ */
+export const buildQueryRegex = (query) => {
+  const queryRegex = new RegExp(String.raw`\b${query}\b(?=[\s.,!?;:]|$)`, 'gi');
+  return queryRegex;
 };
 
 // TODO:: Could be used for marking search hits in Word Doc transcripts?

--- a/src/services/transcript-parser.js
+++ b/src/services/transcript-parser.js
@@ -685,13 +685,13 @@ function groupTimedTextLines(lines) {
       t.times = isNote ? "" : line;
       t.tag = isNote ? TRANSCRIPT_CUE_TYPES.note : TRANSCRIPT_CUE_TYPES.timedCue;
       // Make sure there is a single space separating NOTE from the comment for single or multi-line comments
-      t.line = isNote ? line.replace(/^NOTE\s*/,'NOTE ') : '';
+      t.line = isNote ? line.replace(/^NOTE\s*/, 'NOTE ') : '';
       i++;
 
       // Increment until an empty line is encountered marking the end of the block
       while (i < lines.length
         && !(lines[i] == '\r' || lines[i] == '\n' || lines[i] == '\r\n' || lines[i] == '')) {
-        t.line += lines[i].endsWith('-') ? lines[i] : lines[i].replace(/\s*$/,' ');
+        t.line += lines[i].endsWith('-') ? lines[i] : lines[i].replace(/\s*$/, ' ');
         i++;
       }
       t.line = t.line.trimEnd();

--- a/src/services/transcript-parser.test.js
+++ b/src/services/transcript-parser.test.js
@@ -919,27 +919,75 @@ describe('transcript-parser', () => {
         text: 'Phil stopped to return a book to Miss Brown \rwhile his friends went on to the lunchroom.\r'
       },
     ];
-    const searchHits = [
-      {
-        target: "http://example.com/canvas/1/transcript/1/transcripts#t=00:01:36.400,00:01:42.500",
-        targetURI: "http://example.com/canvas/1/transcript/1/transcripts",
-        value: "<em>Phil</em> knew that a Mr. Bungle wouldn't have many friends. He wouldn't want to be like Mr. Bungle."
-      },
-      {
-        target: "http://example.com/canvas/1/transcript/1/transcripts#t=00:01:58.500,00:02:03.200",
-        targetURI: "http://example.com/canvas/1/transcrip/1/transcripts",
-        value: "<em>Phil</em> stopped to return a book to Miss Brown while his friends went on to the lunchroom."
-      },
-    ];
-    const matchedTranscriptLines = transcriptParser.getMatchedTranscriptLines(searchHits, 'phil', transcripts);
-    expect(matchedTranscriptLines).toHaveLength(2);
-    expect(matchedTranscriptLines[0]).toEqual({
-      id: 3,
-      begin: 96.4,
-      end: 102.5,
-      tag: "TIMED_CUE",
-      text: "<em>Phil</em> knew that a Mr. Bungle wouldn't have many friends. He wouldn't want to be like Mr. Bungle.",
-      match: ["", "Phil", " knew that a Mr. Bungle wouldn't have many friends. He wouldn't want to be like Mr. Bungle."]
+
+    test('with a single match in a cue', () => {
+      const searchHits = [
+        {
+          target: "http://example.com/canvas/1/transcript/1/transcripts#t=00:01:36.400,00:01:42.500",
+          targetURI: "http://example.com/canvas/1/transcript/1/transcripts",
+          hitCount: 1,
+          value: "<em>Phil</em> knew that a Mr. Bungle wouldn't have many friends. He wouldn't want to be like Mr. Bungle."
+        },
+        {
+          target: "http://example.com/canvas/1/transcript/1/transcripts#t=00:01:58.500,00:02:03.200",
+          targetURI: "http://example.com/canvas/1/transcrip/1/transcripts",
+          hitCount: 1,
+          value: "<em>Phil</em> stopped to return a book to Miss Brown while his friends went on to the lunchroom."
+        },
+      ];
+      const matchedTranscriptLines = transcriptParser.getMatchedTranscriptLines(searchHits, 'phil', transcripts);
+      expect(matchedTranscriptLines).toHaveLength(2);
+      expect(matchedTranscriptLines[0]).toEqual({
+        id: 3,
+        begin: 96.4,
+        end: 102.5,
+        tag: "TIMED_CUE",
+        text: "<em>Phil</em> knew that a Mr. Bungle wouldn't have many friends. He wouldn't want to be like Mr. Bungle.",
+        match: "<span class=\"ramp--transcript_highlight\">Phil</span> knew that a Mr. Bungle wouldn't have many friends. He wouldn't want to be like Mr. Bungle.",
+        matchCount: 1,
+      });
+    });
+
+    test('with multiple matches in a cue', () => {
+      const searchHits = [
+        {
+          target: "http://example.com/canvas/1/transcript/1/transcripts#t=00:01:11.900,00:01:22.000",
+          targetURI: "http://example.com/canvas/1/transcript/1/transcripts",
+          hitCount: 1,
+          value: "Then, in the lunchroom, Mr. <em>Bungle</em> was so clumsy and impolite that he knocked over everything. And no one wanted to sit next to him."
+        },
+        {
+          target: "http://example.com/canvas/1/transcript/1/transcripts#t=00:01:30.300,00:01:36.300",
+          targetURI: "http://example.com/canvas/1/transcrip/1/transcripts",
+          hitCount: 1,
+          value: "The children knew that even though Mr. <em>Bungle</em> was funny to watch, he wouldn\'t be much fun to eat with."
+        },
+        {
+          target: "http://example.com/canvas/1/transcript/1/transcripts#t=00:01:36.400,00:01:42.500",
+          targetURI: "http://example.com/canvas/1/transcript/1/transcripts",
+          hitCount: 2,
+          value: "Phil knew that a Mr. <em>Bungle</em> wouldn't have many friends. He wouldn't want to be like Mr. <em>Bungle</em>."
+        },
+      ];
+      const matchedTranscriptLines = transcriptParser.getMatchedTranscriptLines(searchHits, 'bungle', transcripts);
+      expect(matchedTranscriptLines).toHaveLength(3);
+      expect(matchedTranscriptLines[0]).toEqual({
+        id: 0,
+        begin: 71.9, end: 82,
+        tag: "TIMED_CUE",
+        text: "Then, in the lunchroom, Mr. <em>Bungle</em> was so clumsy and impolite that he knocked over everything. And no one wanted to sit next to him.",
+        match: "Then, in the lunchroom, Mr. <span class=\"ramp--transcript_highlight\">Bungle</span> was so clumsy and impolite that he knocked over everything. And no one wanted to sit next to him.",
+        matchCount: 1,
+      });
+      expect(matchedTranscriptLines[2]).toEqual({
+        id: 3,
+        begin: 96.4,
+        end: 102.5,
+        tag: "TIMED_CUE",
+        text: "Phil knew that a Mr. <em>Bungle</em> wouldn't have many friends. He wouldn't want to be like Mr. <em>Bungle</em>.",
+        match: "Phil knew that a Mr. <span class=\"ramp--transcript_highlight\">Bungle</span> wouldn't have many friends. He wouldn't want to be like Mr. <span class=\"ramp--transcript_highlight\">Bungle</span>.",
+        matchCount: 2,
+      });
     });
   });
 });

--- a/src/services/utility-helpers.js
+++ b/src/services/utility-helpers.js
@@ -673,3 +673,16 @@ export function playerHotKeys(event, player, canvasIsEmpty) {
     event.stopPropagation();
   }
 }
+
+/**
+ * Group a JSON object array by a given property
+ * @param {Array} arry array of JSON objects to be grouped
+ * @param {String} key property name used for grouping
+ * @returns a map of grouped JSON objects
+ */
+export const groupBy = (arry, key) => {
+  return arry.reduce(function (rv, x) {
+    (rv[x[key]] = rv[x[key]] || []).push(x);
+    return rv;
+  }, {});
+};


### PR DESCRIPTION
Refinements to feature added in #502 

This PR includes the following refinements to content search:
- Use cached search results when switching between transcripts in the same Canvas without changing the query
- Preserve search counts when switching to a transcript where search is disabled
- Update search results counts properly when switching between transcripts
- Clear search counts when current search is cleared
- Display hit counts correctly when there are multiple hits in a single cue
- General refactoring to parts of code related to transcript component