### PR TITLE
Limit time tooltip display offset to playable range width

### DIFF
--- a/src/components/MediaPlayer/VideoJS/components/js/VideoJSProgress.js
+++ b/src/components/MediaPlayer/VideoJS/components/js/VideoJSProgress.js
@@ -490,15 +490,20 @@ function ProgressBar({
 
     let time = convertToTime(e, offsetx, currentSrcIndex);
 
+    if (!time) { return; }
+
     setActiveSrcIndex(currentSrcIndex);
     setCurrentTime(time);
 
     // Set text in the tooltip as the time relevant to the pointer event's position
     timeToolRef.current.innerHTML = formatTooltipTime(time);
 
-    // Calculate the horizontal position of the time tooltip
-    // using the event's offsetX property
-    let leftWidth = offsetx - timeToolRef.current.offsetWidth / 2; // deduct 0.5 x width of tooltip element
+    // Calculate the horizontal position of the time tooltip using the event's offsetX property
+    // Set time tooltip offset starting from the start of playable range
+    let leftWidth = leftBlockRef.current?.offsetWidth <= offsetx ? offsetx - leftBlockRef.current?.offsetWidth : offsetx;
+    // Set time tooltip offset to not excedd the end of playable range
+    leftWidth = Math.min(leftWidth, sliderRangeRef.current?.offsetWidth + leftBlockRef.current?.offsetWidth);
+    leftWidth = leftWidth - timeToolRef.current.offsetWidth / 2; // deduct 0.5 x width of tooltip element
     if (leftBlockRef.current) leftWidth += leftBlockRef.current.offsetWidth; // add the blocked off area width
 
     // Add the width of preceding dummy ranges


### PR DESCRIPTION
When mouse pointer is hovering over the blocked parts of the progress-bar, the time tool-tip is displayed outside of the progress-bar container.
This PR fixes the alignment of the time tool-tip by limiting the calculated offset to always align tool-tip with the playable range of the media.

Before:
![Screenshot 2024-08-27 at 4 03 51 PM](https://github.com/user-attachments/assets/29804d15-7328-48cf-b248-320418584e37)

After:

![Screenshot 2024-08-27 at 4 05 02 PM](https://github.com/user-attachments/assets/6be34984-a156-4dbf-9fda-ba7c485034f2)
