### PR TITLE
Reveal player early on progress event with enough data for playback

### DIFF
--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -468,9 +468,6 @@ function VideoJSPlayer({
 
       player.duration(canvasDurationRef.current);
 
-      // Reveal player once metadata is loaded
-      player.removeClass('vjs-disabled');
-
       isEndedRef.current ? player.currentTime(0) : player.currentTime(currentTimeRef.current);
 
       if (isEndedRef.current || isPlayingRef.current) {
@@ -579,6 +576,10 @@ function VideoJSPlayer({
       }
     });
 
+    player.on('progress', () => {
+      // Reveal player, since this state has enough segments to start playback
+      if (player.hasClass('vjs-disabled')) { player.removeClass('vjs-disabled'); }
+    });
     player.on('canplay', () => {
       // Reset isEnded flag
       playerDispatch({ isEnded: false, type: 'setIsEnded' });

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -533,6 +533,10 @@ function VideoJSPlayer({
       if (!isVideo && (IS_SAFARI || IS_IOS) && player.readyState() != 4) {
         player.load();
       }
+
+      // Reveal player if not revealed on 'progress' event, allowing user to 
+      // interact with the player since enough data is available for playback
+      if (player.hasClass('vjs-disabled')) { player.removeClass('vjs-disabled'); }
     });
   };
 
@@ -577,7 +581,8 @@ function VideoJSPlayer({
     });
 
     player.on('progress', () => {
-      // Reveal player, since this state has enough segments to start playback
+      // Reveal player if not revealed on 'loadedmetadata' event, allowing user to 
+      // interact with the player since enough data is available for playback
       if (player.hasClass('vjs-disabled')) { player.removeClass('vjs-disabled'); }
     });
     player.on('canplay', () => {


### PR DESCRIPTION
Reveal player on `progress` event as the browser has enough data to start playback at this point.

I tested this on different browsers on different platforms for an [item from MCO](https://media.dlib.indiana.edu/media_objects/qj72p820d);
- Safari on iPhone: fires `progress` event first, and `loadedmetadata` event fires within ~10ms after that
- Safari on iPads and desktop: fires `loadedmetadata` event first, and the `progress` event fires within less than ~300ms of it
- Chrome on Android: fires `progress` event first, and `loadedmetadata` event fires within less than ~500ms (0.5sec) of it
- Firefox and Chrome on desktop: fires `progress` event first, and `loadedmetadata` event fires within less than ~1000ms (1sec) of it

Since the order in which the events are fired is different on different platforms;
The solution suggested in this PR is, to look for `vjs-disabled` class in the player, which adds the grey overlay on top of the player in both `loadedmetadata` and `progress` events. And whichever event sees it first unveils the player. 
And this should still serve the  purpose of blocking the player until enough data is available for playback.