### PR TITLE
SRT/VTT timestamp validation to deny single digit hour in hh:mm...

### DIFF
--- a/src/components/Transcript/Transcript.js
+++ b/src/components/Transcript/Transcript.js
@@ -17,6 +17,7 @@ import './Transcript.scss';
 const NO_TRANSCRIPTS_MSG = 'No valid Transcript(s) found, please check again.';
 const INVALID_URL_MSG = 'Invalid URL for transcript, please check again.';
 const INVALID_VTT = 'Invalid WebVTT file, please check again.';
+const INVALID_TIMESTAMP = 'Invalid timestamp format in cue(s), please check again.';
 const NO_SUPPORT = 'Transcript format is not supported, please check again.';
 
 const buildSpeakerText = (item) => {
@@ -431,14 +432,24 @@ const Transcript = ({ playerID, manifestUrl, showNotes = false, search = {}, tra
         if (value != null) {
           const { tData, tUrl, tType, tFileExt } = value;
           let newError = '';
-          if (tType === TRANSCRIPT_TYPES.invalid) {
-            newError = INVALID_URL_MSG;
-          } else if (tType === TRANSCRIPT_TYPES.noTranscript) {
-            newError = NO_TRANSCRIPTS_MSG;
-          } else if (tType === TRANSCRIPT_TYPES.noSupport) {
-            newError = NO_SUPPORT;
-          } else if (tType === TRANSCRIPT_TYPES.invalidTimedText) {
-            newError = INVALID_VTT;
+          switch (tType) {
+            case TRANSCRIPT_TYPES.invalid:
+              newError = INVALID_URL_MSG;
+              break;
+            case TRANSCRIPT_TYPES.noTranscript:
+              newError = NO_TRANSCRIPTS_MSG;
+              break;
+            case TRANSCRIPT_TYPES.noSupport:
+              newError = NO_SUPPORT;
+              break;
+            case TRANSCRIPT_TYPES.invalidVTT:
+              newError = INVALID_VTT;
+              break;
+            case TRANSCRIPT_TYPES.invalidTimestamp:
+              newError = INVALID_TIMESTAMP;
+              break;
+            default:
+              break;
           }
           setTranscript(tData);
           setTranscriptInfo({ title, filename, id, isMachineGen, tType, tUrl, tFileExt, tError: newError });

--- a/src/components/Transcript/Transcript.test.js
+++ b/src/components/Transcript/Transcript.test.js
@@ -237,7 +237,7 @@ describe('Transcript component', () => {
           initialManifestState: { manifest: lunchroomManners, canvasIndex: 0 },
           initialPlayerState: {},
           ...props,
-	  showNotes: true,
+          showNotes: true,
         });
 
         render(
@@ -782,7 +782,7 @@ describe('Transcript component', () => {
         .mockReturnValue({
           tData: [],
           tUrl: 'https://example.com/lunchroom_manners.vtt',
-          tType: transcriptParser.TRANSCRIPT_TYPES.invalidTimedText,
+          tType: transcriptParser.TRANSCRIPT_TYPES.invalidVTT,
         });
 
       const TranscriptWithState = withManifestAndPlayerProvider(Transcript, {
@@ -806,6 +806,55 @@ describe('Transcript component', () => {
         expect(screen.queryByTestId('no-transcript')).toBeInTheDocument();
         expect(screen.getByTestId('no-transcript')).toHaveTextContent(
           'Invalid WebVTT file, please check again.'
+        );
+      });
+    });
+
+    test('WebVTT file with invalid timestamps', async () => {
+      const props = {
+        playerID: 'player-id',
+        transcripts: [
+          {
+            canvasId: 0,
+            items: [
+              {
+                title: 'WebVTT Transcript',
+                url: 'https://example.com/lunchroom_manners.vtt',
+              },
+            ],
+          },
+        ],
+      };
+
+      const parseTranscriptMock = jest
+        .spyOn(transcriptParser, 'parseTranscriptData')
+        .mockReturnValue({
+          tData: [],
+          tUrl: 'https://example.com/lunchroom_manners.vtt',
+          tType: transcriptParser.TRANSCRIPT_TYPES.invalidTimestamp,
+        });
+
+      const TranscriptWithState = withManifestAndPlayerProvider(Transcript, {
+        initialManifestState: { manifest: lunchroomManners, canvasIndex: 0 },
+        initialPlayerState: {},
+        ...props
+      });
+
+      render(
+        <React.Fragment>
+          <video id="player-id" />
+          <TranscriptWithState />
+        </React.Fragment>
+      );
+
+      await act(() => Promise.resolve());
+
+      await waitFor(() => {
+        expect(parseTranscriptMock).toHaveBeenCalled();
+        expect(screen.queryByTestId('transcript_content_-4')).toBeInTheDocument();
+        expect(screen.queryByTestId('no-transcript')).toBeInTheDocument();
+        expect(screen.getByTestId('no-transcript')).toHaveTextContent(
+          'Invalid timestamp format in cue(s), please check again.'
         );
       });
     });

--- a/src/services/transcript-parser.test.js
+++ b/src/services/transcript-parser.test.js
@@ -852,7 +852,7 @@ describe('transcript-parser', () => {
         expect(tData).toHaveLength(0);
         expect(console.error).toHaveBeenCalledTimes(1);
         expect(console.error).toHaveBeenCalledWith('Invalid WebVTT file');
-        expect(tType).toEqual(transcriptParser.TRANSCRIPT_TYPES.invalidTimedText);
+        expect(tType).toEqual(transcriptParser.TRANSCRIPT_TYPES.invalidVTT);
       });
 
       test('with random text in the header', () => {
@@ -866,10 +866,10 @@ describe('transcript-parser', () => {
         expect(tData).toHaveLength(0);
         expect(console.error).toHaveBeenCalledTimes(1);
         expect(console.error).toHaveBeenCalledWith('Invalid WebVTT file');
-        expect(tType).toEqual(transcriptParser.TRANSCRIPT_TYPES.invalidTimedText);
+        expect(tType).toEqual(transcriptParser.TRANSCRIPT_TYPES.invalidVTT);
       });
 
-      test('with incorrect timestamp', () => {
+      test('with incorrect timestamp with missing seconds group in hh:mm:ss format', () => {
         // mock console.error
         console.error = jest.fn();
         const mockResponse =
@@ -877,13 +877,30 @@ describe('transcript-parser', () => {
 
         const { tData, tType } = transcriptParser.parseTimedText(mockResponse);
 
-        expect(tData).toHaveLength(4);
+        expect(tData).toBeNull();
         expect(console.error).toHaveBeenCalledTimes(1);
         expect(console.error).toHaveBeenCalledWith(
           'Invalid timestamp in line with text; ',
           '[music]'
         );
-        expect(tType).toEqual(transcriptParser.TRANSCRIPT_TYPES.timedText);
+        expect(tType).toEqual(transcriptParser.TRANSCRIPT_TYPES.invalidTimestamp);
+      });
+
+      test('with incorrect timestamp with a single digit for hour in hh:mm:ss format', () => {
+        // mock console.error
+        console.error = jest.fn();
+        const mockResponse =
+          'WEBVTT\r\n\r\n1\r\n0:00:01.200 --> 0:00:00.000\n[music]\n\r\n2\r\n0:00:22.200 --> 0:00:26.600\nJust before lunch one day, a puppet show \nwas put on at school.\n\r\n3\r\n0:00:26.700 --> 0:00:31.500\nIt was called "Mister Bungle Goes to Lunch".\n\r\n4\r\n0:00:31.600 --> 0:00:34.500\nIt was fun to watch.\r\n\r\n5\r\n0:00:36.100 --> 0:00:41.300\nIn the puppet show, Mr. Bungle came to the \nboys\' room on his way to lunch.\n';
+
+        const { tData, tType } = transcriptParser.parseTimedText(mockResponse);
+
+        expect(tData).toBeNull();
+        expect(console.error).toHaveBeenCalledTimes(5);
+        expect(console.error).toHaveBeenCalledWith(
+          'Invalid timestamp in line with text; ',
+          '[music]'
+        );
+        expect(tType).toEqual(transcriptParser.TRANSCRIPT_TYPES.invalidTimestamp);
       });
     });
   });


### PR DESCRIPTION
Related issue: #537 

Display a message when at least one of the timestamps in SRT/VTT cues are invalid:

<img width="497" alt="Screenshot 2024-07-01 at 3 34 43 PM" src="https://github.com/samvera-labs/ramp/assets/1331659/934e592c-3c5d-4b53-b026-afcd413f8cba">