### PR TITLE
Set duration on page load for progressbar creation

### DIFF
--- a/src/components/MediaPlayer/MediaPlayer.js
+++ b/src/components/MediaPlayer/MediaPlayer.js
@@ -263,6 +263,7 @@ const MediaPlayer = ({
           timeFragment = { start: 0, end: duration };
         }
         timeFragment.altStart = timeFragment.start;
+        timeFragment.duration = duration;
         /*
          * This is necessary to ensure expected progress bar behavior when
          * there is a start defined at the manifest level

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -339,7 +339,6 @@ function VideoJSPlayer({
     player.src(options.sources);
     player.poster(options.poster);
     player.canvasIndex = cIndexRef.current;
-    player.canvasDuration = canvasDurationRef.current;
     player.srcIndex = srcIndex;
     player.targets = targets;
     player.canvasIsEmpty = canvasIsEmptyRef.current;
@@ -467,11 +466,6 @@ function VideoJSPlayer({
       console.log('Player loadedmetadata');
 
       player.duration(canvasDurationRef.current);
-      /**
-       * Set property canvasDuration in the player to use in videoJSProgress component.
-       * This updates the property when player.src() is updates.
-       */
-      player.canvasDuration = canvasDurationRef.current;
 
       // Reveal player once metadata is loaded
       player.removeClass('vjs-disabled');
@@ -565,14 +559,6 @@ function VideoJSPlayer({
       player.srcIndex = srcIndex;
       player.duration(canvasDurationRef.current);
 
-      /**
-       * Set property canvasDuration in the player to use in videoJSProgress component.
-       * Video.js' in-built duration function doesn't seem to update as fast as
-       * we expect to be used in videoJSProgress component.
-       * Setting this in the ready callback makes sure this is updated to the
-       * correct value before 'loadstart' event is fired in videoJSProgress component.
-       */
-      player.canvasDuration = canvasDurationRef.current;
       if (enableTitleLink) { player.canvasLink = canvasLinkRef.current; }
       // Need to set this once experimentalSvgIcons option in Video.js options was enabled
       player.getChild('controlBar').qualitySelector.setIcon('cog');

--- a/src/components/MediaPlayer/VideoJS/components/js/VideoJSProgress.js
+++ b/src/components/MediaPlayer/VideoJS/components/js/VideoJSProgress.js
@@ -48,8 +48,7 @@ class VideoJSProgress extends vjsComponent {
   /** Build progress bar elements from the options */
   initProgressBar() {
     const { targets, srcIndex } = this.options;
-    const { start, end } = targets[srcIndex];
-    const duration = this.player.canvasDuration;
+    const { start, end, duration } = targets[srcIndex];
     let startTime = start,
       endTime = end;
 
@@ -122,7 +121,6 @@ class VideoJSProgress extends vjsComponent {
       if (nextItems.length == 0) { options.nextItemClicked(0, targets[0].start); }
       player.pause();
       player.trigger('ended');
-
 
       // On the next play event set the time to start or a seeked time
       // in between the 'ended' event and 'play' event
@@ -444,13 +442,13 @@ function ProgressBar({
    * Set start values for progress bar
    * @param {Number} start canvas start time
    */
-  const initializeProgress = (start) => {  
+  const initializeProgress = (start) => {
     setProgress(start);
     setInitTime(start);
 
     setCurrentTime(start);
     player.currentTime(start);
-  }
+  };
 
   /**
    * Set progress and player time when using the input range


### PR DESCRIPTION
Related issue: #567 

These changes were overwritten in conflict resolution. This was supposed to be on Ramp 3.2 release.

For me in testing things; this was happening intermittently on Firefox mostly and less in Chrome and Safari.
