### PR TITLE
Check if manfiestState exists for search service parsing

### DIFF
--- a/src/services/search.js
+++ b/src/services/search.js
@@ -112,10 +112,12 @@ export function useFilteredTranscripts({
 
   // Parse searchService from the Canvas/Manifest
   useEffect(() => {
-    const { manifest } = manifestState;
-    if (manifest) {
-      let serviceId = getSearchService(manifest, canvasIndex);
-      setSearchService(serviceId);
+    if (manifestState) {
+      const { manifest } = manifestState;
+      if (manifest) {
+        let serviceId = getSearchService(manifest, canvasIndex);
+        setSearchService(serviceId);
+      }
     }
     // Reset cached search hits on Canvas change
     setAllSearchResults(null);


### PR DESCRIPTION
Check existence of `manifestState` context in the `search.js` when trying to parse the search service from the given Manifest.
Without this check the transcript component crashes when used outside of the context providers.