### PR TITLE
Text search nav

### DIFF
--- a/src/components/Transcript/Transcript.js
+++ b/src/components/Transcript/Transcript.js
@@ -108,7 +108,7 @@ const TranscriptLine = ({
         const currentHighlight = highlights[activeRelativeCountRef.current];
         if (currentHighlight != undefined) {
           currentHighlight.classList.add('current-hit');
-          autoScroll(currentHighlight, transcriptContainerRef);
+          autoScroll(currentHighlight, transcriptContainerRef, true);
         }
       }
       // Update the ref for focused match index in the component
@@ -121,7 +121,7 @@ const TranscriptLine = ({
     e.stopPropagation();
     if (item.match && focusedMatchId !== item.id) {
       setFocusedMatchId(item.id);
-    } else if (focusedMatchId !== null) {
+    } else if (focusedMatchId !== null && item.tag === TRANSCRIPT_CUE_TYPES.timedCue) {
       autoScroll(itemRef.current, transcriptContainerRef, true);
     }
     goToItem(item);

--- a/src/components/Transcript/Transcript.js
+++ b/src/components/Transcript/Transcript.js
@@ -41,12 +41,15 @@ const TranscriptLine = ({
   autoScrollEnabled,
   showNotes,
   transcriptContainerRef,
-  isNonTimedText
+  isNonTimedText,
+  focusedMatchIndex,
 }) => {
   const itemRef = React.useRef(null);
   const isFocused = item.id === focusedMatchId;
   const wasFocusedRef = React.useRef(isFocused);
   const wasActiveRef = React.useRef(isActive);
+  const focusedIndexRef = React.useRef(1);
+  const activeRelativeCountRef = React.useRef(0);
 
   React.useEffect(() => {
     let doScroll = false;
@@ -68,6 +71,27 @@ const TranscriptLine = ({
       autoScroll(itemRef.current, transcriptContainerRef, true);
     }
   }, [autoScrollEnabled, isActive, isFocused, itemRef.current]);
+
+  React.useEffect(() => {
+    if (itemRef.current && isFocused) {
+      activeRelativeCountRef.current = 0;
+    }
+  }, [focusedMatchId]);
+
+  React.useEffect(() => {
+    if (itemRef.current && isFocused) {
+      const highlights = itemRef.current.querySelectorAll('.ramp--transcript_highlight');
+      highlights.forEach(h => h.style.border = 'none');
+      console.log(activeRelativeCountRef.current, focusedMatchIndex, focusedIndexRef.current);
+      const currentHighlight = highlights[activeRelativeCountRef.current];
+      currentHighlight.style.border = '1px solid';
+      autoScroll(currentHighlight, transcriptContainerRef, true);
+      activeRelativeCountRef.current = focusedMatchIndex > focusedIndexRef.current && focusedIndexRef.current >= 0
+        ? activeRelativeCountRef.current + 1
+        : activeRelativeCountRef.current - 1;
+      focusedIndexRef.current = focusedMatchIndex;
+    }
+  }, [focusedMatchIndex]);
 
   const onClick = (e) => {
     e.preventDefault();
@@ -158,7 +182,8 @@ const TranscriptList = ({
   setFocusedMatchId,
   autoScrollEnabled,
   showNotes,
-  transcriptContainerRef
+  transcriptContainerRef,
+  focusedMatchIndex,
 }) => {
   const [manuallyActivatedItemId, setManuallyActivatedItem] = React.useState(null);
   const goToItem = React.useCallback((item) => {
@@ -215,6 +240,7 @@ const TranscriptList = ({
                 showNotes={showNotes}
                 transcriptContainerRef={transcriptContainerRef}
                 isNonTimedText={true}
+                focusedMatchIndex={focusedMatchIndex}
               />
             ))
           }
@@ -534,6 +560,7 @@ const Transcript = ({ playerID, manifestUrl, showNotes = false, search = {}, tra
             autoScrollEnabled={autoScrollEnabledRef.current && searchQuery === null}
             showNotes={showNotes}
             transcriptContainerRef={transcriptContainerRef}
+            focusedMatchIndex={focusedMatchIndex}
           />
         </div>
       </div>

--- a/src/components/Transcript/Transcript.scss
+++ b/src/components/Transcript/Transcript.scss
@@ -36,12 +36,8 @@
   }
 }
 
-p.ramp--transcript_item {
-  &.focused,
-  &.focused:hover,
-  &.focused:focus {
-    background-color: $primaryGreenSemiLight;
-  }
+p.ramp--transcript_untimed_item {
+  margin: 0;
 }
 
 a.ramp--transcript_item {
@@ -68,6 +64,13 @@ a.ramp--transcript_item {
   &.focused:hover,
   &.focused:focus {
     background-color: $primaryGreenSemiLight;
+  }
+
+  &.focused {
+    .ramp--transcript_highlight.current-hit {
+      border: 1px solid;
+      text-decoration: none;
+    }
   }
 
   .ramp--transcript_time {

--- a/src/services/search.js
+++ b/src/services/search.js
@@ -170,7 +170,7 @@ export function useFilteredTranscripts({
   }, [matcher, query, enabled, sorter, matchesOnly, showMarkers, playerDispatch, selectedTranscript]);
 
   const callSearchFactory = () => {
-    clearTimeout(debounceTimerRef.current);
+    if (!debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
 
     const abortController = new AbortController();
     abortControllerRef.current = abortController;
@@ -342,6 +342,12 @@ export const useFocusedMatch = ({ searchResults }) => {
       setFocusedMatchIndex(searchResults.matchingIds.length - 1);
     }
   }, [searchResults.matchingIds, focusedMatchIndex]);
+
+  useEffect(() => {
+    if (searchResults.matchingIds.length && focusedMatchIndex > 0) {
+      setFocusedMatchIndex(null);
+    }
+  }, [searchResults.matchingIds]);
 
   return { focusedMatchId, setFocusedMatchId, focusedMatchIndex, setFocusedMatchIndex };
 };

--- a/src/services/search.test.js
+++ b/src/services/search.test.js
@@ -254,112 +254,271 @@ describe('useFilteredTranscripts', () => {
 
   describe('content search behavior', () => {
     describe('with timed-text', () => {
-      beforeEach(() => {
-        global.fetch = jest.fn().mockImplementation(() =>
-          Promise.resolve({
-            json: () => {
-              return {
-                id: 'http://example.com/1/search?q=bungle',
-                type: 'AnnotationPage',
-                items: [
-                  {
-                    id: 'http://example.com/canvas/1/search/3',
-                    type: 'Annotation',
-                    motivation: 'supplementing',
-                    target: "http://example.com/canvas/1/transcript/1#t=00:01:45.000,00:01:49.200",
-                    body: {
-                      type: 'TextualBody',
-                      value: "Once there they were introduced by somebody who knew <em>Gatsby</em>,",
-                      format: 'text/plain'
-                    }
-                  },
-                  {
-                    id: 'http://example.com/canvas/1/search/4',
-                    type: 'Annotation',
-                    motivation: 'supplementing',
-                    target: "http://example.com/canvas/1/transcript/1#t=00:02:01.300,00:02:03.900",
-                    body: {
-                      type: 'TextualBody',
-                      value: "Sometimes they came and went without having met <em>Gatsby</em> at all,",
-                      format: 'text/plain'
-                    }
-                  },
-                ]
-              };
-            },
-          })
-        );
-      });
-      const matcherFactory = (items) => {
-        const matcher = contentSearchFactory('http://example.com/1/search', items, 'http://example.com/canvas/1/transcript/1');
-        return async (query, abortController) => {
-          const results = matcher(query, abortController);
-          await new Promise(r => setTimeout(r, 500));
-          return results;
-        };
-      };
-
-      test('when the search query is null, all results are returned with 0 matches', async () => {
-        const { resultRef, Component } = createTest({ matcherFactory, transcripts: transcriptsFixture, query: null });
-        render(Component);
-        await waitFor(() => expect(resultRef.current).toEqual(fixture));
-      });
-      test('when enabled: false is passed, all results are returned with 0 matches', async () => {
-        const { resultRef, Component } = createTest({ enabled: false, transcripts: transcriptsFixture });
-        render(Component);
-        await waitFor(() => expect(resultRef.current).toEqual(fixture));
-      });
-      test('when the search query is set, matchingIds will contain ids of matches', async () => {
-        const { resultRef, Component } = createTest({
-          matcherFactory,
-          transcripts: transcriptsFixture,
-          query: 'Gatsby'
-        });
-        render(Component);
-        await waitFor(() => {
-          expect(resultRef.current.matchingIds).toEqual([5, 7]);
-          expect(resultRef.current.counts).toEqual([{
-            transcriptURL: 'http://example.com/canvas/1/transcript/1',
-            numberOfHits: 2
-          }]);
-        });
-      });
-      test('when matchesOnly is true, only matching results are returned', async () => {
-        const { resultRef, Component } = createTest({
-          matcherFactory,
-          transcripts: transcriptsFixture,
-          query: 'Gatsby',
-          matchesOnly: true
-        });
-        render(Component);
-        await waitFor(() => {
-          expect(resultRef.current.matchingIds).toEqual([5, 7]);
-          expect(resultRef.current.counts).toEqual([{
-            transcriptURL: 'http://example.com/canvas/1/transcript/1',
-            numberOfHits: 2
-          }]);
-        });
-      });
-      test('results included in the match set will include a match property for highlighting matches', async () => {
-        const { resultRef, Component } = createTest({
-          matcherFactory,
-          transcripts: transcriptsFixture,
-          query: 'Gatsby'
-        });
-        render(Component);
-        await waitFor(() => {
-          expect(resultRef.current.results[5].match).toEqual(
-            'Once there they were introduced by somebody who knew <span class="ramp--transcript_highlight">Gatsby</span>,'
+      describe('with single word query', () => {
+        beforeEach(() => {
+          global.fetch = jest.fn().mockImplementation(() =>
+            Promise.resolve({
+              json: () => {
+                return {
+                  id: 'http://example.com/1/search?q=bungle',
+                  type: 'AnnotationPage',
+                  items: [
+                    {
+                      id: 'http://example.com/canvas/1/search/3',
+                      type: 'Annotation',
+                      motivation: 'supplementing',
+                      target: "http://example.com/canvas/1/transcript/1#t=00:01:45.000,00:01:49.200",
+                      body: {
+                        type: 'TextualBody',
+                        value: "Once there they were introduced by somebody who knew <em>Gatsby</em>,",
+                        format: 'text/plain'
+                      }
+                    },
+                    {
+                      id: 'http://example.com/canvas/1/search/4',
+                      type: 'Annotation',
+                      motivation: 'supplementing',
+                      target: "http://example.com/canvas/1/transcript/1#t=00:02:01.300,00:02:03.900",
+                      body: {
+                        type: 'TextualBody',
+                        value: "Sometimes they came and went without having met <em>Gatsby</em> at all,",
+                        format: 'text/plain'
+                      }
+                    },
+                  ]
+                };
+              },
+            })
           );
         });
-        expect(resultRef.current.results[7].match).toEqual(
-          'Sometimes they came and went without having met <span class="ramp--transcript_highlight">Gatsby</span> at all,'
-        );
+        const matcherFactory = (items) => {
+          const matcher = contentSearchFactory('http://example.com/1/search', items, 'http://example.com/canvas/1/transcript/1');
+          return async (query, abortController) => {
+            const results = matcher(query, abortController);
+            await new Promise(r => setTimeout(r, 500));
+            return results;
+          };
+        };
+
+        test('when the search query is null, all results are returned with 0 matches', async () => {
+          const { resultRef, Component } = createTest({ matcherFactory, transcripts: transcriptsFixture, query: null });
+          render(Component);
+          await waitFor(() => expect(resultRef.current).toEqual(fixture));
+        });
+        test('when enabled: false is passed, all results are returned with 0 matches', async () => {
+          const { resultRef, Component } = createTest({ enabled: false, transcripts: transcriptsFixture });
+          render(Component);
+          await waitFor(() => expect(resultRef.current).toEqual(fixture));
+        });
+        test('when the search query is set, matchingIds will contain ids of matches', async () => {
+          const { resultRef, Component } = createTest({
+            matcherFactory,
+            transcripts: transcriptsFixture,
+            query: 'Gatsby'
+          });
+          render(Component);
+          await waitFor(() => {
+            expect(resultRef.current.matchingIds).toEqual([5, 7]);
+            expect(resultRef.current.counts).toEqual([{
+              transcriptURL: 'http://example.com/canvas/1/transcript/1',
+              numberOfHits: 2
+            }]);
+          });
+        });
+        test('when matchesOnly is true, only matching results are returned', async () => {
+          const { resultRef, Component } = createTest({
+            matcherFactory,
+            transcripts: transcriptsFixture,
+            query: 'Gatsby',
+            matchesOnly: true
+          });
+          render(Component);
+          await waitFor(() => {
+            expect(resultRef.current.matchingIds).toEqual([5, 7]);
+            expect(resultRef.current.counts).toEqual([{
+              transcriptURL: 'http://example.com/canvas/1/transcript/1',
+              numberOfHits: 2
+            }]);
+          });
+        });
+        test('results included in the match set will include a match property for highlighting matches', async () => {
+          const { resultRef, Component } = createTest({
+            matcherFactory,
+            transcripts: transcriptsFixture,
+            query: 'Gatsby'
+          });
+          render(Component);
+          await waitFor(() => {
+            expect(resultRef.current.results[5].match).toEqual(
+              'Once there they were introduced by somebody who knew <span class="ramp--transcript_highlight">Gatsby</span>,'
+            );
+          });
+          expect(resultRef.current.results[7].match).toEqual(
+            'Sometimes they came and went without having met <span class="ramp--transcript_highlight">Gatsby</span> at all,'
+          );
+        });
+      });
+
+      describe('with phrase search query', () => {
+        beforeAll(() => {
+          global.fetch = jest.fn().mockImplementation(() =>
+            Promise.resolve({
+              json: () => {
+                return {
+                  id: 'http://example.com/1/search?q=bungle',
+                  type: 'AnnotationPage',
+                  items: [
+                    {
+                      id: 'http://example.com/canvas/1/search/4',
+                      type: 'Annotation',
+                      motivation: 'supplementing',
+                      target: "http://example.com/canvas/1/transcript/1#t=00:02:01.300,00:02:03.900",
+                      body: {
+                        type: 'TextualBody',
+                        value: "Sometimes they came and went without having <em>met</em> <em>Gatsby</em> at all,",
+                        format: 'text/plain'
+                      }
+                    },
+                  ]
+                };
+              },
+            })
+          );
+        });
+        const matcherFactory = (items) => {
+          const matcher = contentSearchFactory('http://example.com/1/search', items, 'http://example.com/canvas/1/transcript/1');
+          return async (query, abortController) => {
+            const results = matcher(query, abortController);
+            await new Promise(r => setTimeout(r, 500));
+            return results;
+          };
+        };
+
+        test('results include matched text with search phrase highlighted', async () => {
+          const { resultRef, Component } = createTest({
+            matcherFactory,
+            transcripts: transcriptsFixture,
+            query: 'met gatsby'
+          });
+          render(Component);
+          await waitFor(() => {
+            expect(resultRef.current.results[7].match).toEqual(
+              'Sometimes they came and went without having <span class="ramp--transcript_highlight">met Gatsby</span> at all,'
+            );
+          });
+        });
       });
     });
 
     describe('with untimed-text', () => {
-      beforeEach(() => {
+      describe('with a single word query', () => {
+        beforeEach(() => {
+          global.fetch = jest.fn().mockImplementation(() =>
+            Promise.resolve({
+              json: () => {
+                return {
+                  id: 'http://example.com/1/search?q=bungle',
+                  type: 'AnnotationPage',
+                  items: [
+                    {
+                      id: 'http://example.com/canvas/1/search/3',
+                      type: 'Annotation',
+                      motivation: 'supplementing',
+                      target: "http://example.com/canvas/1/transcript/1",
+                      body: {
+                        type: 'TextualBody',
+                        value: "Once there they were introduced by somebody who knew <em>Gatsby</em>,",
+                        format: 'text/plain'
+                      }
+                    },
+                    {
+                      id: 'http://example.com/canvas/1/search/4',
+                      type: 'Annotation',
+                      motivation: 'supplementing',
+                      target: "http://example.com/canvas/1/transcript/1",
+                      body: {
+                        type: 'TextualBody',
+                        value: "Sometimes they came and went without having met <em>Gatsby</em> at all,",
+                        format: 'text/plain'
+                      }
+                    },
+                  ]
+                };
+              },
+            })
+          );
+        });
+        const matcherFactory = (items) => {
+          const matcher = contentSearchFactory('http://example.com/1/search', items, 'http://example.com/canvas/1/transcript/1');
+          return async (query, abortController) => {
+            const results = matcher(query, abortController);
+            await new Promise(r => setTimeout(r, 500));
+            return results;
+          };
+        };
+
+        test('when the search query is null, all results are returned with 0 matches', async () => {
+          const { resultRef, Component } = createTest({ matcherFactory, transcripts: untimedTranscriptFixture, query: null });
+          render(Component);
+          await waitFor(() => expect(resultRef.current).toEqual(untimedFixture));
+        });
+        test('when enabled: false is passed, all results are returned with 0 matches', async () => {
+          const { resultRef, Component } = createTest({ transcripts: untimedTranscriptFixture, enabled: false });
+          render(Component);
+          await waitFor(() => expect(resultRef.current).toEqual(untimedFixture));
+        });
+        test('when the search query is set, matchingIds will contain ids of matches', async () => {
+          const { resultRef, Component } = createTest({
+            matcherFactory,
+            transcripts: [...untimedTranscriptFixture],
+            query: 'Gatsby'
+          });
+          render(Component);
+          await waitFor(() => {
+            expect(resultRef.current.ids).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8]);
+            expect(resultRef.current.matchingIds).toEqual([5, 7]);
+            expect(resultRef.current.counts).toEqual([{
+              transcriptURL: 'http://example.com/canvas/1/transcript/1',
+              numberOfHits: 2
+            }]);
+          });
+        });
+        test('when matchesOnly is true, only matching results are returned', async () => {
+          const { resultRef, Component } = createTest({
+            matcherFactory,
+            transcripts: [...untimedTranscriptFixture],
+            query: 'Gatsby',
+            matchesOnly: true
+          });
+          render(Component);
+          await waitFor(() => {
+            expect(resultRef.current.matchingIds).toEqual([5, 7]);
+            expect(resultRef.current.ids).toEqual([5, 7]);
+            expect(resultRef.current.counts).toEqual([{
+              transcriptURL: 'http://example.com/canvas/1/transcript/1',
+              numberOfHits: 2
+            }]);
+          });
+        });
+        test('results included in the match set will include a match property for highlighting matches', async () => {
+          const { resultRef, Component } = createTest({
+            matcherFactory,
+            transcripts: [...untimedTranscriptFixture],
+            query: 'Gatsby'
+          });
+          render(Component);
+          await waitFor(() => {
+            expect(resultRef.current.results[5].match).toEqual(
+              'Once there they were introduced by somebody who knew <span class="ramp--transcript_highlight">Gatsby</span>,'
+            );
+          });
+          expect(resultRef.current.results[7].match).toEqual(
+            'Sometimes they came and went without having met <span class="ramp--transcript_highlight">Gatsby</span> at all,'
+          );
+        });
+      });
+
+      describe('with phrase search query', () => {
         global.fetch = jest.fn().mockImplementation(() =>
           Promise.resolve({
             json: () => {
@@ -368,24 +527,13 @@ describe('useFilteredTranscripts', () => {
                 type: 'AnnotationPage',
                 items: [
                   {
-                    id: 'http://example.com/canvas/1/search/3',
-                    type: 'Annotation',
-                    motivation: 'supplementing',
-                    target: "http://example.com/canvas/1/transcript/1",
-                    body: {
-                      type: 'TextualBody',
-                      value: "Once there they were introduced by somebody who knew <em>Gatsby</em>,",
-                      format: 'text/plain'
-                    }
-                  },
-                  {
                     id: 'http://example.com/canvas/1/search/4',
                     type: 'Annotation',
                     motivation: 'supplementing',
                     target: "http://example.com/canvas/1/transcript/1",
                     body: {
                       type: 'TextualBody',
-                      value: "Sometimes they came and went without having met <em>Gatsby</em> at all,",
+                      value: "Sometimes they came and went without having <em>met</em> <em>Gatsby</em> at all,",
                       format: 'text/plain'
                     }
                   },
@@ -394,74 +542,28 @@ describe('useFilteredTranscripts', () => {
             },
           })
         );
-      });
-      const matcherFactory = (items) => {
-        const matcher = contentSearchFactory('http://example.com/1/search', items, 'http://example.com/canvas/1/transcript/1');
-        return async (query, abortController) => {
-          const results = matcher(query, abortController);
-          await new Promise(r => setTimeout(r, 500));
-          return results;
+        const matcherFactory = (items) => {
+          const matcher = contentSearchFactory('http://example.com/1/search', items, 'http://example.com/canvas/1/transcript/1');
+          return async (query, abortController) => {
+            const results = matcher(query, abortController);
+            await new Promise(r => setTimeout(r, 500));
+            return results;
+          };
         };
-      };
 
-      test('when the search query is null, all results are returned with 0 matches', async () => {
-        const { resultRef, Component } = createTest({ matcherFactory, transcripts: untimedTranscriptFixture, query: null });
-        render(Component);
-        await waitFor(() => expect(resultRef.current).toEqual(untimedFixture));
-      });
-      test('when enabled: false is passed, all results are returned with 0 matches', async () => {
-        const { resultRef, Component } = createTest({ transcripts: untimedTranscriptFixture, enabled: false });
-        render(Component);
-        await waitFor(() => expect(resultRef.current).toEqual(untimedFixture));
-      });
-      test('when the search query is set, matchingIds will contain ids of matches', async () => {
-        const { resultRef, Component } = createTest({
-          matcherFactory,
-          transcripts: [...untimedTranscriptFixture],
-          query: 'Gatsby'
+        test('results included in the match set will include a match property for highlighting matches', async () => {
+          const { resultRef, Component } = createTest({
+            matcherFactory,
+            transcripts: [...untimedTranscriptFixture],
+            query: 'met gatsby'
+          });
+          render(Component);
+          await waitFor(() => {
+            expect(resultRef.current.results[7].match).toEqual(
+              'Sometimes they came and went without having <span class="ramp--transcript_highlight">met Gatsby</span> at all,'
+            );
+          });
         });
-        render(Component);
-        await waitFor(() => {
-          expect(resultRef.current.ids).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8]);
-          expect(resultRef.current.matchingIds).toEqual([5, 7]);
-          expect(resultRef.current.counts).toEqual([{
-            transcriptURL: 'http://example.com/canvas/1/transcript/1',
-            numberOfHits: 2
-          }]);
-        });
-      });
-      test('when matchesOnly is true, only matching results are returned', async () => {
-        const { resultRef, Component } = createTest({
-          matcherFactory,
-          transcripts: [...untimedTranscriptFixture],
-          query: 'Gatsby',
-          matchesOnly: true
-        });
-        render(Component);
-        await waitFor(() => {
-          expect(resultRef.current.matchingIds).toEqual([5, 7]);
-          expect(resultRef.current.ids).toEqual([5, 7]);
-          expect(resultRef.current.counts).toEqual([{
-            transcriptURL: 'http://example.com/canvas/1/transcript/1',
-            numberOfHits: 2
-          }]);
-        });
-      });
-      test('results included in the match set will include a match property for highlighting matches', async () => {
-        const { resultRef, Component } = createTest({
-          matcherFactory,
-          transcripts: [...untimedTranscriptFixture],
-          query: 'Gatsby'
-        });
-        render(Component);
-        await waitFor(() => {
-          expect(resultRef.current.results[5].match).toEqual(
-            'Once there they were introduced by somebody who knew <span class="ramp--transcript_highlight">Gatsby</span>,'
-          );
-        });
-        expect(resultRef.current.results[7].match).toEqual(
-          'Sometimes they came and went without having met <span class="ramp--transcript_highlight">Gatsby</span> at all,'
-        );
       });
     });
   });

--- a/src/services/transcript-parser.js
+++ b/src/services/transcript-parser.js
@@ -898,6 +898,13 @@ const getAllHits = (transcripts, mappedText, query, traversedIds) => {
   const matched = transcripts.filter((t) => {
     const cleaned = t.text.replace(/<\/?[^>]+>/gi, '').trim();
     const matches = [...cleaned.matchAll(queryregex)];
+    /**
+     * For untimed text the search response text could be either,
+     * - mapped one to one with the cue text in Transcript component
+     * - include a part of the cue text in Transcript component
+     * When none of these work check if the cue text contains the query
+     */
+
     return mappedText.trim() == cleaned || mappedText.trim().includes(cleaned) || matches?.length > 0;
   });
   let hits = [];
@@ -931,6 +938,7 @@ const getAllHits = (transcripts, mappedText, query, traversedIds) => {
  * @returns matched cue with HTML tags added for marking the hightlight 
  */
 export const markMatchedParts = (text, query, hasHighlight = false) => {
+  if (text === undefined || !text) return;
   let replacerFn = (match) => {
     const cleanedMatch = match.replace(/<\/?[^>]+>/gi, '');
     return `<span class="ramp--transcript_highlight">${cleanedMatch}</span>`;
@@ -958,6 +966,7 @@ export const markMatchedParts = (text, query, hasHighlight = false) => {
  * @returns a string formatted with highlights
  */
 export const addStyledHighlights = (text, query) => {
+  if (text === undefined || !text) return;
   let replacerFn = (match) => {
     const cleanedMatch = buildHighlightText(match);
     return cleanedMatch;

--- a/src/services/utility-helpers.js
+++ b/src/services/utility-helpers.js
@@ -1,4 +1,5 @@
 import { parseManifest, Annotation, AnnotationPage } from 'manifesto.js';
+import { decode } from 'html-entities';
 
 // Handled file types for downloads
 const VALID_FILE_EXTENSIONS = [
@@ -499,22 +500,13 @@ export function getLabelValue(label) {
     if (labelKeys && labelKeys.length > 0) {
       // Get the first key's first value
       const firstKey = labelKeys[0];
-      return label[firstKey].length > 0 ? decodeHTML(label[firstKey][0]) : '';
+      return label[firstKey].length > 0 ? decode(label[firstKey][0]) : '';
     }
   } else if (typeof label === 'string') {
-    return decodeHTML(label);
+    return decode(label);
   }
   return 'Label could not be parsed';
 }
-
-export function decodeHTML(labelText) {
-  return labelText
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&apos;/g, "'");
-};
 
 /**
  * Validate time input from user against the hh:mm:ss.ms format

--- a/src/services/utility-helpers.js
+++ b/src/services/utility-helpers.js
@@ -494,14 +494,6 @@ export function identifySupplementingAnnotation(uri) {
  * @param {Object} label
  */
 export function getLabelValue(label) {
-  let decodeHTML = (labelText) => {
-    return labelText
-      .replace(/&amp;/g, '&')
-      .replace(/&lt;/g, '<')
-      .replace(/&gt;/g, '>')
-      .replace(/&quot;/g, '"')
-      .replace(/&apos;/g, "'");
-  };
   if (label && typeof label === 'object') {
     const labelKeys = Object.keys(label);
     if (labelKeys && labelKeys.length > 0) {
@@ -514,6 +506,15 @@ export function getLabelValue(label) {
   }
   return 'Label could not be parsed';
 }
+
+export function decodeHTML(labelText) {
+  return labelText
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'");
+};
 
 /**
  * Validate time input from user against the hh:mm:ss.ms format


### PR DESCRIPTION
Related issue: #513 

This PR adds the ability to see focused search hits using results navigation when there are multiple hits within a focused cue.

Example of search results navigation when the transcript is one block of text:
![Screenshot 2024-07-09 at 5 11 46 PM](https://github.com/samvera-labs/ramp/assets/1331659/f217cac0-1128-4336-bf35-7c285f503d79)
