### PR TITLE
Align CC btn in control bar with green border

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -61,6 +61,11 @@
   font-size: 90%;
 }
 
+/* Center the CC button in mobile devices */
+.vjs-subs-caps-button>button {
+  padding: 0;
+}
+
 .is-mobile .vjs-control {
   width: 2rem !important;
 }


### PR DESCRIPTION
Related issue: #586 

~~**Wait for 7.8 Ramp release to be merged**~~

Before:

![bs_realios_Tablet_iPad Pro 13 2024-17 0](https://github.com/user-attachments/assets/b401956f-5175-45be-bf9e-c2bcbe00ac27)

After:
![bs_realios_Tablet_iPad Pro 13 2024-17 0 (1)](https://github.com/user-attachments/assets/ba0705c1-0d7b-46bc-8854-eb18cabcec62)
