### PR TITLE
Remove useMemo in component export, refactor MetadataDisplay component

### DIFF
--- a/src/components/AutoAdvanceToggle/AutoAdvanceToggle.js
+++ b/src/components/AutoAdvanceToggle/AutoAdvanceToggle.js
@@ -11,34 +11,36 @@ const AutoAdvanceToggle = ({ label = "Autoplay", showLabel = true }) => {
     manifestDispatch({ autoAdvance: e.target.checked, type: "setAutoAdvance" });
   };
 
-  return React.useMemo(() => {
-    return (
-      <div data-testid="auto-advance" className="ramp--auto-advance">
-        {showLabel && (
-          <span
-            className="ramp--auto-advance-label"
-            data-testid="auto-advance-label"
-            htmlFor="auto-advance-toggle"
-            id="auto-advance-toggle-label"
-          >
-            {label}
-          </span>
-        )}
-        <label className="ramp--auto-advance-toggle"
-          aria-labelledby="auto-advance-toggle-label">
-          <input
-            data-testid="auto-advance-toggle"
-            name="auto-advance-toggle"
-            type="checkbox"
-            checked={autoAdvance}
-            aria-label={label}
-            onChange={handleChange}
-          />
-          <span className="slider round"></span>
-        </label>
-      </div>
-    );
+  const toggleButton = React.useMemo(() => {
+    return (<input
+      data-testid="auto-advance-toggle"
+      name="auto-advance-toggle"
+      type="checkbox"
+      checked={autoAdvance}
+      aria-label={label}
+      onChange={handleChange}
+    />);
   }, [autoAdvance]);
+
+  return (
+    <div data-testid="auto-advance" className="ramp--auto-advance">
+      {showLabel && (
+        <span
+          className="ramp--auto-advance-label"
+          data-testid="auto-advance-label"
+          htmlFor="auto-advance-toggle"
+          id="auto-advance-toggle-label"
+        >
+          {label}
+        </span>
+      )}
+      <label className="ramp--auto-advance-toggle"
+        aria-labelledby="auto-advance-toggle-label">
+        {toggleButton}
+        <span className="slider round"></span>
+      </label>
+    </div>
+  );
 };
 
 AutoAdvanceToggle.propTypes = {

--- a/src/components/MarkersDisplay/MarkersDisplay.js
+++ b/src/components/MarkersDisplay/MarkersDisplay.js
@@ -76,26 +76,22 @@ const MarkersDisplay = ({ showHeading = true, headingText = 'Markers' }) => {
     manifestDispatch({ isEditing: flag, type: 'setIsEditing' });
   });
 
-  return useMemo(() => {
-    return (<div className="ramp--markers-display"
-      data-testid="markers-display">
-      {showHeading && (
-        <div
-          className="ramp--markers-display__title"
-          data-testid="markers-display-title"
-        >
-          <h4>{headingText}</h4>
-        </div>
-      )}
-      {hasAnnotationService && (
+  const createMarker = useMemo(() => {
+    if (hasAnnotationService) {
+      return (
         <CreateMarker
           newMarkerEndpoint={annotationServiceId}
           canvasId={canvasIdRef.current}
           handleCreate={handleCreate}
           csrfToken={csrfToken}
         />
-      )}
-      {canvasPlaylistsMarkersRef.current.length > 0 && (
+      );
+    }
+  }, [hasAnnotationService, canvasIdRef.current, csrfToken]);
+
+  const markersTable = useMemo(() => {
+    if (canvasPlaylistsMarkersRef.current.length > 0) {
+      return (
         <table className="ramp--markers-display_table" data-testid="markers-display-table">
           <thead>
             <tr>
@@ -117,10 +113,23 @@ const MarkersDisplay = ({ showHeading = true, headingText = 'Markers' }) => {
             ))}
           </tbody>
         </table>
-      )}
-    </div>
-    );
-  }, [canvasPlaylistsMarkersRef.current, csrfToken]);
+      );
+    }
+  }, [canvasPlaylistsMarkersRef.current]);
+
+  return <div className="ramp--markers-display"
+    data-testid="markers-display">
+    {showHeading && (
+      <div
+        className="ramp--markers-display__title"
+        data-testid="markers-display-title"
+      >
+        <h4>{headingText}</h4>
+      </div>
+    )}
+    {createMarker}
+    {markersTable}
+  </div>;
 };
 
 MarkersDisplay.propTypes = {

--- a/src/components/MarkersDisplay/MarkersDisplay.test.js
+++ b/src/components/MarkersDisplay/MarkersDisplay.test.js
@@ -187,12 +187,14 @@ describe('MarkersDisplay component', () => {
         fireEvent.click(secondDeleteButton);
         fireEvent.click(screen.getByTestId('delete-confirm-button'));
 
-        expect(deleteFetchSpy).toHaveBeenCalled();
-        expect(deleteFetchSpy).toHaveBeenCalledWith(
-          "http://example.com/playlists/1/canvas/3/marker/4",
-          deleteOptions,
-          { signal: 'test-signal' },
-        );
+        waitFor(() => {
+          expect(deleteFetchSpy).toHaveBeenCalled();
+          expect(deleteFetchSpy).toHaveBeenCalledWith(
+            "http://example.com/playlists/1/canvas/3/marker/4",
+            deleteOptions,
+            { signal: 'test-signal' },
+          );
+        });
       });
     });
   });

