### PR TITLE
Read duration from either options or player property in progressbar

### DIFF
--- a/src/components/MediaPlayer/MediaPlayer.js
+++ b/src/components/MediaPlayer/MediaPlayer.js
@@ -315,7 +315,7 @@ const MediaPlayer = ({
   };
 
   React.useEffect(() => {
-    const hlsOptions = withCredentials ? { hls: { withCredentials: true } } : {}
+    const hlsOptions = withCredentials ? { hls: { withCredentials: true } } : {};
     let videoJsOptions;
     // Only build the full set of option for the first playable Canvas since
     // these options are only used on the initia Video.js instance creation
@@ -360,7 +360,6 @@ const MediaPlayer = ({
             // 'vjsYo',             custom component
           ],
           videoJSProgress: {
-            duration: canvasDuration,
             srcIndex,
             targets,
             currentTime: currentTime || 0,

--- a/src/components/MediaPlayer/VideoJS/components/js/VideoJSProgress.js
+++ b/src/components/MediaPlayer/VideoJS/components/js/VideoJSProgress.js
@@ -39,7 +39,7 @@ class VideoJSProgress extends vjsComponent {
       this.options.targets = this.player.targets?.length > 0
         ? this.player.targets
         : this.options.targets;
-      this.options.duration = this.player.canvasDuration;
+      this.options.duration ||= this.player.canvasDuration;
       this.mount();
       this.initProgressBar();
     });

--- a/src/components/MediaPlayer/VideoJS/components/js/VideoJSProgress.js
+++ b/src/components/MediaPlayer/VideoJS/components/js/VideoJSProgress.js
@@ -39,7 +39,6 @@ class VideoJSProgress extends vjsComponent {
       this.options.targets = this.player.targets?.length > 0
         ? this.player.targets
         : this.options.targets;
-      this.options.duration ||= this.player.canvasDuration;
       this.mount();
       this.initProgressBar();
     });
@@ -47,16 +46,17 @@ class VideoJSProgress extends vjsComponent {
 
   /** Build progress bar elements from the options */
   initProgressBar() {
-    const { targets, duration, srcIndex } = this.options;
+    const { targets, srcIndex } = this.options;
     const { start, end } = targets[srcIndex];
+    const duration = this.player.canvasDuration;
     let startTime = start,
       endTime = end;
 
     const isMultiSourced = targets.length > 1 ? true : false;
-    let totalDuration = targets.reduce((acc, t) => acc + t.duration, 0);
 
     let toPlay;
     if (isMultiSourced) {
+      let totalDuration = targets.reduce((acc, t) => acc + t.duration, 0);
       // Calculate the width of the playable range as a percentage of total
       // Canvas duration
       toPlay = Math.min(


### PR DESCRIPTION
I was still seeing the shortened progressbar on initial load in the Ramp demo site (#567) in Firefox. It seems on the initial load of the page it's safer to read the duration from options passed into the `VideoJSProgress` component rather than relying on `canvasDuration` property of the player instance.