### PR TITLE
Adjust text highlight color for contrast in transcript search

### DIFF
--- a/src/styles/_vars.scss
+++ b/src/styles/_vars.scss
@@ -10,8 +10,8 @@ $primaryGreenLight: #cfd8d3;
 $primaryGreenSemiLight: #d0dcdc;
 $primaryGreen: #80a590;
 $primaryGreenDim: #4d7b7b;
-$primaryGreenDimmer: #3f6666;
-$primaryGreenDark: #2A5459;
+$primaryGreenDimmer: #3b5e5e;
+$primaryGreenDark: #2a5459;
 $primaryGreenDarker: #1a3a3f;
 
 $danger: #e0101a;


### PR DESCRIPTION
Related issue: https://github.com/avalonmediasystem/avalon/issues/5753

Transcript highlight colors were checked for WCAG AA color contrast ratio of 4.5:1