--- a/src/components/SupplementalFiles/SupplementalFiles.js
+++ b/src/components/SupplementalFiles/SupplementalFiles.js
@@ -47,14 +47,9 @@ const SupplementalFiles = ({
     fileDownload(file.id, file.filename, file.fileExt, file.isMachineGen);
   };
 
-  return useMemo(() => {
+  const filesDisplay = useMemo(() => {
     return (
-      <div data-testid="supplemental-files" className="ramp--supplemental-files">
-        {showHeading && (
-          <div className="ramp--supplemental-files-heading" data-testid="supplemental-files-heading">
-            <h4>Files</h4>
-          </div>
-        )}
+      <>
         {hasFiles && <div className="ramp--supplemental-files-display-content"
           data-testid="supplemental-files-display-content">
           {Array.isArray(manifestSupplementalFiles) && manifestSupplementalFiles.length > 0 && (
@@ -104,9 +99,18 @@ const SupplementalFiles = ({
           className="ramp--supplemental-files-empty">
           <p>No Supplemental file(s) in Manifest</p>
         </div>}
-      </div>
+      </>
     );
   }, [hasFiles, hasSectionFiles]);
+
+  return <div data-testid="supplemental-files" className="ramp--supplemental-files">
+    {showHeading && (
+      <div className="ramp--supplemental-files-heading" data-testid="supplemental-files-heading">
+        <h4>Files</h4>
+      </div>
+    )}
+    {filesDisplay}
+  </div>;
 };
 
 export default SupplementalFiles;

--- a/src/services/ramp-hooks.js
+++ b/src/services/ramp-hooks.js
@@ -1,4 +1,4 @@
-import { useMemo, useContext, useCallback, useEffect, useRef } from 'react';
+import { useMemo, useContext, useCallback, useRef } from 'react';
 import { ManifestStateContext } from '../context/manifest-context';
 import { PlayerStateContext } from '../context/player-context';
 

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -2,7 +2,6 @@ const path = require('path');
 const webpack = require('webpack');
 
 module.exports = {
-  components: 'src/components/**/**.js',
   exampleMode: 'collapse',
   skipComponentsWithoutExample: true,
   styleguideDir: 'docs',


### PR DESCRIPTION
Related issue: #630 

Refactor `MetadataDisplay` component's calculated UI portions to re-render only when relevant state variables are changed using `React.useMemo` hook.
Use the same concept in other mostly static components refactored in https://github.com/samvera-labs/ramp/pull/640, instead of wrapping the component export in `React.useMemo`. 
The implementation in https://github.com/samvera-labs/ramp/pull/640 with `React.useMemo` was still emitting a warning react-styleguidist docs regardless of the styleguidist config changes. And with this implementation we can still limit the re-renders to the entire component and export pure components for react-styleguidist to use to generate documents.