### PR TITLE
After an inaccessible item play the next item if user has started playback

### DIFF
--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -566,11 +566,13 @@ function VideoJSPlayer({
     playerLoadedMetadata(player);
 
     player.on('pause', () => {
-      // When canvas is empty the pause event is temporary to keep the player
-      // instance on page without playing for inaccessible items. The state
-      // update is blocked on these events, since it is expected to autoplay
-      // the next time player is loaded with playable media.
-      if (!canvasIsEmptyRef.current) {
+      /**
+       * When canvas is empty the pause event is temporary to keep the player
+       * instance on page without playing for inaccessible items. The state
+       * update is blocked on these events, since it is expected to autoplay
+       * the next time player is loaded with playable media.
+       */
+      if (!canvasIsEmptyRef.current && isReadyRef.current) {
         playerDispatch({ isPlaying: false, type: 'setPlayingStatus' });
       }
     });
@@ -586,8 +588,14 @@ function VideoJSPlayer({
       handleTimeUpdate();
     });
     player.on('ended', () => {
-      playerDispatch({ isEnded: true, type: 'setIsEnded' });
-      handleEnded();
+      /**
+       * Checking against isReadyRef stops from delayed events being executed
+       * when transitioning from a Canvas to another
+       */
+      if (isReadyRef.current) {
+        playerDispatch({ isEnded: true, type: 'setIsEnded' });
+        handleEnded();
+      }
     });
     player.on('volumechange', () => {
       setStartMuted(player.muted());

--- a/src/components/StructuredNavigation/StructuredNavigation.js
+++ b/src/components/StructuredNavigation/StructuredNavigation.js
@@ -131,13 +131,6 @@ const StructuredNavigation = () => {
         playerDispatch({
           type: 'resetClick',
         });
-        // Ensure autoplay from inaccessible items in playlists
-        if (playlist) {
-          playerDispatch({
-            isPlaying: autoAdvance,
-            type: 'setPlayingStatus',
-          })
-        }
       }
     }
   }, [isClicked, player]);


### PR DESCRIPTION
Related issue: #580 

Fixed behavior in PR:
- If the user has started playback at some point play the next item after an inaccessible item when the timer ends
- If the user has not started playback at any point/started playback and paused it before reaching the inaccessible item don't play the next item after an inaccessible item when the timer ends

**Not sure whether this can go into 7.8, needs to discuss before merging**