### PR TITLE
Sanitize manifest url if params included in middle

### DIFF
--- a/src/components/IIIFPlayerWrapper.js
+++ b/src/components/IIIFPlayerWrapper.js
@@ -34,8 +34,13 @@ export default function IIIFPlayerWrapper({
         //credentials: 'include',
         // headers: { 'Avalon-Api-Key': '' },
       };
+      /**
+       * Sanitize manifest urls of query or anchor fragments included in the
+       * middle of the url: hhtp://example.com/endpoint?params/manifest
+       */
+      const sanitizedUrl = manifestUrl.replace(/[\?#].*(?=\/)/i, '')
       try {
-        await fetch(manifestUrl, requestOptions)
+        await fetch(sanitizedUrl, requestOptions)
           .then((result) => {
             if (result.status != 200 && result.status != 201) {
               throw new Error('Failed to fetch Manifest. Please check again.');


### PR DESCRIPTION
This commit is to fix an issue found with Ramp embedded in Avalon. If the request url from Avalon has params on the end, Avalon feeds the entire url into Ramp as
`https://example.com/endpoint?params/manifest.json`. This causes media to fail to load because it is not a valid manifest url. By removing the params from the middle of the url, we can get Ramp to request the proper manifest url.

Related issue: #615 