### PR TITLE
Initial attempt at retaining collapse/expand sections with custom hooks

### DIFF
--- a/src/components/StructuredNavigation/NavUtils/SectionHeading.js
+++ b/src/components/StructuredNavigation/NavUtils/SectionHeading.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { autoScroll } from '@Services/utility-helpers';
+import List from './List';
+import { useActiveStructure } from '@Services/structure';
 
 const SectionHeading = ({
   duration,
@@ -10,12 +12,30 @@ const SectionHeading = ({
   sectionRef,
   itemId,
   isRoot,
-  handleClick,
-  structureContainerRef
+  structureContainerRef,
+  hasChildren,
+  items,
 }) => {
+  let itemIdRef = React.useRef();
+  itemIdRef.current = itemId;
+
   let itemLabelRef = React.useRef();
   itemLabelRef.current = label;
 
+  const { handleClick } = useActiveStructure({
+    itemIdRef,
+    liRef: sectionRef,
+    sectionRef,
+    structureContainerRef,
+    isCanvas: true,
+    canvasDuration: duration
+  });
+
+  const [isOpen, setIsOpen] = React.useState(false);
+  const toggleOpen = (e) => {
+    setIsOpen(!isOpen);
+    sectionRef.current.isOpen = true;
+  };
   /*
     Auto-scroll active section into view only when user is not
     actively interacting with structured navigation
@@ -36,19 +56,32 @@ const SectionHeading = ({
       <div className={sectionClassName}
         role="listitem" data-testid="listitem-section"
         ref={sectionRef} data-mediafrag={itemId} data-label={itemLabelRef.current}>
-        <button data-testid="listitem-section-button"
-          ref={sectionRef} onClick={handleClick}>
-          <span className="ramp--structured-nav__title"
-            aria-label={itemLabelRef.current}
-          >
-            {`${itemIndex}. `}
-            {itemLabelRef.current}
-            {duration != '' &&
-              <span className="ramp--structured-nav__section-duration">
-                {duration}
-              </span>}
-          </span>
-        </button>
+        <div className="section-head-buttons">
+          <button data-testid="listitem-section-button"
+            ref={sectionRef} onClick={handleClick}>
+            <span className="ramp--structured-nav__title"
+              aria-label={itemLabelRef.current}
+            >
+              {`${itemIndex}. `}
+              {itemLabelRef.current}
+              {duration != '' &&
+                <span className="ramp--structured-nav__section-duration">
+                  {duration}
+                </span>}
+            </span>
+          </button>
+          {hasChildren && <button className="collapse-expand-button" onClick={toggleOpen}>
+            {isOpen ? "-" : "+"}
+          </button>}
+        </div>
+        {isOpen && hasChildren && (
+          <List
+            items={items}
+            sectionRef={sectionRef}
+            key={itemId}
+            structureContainerRef={structureContainerRef}
+          />
+        )}
       </div>
     );
   } else {
@@ -84,6 +117,7 @@ SectionHeading.propTypes = {
   isRoot: PropTypes.bool,
   handleClick: PropTypes.func.isRequired,
   structureContainerRef: PropTypes.object.isRequired,
+  hasChildren: PropTypes.bool,
 };
 
 export default SectionHeading;

--- a/src/components/StructuredNavigation/StructuredNavigation.js
+++ b/src/components/StructuredNavigation/StructuredNavigation.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import List from './NavUtils/List';
+import SectionHeading from './NavUtils/SectionHeading';
 import {
   usePlayerDispatch,
   usePlayerState,
@@ -216,12 +217,27 @@ const StructuredNavigation = () => {
       >
         {structureItemsRef.current?.length > 0 ? (
           structureItemsRef.current.map((item, index) => (
-            <List
-              items={[item]}
-              sectionRef={React.createRef()}
-              key={index}
-              structureContainerRef={structureContainerRef}
-            />
+            /* For playlist views omit the accordion style display of 
+            structure for canvas-level items */
+            item.isCanvas && !playlist.isPlaylist
+              ? (<SectionHeading
+                itemIndex={index + 1}
+                canvasIndex={item.canvasIndex}
+                duration={item.duration}
+                label={item.label}
+                sectionRef={React.createRef()}
+                itemId={item.id}
+                isRoot={item.isRoot}
+                structureContainerRef={structureContainerRef}
+                hasChildren={item.items?.length > 0}
+                items={item.items}
+              />)
+              : (<List
+                items={[item]}
+                sectionRef={React.createRef()}
+                key={index}
+                structureContainerRef={structureContainerRef}
+              />)
           ))
         ) : (
           <p className="ramp--no-structure">

--- a/src/components/StructuredNavigation/StructuredNavigation.scss
+++ b/src/components/StructuredNavigation/StructuredNavigation.scss
@@ -80,17 +80,22 @@ ul.ramp--structured-nav__list {
   list-style: none;
   padding: 0 0 0 0;
   margin: 0px;
+  font-size: medium;
 
-  li:last-child {
-    padding: 0 0 0 0;
-  }
+  // li:last-child {
+  //   padding: 0 0 0 0.5em;
+  // }
 
   li {
     display: block;
-    padding: 0 0 0.5rem 0px;
+    padding: 0 0 0.5rem 0.5em;
 
     .structure-item-locked {
       vertical-align: middle;
+    }
+
+    ul {
+      padding-left: 0.5em;
     }
 
     ul>li {
@@ -121,55 +126,62 @@ ul.ramp--structured-nav__list {
       margin-top: -0.5rem;
     }
   }
-
-  .ramp--structured-nav__section.active {
-    font-weight: bold;
+  svg.structure-item-locked {
+    margin-right: 0.5rem;
   }
+}
 
-  .ramp--structured-nav__section {
-    display: flex;
-    align-items: center;
-    background-color: $primaryLightest;
-    border-top: 1px solid $primaryLight;
+.ramp--structured-nav__section.active {
+  font-weight: bold;
+}
+
+.ramp--structured-nav__section {
+  .section-head-buttons {
+    display: grid;
+    grid-template-columns: 1fr auto;
+  }
+  display: flex;
+  flex-direction: column;
+  background-color: transparent;
+  border-top: 1px solid $primaryLight;
+  font-size: 1.25rem;
+  font-weight: 400;
+
+  button {
+    border: none;
+    cursor: pointer;
+    text-align: left;
+    width: 100%;
+    padding: 1rem;
     font-size: 1.25rem;
-    font-weight: 400;
+    font-weight: inherit;
+    background: $primaryLightest;
 
-    button {
-      border: none;
-      cursor: pointer;
-      text-align: left;
-      width: 100%;
-      padding: 1rem;
-      font-size: 1.25rem;
-      font-weight: inherit;
-      background: transparent;
-
-      &:hover {
-        background-color: $primaryGreenLight;
-      }
-
-      span {
-        padding-left: 0;
-      }
+    &:hover {
+      background-color: $primaryGreenLight;
     }
 
     span {
-      padding: 1rem;
-    }
-
-    span.ramp--structured-nav__section-duration {
-      border: 1px solid $primaryDark;
-      border-radius: 999px;
-      color: $primaryDarkest;
-      font-size: 0.75rem;
-      letter-spacing: 0.02rem;
-      line-height: 1.6;
-      padding: 0 0.5rem;
-      margin-left: 0.5rem;
+      padding-left: 0;
     }
   }
 
-  svg.structure-item-locked {
-    margin-right: 0.5rem;
+  button.collapse-expand-button:hover {
+    background-color: $primaryLightest;
+  }
+
+  span {
+    padding: 1rem;
+  }
+
+  span.ramp--structured-nav__section-duration {
+    border: 1px solid $primaryDark;
+    border-radius: 999px;
+    color: $primaryDarkest;
+    font-size: 0.75rem;
+    letter-spacing: 0.02rem;
+    line-height: 1.6;
+    padding: 0 0.5rem;
+    margin-left: 0.5rem;
   }
 }

--- a/src/services/structure.js
+++ b/src/services/structure.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import { PlayerDispatchContext } from '../context/player-context';
+import { ManifestStateContext } from '../context/manifest-context';
+import { autoScroll, checkSrcRange, getMediaFragment } from '@Services/utility-helpers';
+
+export function useActiveStructure({
+  itemIdRef,
+  liRef,
+  sectionRef,
+  structureContainerRef,
+  isCanvas,
+  canvasDuration,
+}) {
+  const playerDispatch = React.useContext(PlayerDispatchContext);
+  const manifestState = React.useContext(ManifestStateContext);
+  const { canvasIndex, currentNavItem, playlist } = manifestState;
+  const { isPlaylist } = playlist;
+
+  const isActive = React.useMemo(() => {
+    return (itemIdRef.current != undefined && (currentNavItem?.id === itemIdRef.current)
+      && (isPlaylist || !isCanvas) && currentNavItem?.canvasIndex === canvasIndex + 1)
+      ? ' active'
+      : '';
+  }, [currentNavItem, canvasIndex]);
+
+  const handleClick = React.useCallback((e) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    const { start, end } = getMediaFragment(itemIdRef.current, canvasDuration);
+    const inRange = checkSrcRange({ start, end }, { end: canvasDuration });
+    /* 
+      Only continue the click action if not both start and end times of 
+      the timespan are not outside Canvas' duration
+    */
+    if (inRange) {
+      playerDispatch({ clickedUrl: itemIdRef.current, type: 'navClick' });
+      liRef.current.isClicked = true;
+      if (sectionRef.current) {
+        sectionRef.current.isClicked = true;
+      }
+    }
+  });
+
+  React.useEffect(() => {
+    /*
+      Auto-scroll active structure item into view only when user is not actively
+      interacting with structured navigation
+    */
+    if (liRef.current && currentNavItem?.id == itemIdRef.current
+      && liRef.current.isClicked != undefined && !liRef.current.isClicked
+      && structureContainerRef.current.isScrolling != undefined && !structureContainerRef.current.isScrolling) {
+      autoScroll(liRef.current, structureContainerRef);
+    }
+    // Reset isClicked if active structure item is set
+    if (liRef.current) {
+      liRef.current.isClicked = false;
+    }
+  }, [currentNavItem]);
+
+  return { handleClick, isActive, isPlaylist, canvasIndex };
+};


### PR DESCRIPTION
Related issue: #605 

This work is done as PoC to evaluate the eligibility of custom hooks to solve the re-rendering issues we were having with structured navigation collapse/expand feature (https://github.com/samvera-labs/ramp/issues/247).

If we decide to go forward with state management with React context API with custom hooks as a result of the investigation (#605), this work can be re-purposed as a starting point.


https://github.com/user-attachments/assets/721ec64f-4588-4260-ace2-9117177b1c73

