### PR TITLE
Change vertical-align CSS for SVG

### DIFF
--- a/src/components/MediaPlayer/VideoJS/components/styles/VideoJSFileDownload.scss
+++ b/src/components/MediaPlayer/VideoJS/components/styles/VideoJSFileDownload.scss
@@ -35,7 +35,7 @@
 
 .vjs-menu-item-text span,
 svg {
-  vertical-align: middle;
+  vertical-align: top;
   display: inline-block;
 }
 


### PR DESCRIPTION
Related issue: https://github.com/avalonmediasystem/avalon/issues/5927

Once this is brought into Avalon we probably could undo the changes in https://github.com/avalonmediasystem/avalon/pull/5921 as this takes care of the misalignment of svg icons in Ramp.