### PR TITLE
Only reset isClicked if active structure item is set

### DIFF
--- a/src/components/StructuredNavigation/NavUtils/ListItem.js
+++ b/src/components/StructuredNavigation/NavUtils/ListItem.js
@@ -76,7 +76,10 @@ const ListItem = ({
       && structureContainerRef.current.isScrolling != undefined && !structureContainerRef.current.isScrolling) {
       autoScroll(liRef.current, structureContainerRef);
     }
-    liRef.current.isClicked = false;
+    // Reset isClicked if active structure item is set
+    if (liRef.current) {
+      liRef.current.isClicked = false;
+    }
   }, [currentNavItem]);
 
   const renderListItem = () => {


### PR DESCRIPTION
This fixes an error I was seeing with an item in staging but not in production.  Without this fix ramp crashes before fully loading with `TypeError: k.current is null`
https://mco-staging.dlib.indiana.edu/media_objects/dj52wp041/manifest.json