### PR TITLE
Custom hook for MediaPlayer and VideoJSPlayer handling

### DIFF
--- a/src/components/MarkersDisplay/MarkerUtils/CreateMarker.js
+++ b/src/components/MarkersDisplay/MarkerUtils/CreateMarker.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { parseMarkerAnnotation } from '@Services/playlist-parser';
 import { validateTimeInput, timeToS, timeToHHmmss } from '@Services/utility-helpers';
 import { SaveIcon, CancelIcon } from '@Services/svg-icons';
-import { usePlayer } from '@Services/ramp-hooks';
+import { useMediaPlayer } from '@Services/ramp-hooks';
 
 const CreateMarker = ({ newMarkerEndpoint, canvasId, handleCreate, csrfToken }) => {
   const [isOpen, setIsOpen] = React.useState(false);
@@ -13,7 +13,7 @@ const CreateMarker = ({ newMarkerEndpoint, canvasId, handleCreate, csrfToken }) 
   const [markerTime, setMarkerTime] = React.useState();
   let controller;
 
-  const { getCurrentTime, _ } = usePlayer();
+  const { getCurrentTime } = useMediaPlayer();
 
   React.useEffect(() => {
     // Close new marker form on Canvas change

--- a/src/components/MarkersDisplay/MarkerUtils/CreateMarker.test.js
+++ b/src/components/MarkersDisplay/MarkerUtils/CreateMarker.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import CreateMarker from './CreateMarker';
 import * as hooks from '@Services/ramp-hooks';
 

--- a/src/components/MarkersDisplay/MarkerUtils/CreateMarker.test.js
+++ b/src/components/MarkersDisplay/MarkerUtils/CreateMarker.test.js
@@ -1,15 +1,20 @@
 import React from 'react';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import CreateMarker from './CreateMarker';
+import * as hooks from '@Services/ramp-hooks';
 
 describe('CreateMarker component', () => {
   const handleCreateMock = jest.fn();
+  const getCurrentTimeMock = jest.fn(() => { return 44.3; });
+  // Mock custom hook output
+  jest.spyOn(hooks, 'useMediaPlayer').mockImplementation(() => ({
+    getCurrentTime: getCurrentTimeMock
+  }));
   beforeEach(() => {
     render(<CreateMarker
       newMarkerEndpoint={'http://example.com/marker'}
       canvasId={'http://example.com/manifest/canvas/1'}
-      handleCreate={handleCreateMock}
-      playheadTime={44.3} />);
+      handleCreate={handleCreateMock} />);
   });
 
   test('renders successfully', () => {
@@ -28,6 +33,7 @@ describe('CreateMarker component', () => {
     fireEvent.click(screen.getByTestId('create-new-marker-button'));
     waitFor(() => {
       expect(screen.getByTestId('create-marker-title')).toHaveTextContent('');
+      expect(getCurrentTimeMock).toHaveBeenCalledTimes(1);
       expect(screen.getByTestId('create-marker-timestamp')).toHaveTextContent('00:00:44.300');
       expect(screen.getByTestId('create-marker-timestamp')).toHaveClass('time-valid');
     });

--- a/src/components/MarkersDisplay/MarkerUtils/MarkerRow.js
+++ b/src/components/MarkersDisplay/MarkerUtils/MarkerRow.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { CancelIcon, EditIcon, DeleteIcon, SaveIcon } from '@Services/svg-icons';
 import { validateTimeInput, timeToS } from '@Services/utility-helpers';
-import { useMarkers, usePlayer } from '@Services/ramp-hooks';
+import { useMarkers, useMediaPlayer } from '@Services/ramp-hooks';
 
 const MarkerRow = ({
   marker,
@@ -21,7 +21,7 @@ const MarkerRow = ({
   let controller;
 
   const { isDisabled } = useMarkers();
-  const { _, player } = usePlayer();
+  const { player } = useMediaPlayer();
 
   // Remove all fetch requests on unmount
   React.useEffect(() => {

--- a/src/components/MarkersDisplay/MarkersDisplay.test.js
+++ b/src/components/MarkersDisplay/MarkersDisplay.test.js
@@ -6,8 +6,11 @@ import manifest from '@TestData/playlist';
 import manifestWoMarkers from '@TestData/lunchroom-manners';
 import { manifestState, withManifestAndPlayerProvider } from '../../services/testing-helpers';
 import { parsePlaylistAnnotations } from '@Services/playlist-parser';
+import * as hooks from '@Services/ramp-hooks';
 
 describe('MarkersDisplay component', () => {
+  // Mock custom hook output
+  jest.spyOn(hooks, 'useMediaPlayer').mockImplementation(() => ({}));
   describe('with manifest with markers', () => {
     beforeEach(() => {
       const MarkersDisplayWrapped = withManifestAndPlayerProvider(MarkersDisplay, {

--- a/src/components/MediaPlayer/MediaPlayer.js
+++ b/src/components/MediaPlayer/MediaPlayer.js
@@ -45,7 +45,7 @@ const MediaPlayer = ({
     switchPlayer
   } = useSetupPlayer({ enableFileDownload, withCredentials, lastCanvasIndex });
 
-  const { poster, sources, targets, tracks } = playerConfig;
+  const { error, poster, sources, targets, tracks } = playerConfig;
 
   // Using dynamic imports to enforce code-splitting in webpack
   // https://webpack.js.org/api/module-methods/#dynamic-expressions-in-import
@@ -184,9 +184,9 @@ const MediaPlayer = ({
           enableTitleLink={enableTitleLink}
           isVideo={isVideo}
           options={videoJSOptions}
-          placeholderText={playerConfig.error}
+          placeholderText={error}
           scrubberTooltipRef={timeToolRef}
-          tracks={playerConfig.tracks}
+          tracks={tracks}
           trackScrubberRef={trackScrubberRef}
           videoJSLangMap={videoJSLangMap.current}
           withCredentials={withCredentials}

--- a/src/components/MediaPlayer/MediaPlayer.js
+++ b/src/components/MediaPlayer/MediaPlayer.js
@@ -1,21 +1,14 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import VideoJSPlayer from '@Components/MediaPlayer/VideoJS/VideoJSPlayer';
-import { getMediaInfo } from '@Services/iiif-parser';
 import { playerHotKeys } from '@Services/utility-helpers';
-import {
-  useManifestDispatch,
-  useManifestState,
-} from '../../context/manifest-context';
-import {
-  usePlayerState,
-  usePlayerDispatch,
-} from '../../context/player-context';
+import { useManifestState } from '../../context/manifest-context';
+import { usePlayerState } from '../../context/player-context';
 import { useErrorBoundary } from "react-error-boundary";
 import { IS_ANDROID, IS_MOBILE, IS_SAFARI, IS_TOUCH_ONLY } from '@Services/browser';
 // Default language for Video.js
 import en from 'video.js/dist/lang/en.json';
-import { useMediaPlayer } from '@Services/ramp-hooks';
+import { useMediaPlayer, useSetupPlayer } from '@Services/ramp-hooks';
 
 const PLAYER_ID = "iiif-media-player";
 
@@ -29,58 +22,33 @@ const MediaPlayer = ({
 }) => {
   const manifestState = useManifestState();
   const playerState = usePlayerState();
-  const playerDispatch = usePlayerDispatch();
-  const manifestDispatch = useManifestDispatch();
   const { showBoundary } = useErrorBoundary();
 
-  const [playerConfig, setPlayerConfig] = React.useState({
-    error: '',
-    sources: [],
-    tracks: [],
-    poster: null,
-  });
-
-  const [firstLoad, setFirstLoad] = React.useState(true);
-  const [ready, setReady] = React.useState(false);
-  const [cIndex, setCIndex] = React.useState(canvasIndex);
-  const [isMultiSourced, setIsMultiSourced] = React.useState();
-  const [isVideo, setIsVideo] = React.useState();
-  const [options, setOptions] = React.useState();
-  const [renderingFiles, setRenderingFiles] = React.useState();
-
-  const {
-    allCanvases,
-    manifest,
-    canvasIsEmpty,
-    srcIndex,
-    targets,
-    playlist,
-    autoAdvance,
-    hasStructure,
-    customStart,
-    renderings,
-  } = manifestState;
+  const { srcIndex, hasStructure, playlist } = manifestState;
+  const { isPlaylist } = playlist;
   const { playerFocusElement, currentTime } = playerState;
-
-  const autoAdvanceRef = React.useRef();
-  autoAdvanceRef.current = autoAdvance;
 
   const trackScrubberRef = React.useRef();
   const timeToolRef = React.useRef();
 
   let videoJSLangMap = React.useRef('{}');
 
+  const { canvasIsEmpty, canvasIndex, isMultiCanvased, lastCanvasIndex } = useMediaPlayer();
+
   const {
-    isMultiCanvased,
-    lastCanvasIndex,
-    canvasIndex,
-    createCanvasMessageTimer,
-    clearCanvasMessageTimer
-  } = useMediaPlayer();
+    isMultiSourced,
+    isVideo,
+    playerConfig,
+    ready,
+    renderingFiles,
+    nextItemClicked,
+    switchPlayer
+  } = useSetupPlayer({ enableFileDownload, withCredentials, lastCanvasIndex });
+  const { poster, sources, targets, tracks } = playerConfig;
 
   // Using dynamic imports to enforce code-splitting in webpack
   // https://webpack.js.org/api/module-methods/#dynamic-expressions-in-import
-  const loadVideoJSLanguageMap = React.useMemo(() =>
+  const loadVideoJSLanguageMap = useMemo(() =>
     async () => {
       try {
         const resources = await import(`video.js/dist/lang/${language}.json`);
@@ -91,149 +59,13 @@ const MediaPlayer = ({
       }
     }, [language]);
 
-  React.useEffect(() => {
-    if (manifest) {
-      try {
-        loadVideoJSLanguageMap();
-        /*
-          Always start from the start time relevant to the Canvas only in playlist contexts,
-          because canvases related to playlist items always start from the given start.
-          With regular manifests, the start time could be different when using structured 
-          navigation to switch between canvases.
-        */
-        if (canvasIndex == undefined || canvasIndex < 0) {
-          throw new Error('Invalid canvas index. Please check your Manifest.');
-        }
-        initCanvas(canvasIndex, playlist.isPlaylist);
-      } catch (e) {
-        showBoundary(e);
-      }
-    }
-
-    return () => {
-      setReady(false);
-      setCIndex(0);
-      playerDispatch({ player: null, type: 'updatePlayer' });
-    };
-  }, [manifest, canvasIndex]);
-
-  /**
-   * Initialize the next Canvas to be viewed in the player instance
-   * @param {Number} canvasId index of the Canvas to be loaded into the player
-   * @param {Boolean} fromStart flag to indicate how to start new player instance
-   */
-  const initCanvas = (canvasId, fromStart) => {
-    clearCanvasMessageTimer();
+  useEffect(() => {
     try {
-      const {
-        isMultiSource,
-        sources,
-        tracks,
-        canvasTargets,
-        mediaType,
-        error,
-        poster
-      } = getMediaInfo({
-        manifest,
-        canvasIndex: canvasId,
-        startTime: canvasId === customStart.startIndex && firstLoad
-          ? customStart.startTime : 0,
-        srcIndex,
-        isPlaylist: playlist.isPlaylist,
-      });
-
-      if (withCredentials) {
-        sources.map(function (source) {
-          return (source.withCredentials = true);
-        });
-      }
-      setIsVideo(mediaType === 'video');
-      manifestDispatch({ canvasTargets, type: 'canvasTargets' });
-      manifestDispatch({ isMultiSource, type: 'hasMultipleItems' });
-
-      // Set the current time in player from the canvas details
-      if (fromStart) {
-        if (canvasTargets?.length > 0) {
-          playerDispatch({ currentTime: canvasTargets[0].altStart, type: 'setCurrentTime' });
-        } else {
-          playerDispatch({ currentTime: 0, type: 'setCurrentTime' });
-        }
-      }
-
-      setPlayerConfig({ ...playerConfig, error, sources, tracks, poster });
-
-      const currentCanvas = allCanvases.find((c) => c.canvasIndex === canvasId);
-      if (!currentCanvas.isEmpty) {
-        // Manifest is taken from manifest state, and is a basic object at this point
-        // lacking the getLabel() function so we manually retrieve the first label.
-        let manifestLabel = manifest.label ? Object.values(manifest.label)[0][0] : '';
-        // Filter out falsy items in case canvas.label is null or an empty string
-        let titleText = [manifestLabel, currentCanvas.label].filter(Boolean).join(' - ');
-        manifestDispatch({ canvasDuration: currentCanvas.duration, type: 'canvasDuration' });
-        manifestDispatch({
-          canvasLink: { label: titleText, id: currentCanvas.canvasId },
-          type: 'canvasLink',
-        });
-        manifestDispatch({ type: 'setCanvasIsEmpty', isEmpty: false });
-      } else {
-        playerDispatch({ type: 'updatePlayer' });
-        manifestDispatch({ type: 'setCanvasIsEmpty', isEmpty: true });
-        // Set poster as playerConfig.error to be used for empty Canvas message in VideoJSPlayer
-        setPlayerConfig({ ...playerConfig, error: poster });
-        // Create timer to display the message when autoadvance is ON
-        if (autoAdvanceRef.current) {
-          createCanvasMessageTimer();
-        }
-      }
-      setIsMultiSourced(isMultiSource || false);
-
-      setCIndex(canvasId);
-
-      if (enableFileDownload && renderings != {}) {
-        setRenderingFiles(
-          (renderings.manifest)
-            .concat(renderings.canvas[canvasId]?.files)
-        );
-      }
-      error ? setReady(false) : setReady(true);
-      // Reset firstLoad flag after customStart is used on initial load
-      setFirstLoad(false);
+      loadVideoJSLanguageMap();
     } catch (e) {
       showBoundary(e);
     }
-  };
-
-  /**
-   * Switch src in the player when seeked to a time range within a
-   * different item in the same canvas
-   * @param {Number} srcindex new srcIndex
-   * @param {Number} value current time of the player
-   */
-  const nextItemClicked = (srcindex, value) => {
-    playerDispatch({ currentTime: value, type: 'setCurrentTime' });
-    manifestDispatch({
-      srcIndex: srcindex,
-      type: 'setSrcIndex',
-    });
-  };
-
-  /**
-   * Switch player when navigating across canvases
-   * @param {Number} index canvas index to be loaded into the player
-   * @param {Boolean} fromStart flag to indicate set player start time to zero or not
-   * @param {String} focusElement element to be focused within the player when using
-   * next or previous buttons with keyboard
-   */
-  const switchPlayer = (index, fromStart, focusElement = '') => {
-    if (index != undefined && index > -1 && index <= lastCanvasIndex) {
-      manifestDispatch({
-        canvasIndex: index,
-        type: 'switchCanvas',
-      });
-      initCanvas(index, fromStart);
-      playerDispatch({ element: focusElement, type: 'setPlayerFocusElement' });
-    }
-  };
+  }, []);
 
   // Default VideoJS options not updated with the Canvas data
   const defaultOptions = useMemo(() => {
@@ -288,7 +120,7 @@ const MediaPlayer = ({
         aspectRatio: isVideo ? '16:9' : '1:0',
         audioOnlyMode: !isVideo,
         bigPlayButton: isVideo,
-        poster: isVideo ? playerConfig.poster : null,
+        poster: isVideo ? poster : null,
         controlBar: {
           // Define and order control bar controls
           // See https://docs.videojs.com/tutorial-components.html for options of what
@@ -307,8 +139,8 @@ const MediaPlayer = ({
             enablePIP ? 'pictureInPictureToggle' : '',
             enablePlaybackRate ? 'playbackRateMenuButton' : '',
             'qualitySelector',
-            (hasStructure || playlist.isPlaylist) ? 'videoJSTrackScrubber' : '',
-            (playerConfig.tracks.length > 0 && isVideo) ? 'subsCapsButton' : '',
+            (hasStructure || isPlaylist) ? 'videoJSTrackScrubber' : '',
+            (tracks.length > 0 && isVideo) ? 'subsCapsButton' : '',
             IS_MOBILE ? 'muteToggle' : 'volumePanel'
             // 'vjsYo',             custom component
           ],
@@ -318,7 +150,9 @@ const MediaPlayer = ({
             currentTime: currentTime || 0,
             nextItemClicked,
           },
-          videoJSCurrentTime: { srcIndex, targets, currentTime: currentTime || 0 },
+          videoJSCurrentTime: {
+            srcIndex, targets, currentTime: currentTime || 0
+          },
           videoJSFileDownload: enableFileDownload && {
             title: 'Download Files',
             controlText: 'Alternate resource download',
@@ -328,14 +162,14 @@ const MediaPlayer = ({
             { canvasIndex, switchPlayer, playerFocusElement },
           videoJSNextButton: isMultiCanvased &&
             { canvasIndex, lastCanvasIndex, switchPlayer, playerFocusElement },
-          videoJSTrackScrubber: (hasStructure || playlist.isPlaylist) &&
-            { trackScrubberRef, timeToolRef, isPlaylist: playlist.isPlaylist }
+          videoJSTrackScrubber: (hasStructure || isPlaylist) &&
+            { trackScrubberRef, timeToolRef, isPlaylist }
         },
         sources: isMultiSourced
-          ? [playerConfig.sources[srcIndex]]
-          : playerConfig.sources,
+          ? [sources[srcIndex]]
+          : sources,
       } : { ...defaultOptions, sources: [] };
-  }, [isVideo, playerConfig]);
+  }, [isVideo, playerConfig, srcIndex]);
 
   if ((ready && videoJSOptions != undefined) || canvasIsEmpty) {
     return (
@@ -345,20 +179,13 @@ const MediaPlayer = ({
         role="presentation"
       >
         <VideoJSPlayer
-          isVideo={isVideo}
-          hasMultipleCanvases={isMultiCanvased}
-          isPlaylist={playlist.isPlaylist}
           trackScrubberRef={trackScrubberRef}
           scrubberTooltipRef={timeToolRef}
-          tracks={playerConfig.tracks}
-          placeholderText={playerConfig.error}
-          renderingFiles={renderingFiles}
           enableFileDownload={enableFileDownload}
-          loadPrevOrNext={switchPlayer}
-          lastCanvasIndex={lastCanvasIndex}
           enableTitleLink={enableTitleLink}
           videoJSLangMap={videoJSLangMap.current}
           options={videoJSOptions}
+          withCredentials={withCredentials}
         />
       </div>
     );

--- a/src/components/MediaPlayer/MediaPlayer.js
+++ b/src/components/MediaPlayer/MediaPlayer.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import PropTypes from 'prop-types';
 import VideoJSPlayer from '@Components/MediaPlayer/VideoJS/VideoJSPlayer';
 import { playerHotKeys } from '@Services/utility-helpers';
@@ -6,9 +6,10 @@ import { useManifestState } from '../../context/manifest-context';
 import { usePlayerState } from '../../context/player-context';
 import { useErrorBoundary } from "react-error-boundary";
 import { IS_ANDROID, IS_MOBILE, IS_SAFARI, IS_TOUCH_ONLY } from '@Services/browser';
+import { useMediaPlayer, useSetupPlayer } from '@Services/ramp-hooks';
+
 // Default language for Video.js
 import en from 'video.js/dist/lang/en.json';
-import { useMediaPlayer, useSetupPlayer } from '@Services/ramp-hooks';
 
 const PLAYER_ID = "iiif-media-player";
 
@@ -28,10 +29,9 @@ const MediaPlayer = ({
   const { isPlaylist } = playlist;
   const { playerFocusElement, currentTime } = playerState;
 
-  const trackScrubberRef = React.useRef();
-  const timeToolRef = React.useRef();
-
-  let videoJSLangMap = React.useRef('{}');
+  const trackScrubberRef = useRef();
+  const timeToolRef = useRef();
+  let videoJSLangMap = useRef('{}');
 
   const { canvasIsEmpty, canvasIndex, isMultiCanvased, lastCanvasIndex } = useMediaPlayer();
 
@@ -44,6 +44,7 @@ const MediaPlayer = ({
     nextItemClicked,
     switchPlayer
   } = useSetupPlayer({ enableFileDownload, withCredentials, lastCanvasIndex });
+
   const { poster, sources, targets, tracks } = playerConfig;
 
   // Using dynamic imports to enforce code-splitting in webpack
@@ -147,7 +148,7 @@ const MediaPlayer = ({
           videoJSProgress: {
             srcIndex,
             targets,
-            currentTime: currentTime || 0,
+            currentTime: currentTime ?? 0,
             nextItemClicked,
           },
           videoJSCurrentTime: {
@@ -179,12 +180,15 @@ const MediaPlayer = ({
         role="presentation"
       >
         <VideoJSPlayer
-          trackScrubberRef={trackScrubberRef}
-          scrubberTooltipRef={timeToolRef}
           enableFileDownload={enableFileDownload}
           enableTitleLink={enableTitleLink}
-          videoJSLangMap={videoJSLangMap.current}
+          isVideo={isVideo}
           options={videoJSOptions}
+          placeholderText={playerConfig.error}
+          scrubberTooltipRef={timeToolRef}
+          tracks={playerConfig.tracks}
+          trackScrubberRef={trackScrubberRef}
+          videoJSLangMap={videoJSLangMap.current}
           withCredentials={withCredentials}
         />
       </div>

--- a/src/components/MediaPlayer/MediaPlayer.test.js
+++ b/src/components/MediaPlayer/MediaPlayer.test.js
@@ -8,6 +8,7 @@ import videoManifest from '@TestData/lunchroom-manners';
 import noCaptionManifest from '@TestData/multiple-canvas-auto-advance';
 import emptyCanvasManifest from '@TestData/transcript-annotation';
 import playlistManifest from '@TestData/playlist';
+import * as hooks from '@Services/ramp-hooks';
 
 describe('MediaPlayer component', () => {
   let originalError, originalLogger;
@@ -445,177 +446,177 @@ describe('MediaPlayer component', () => {
     });
   });
 
-  describe('displays inaccessible message', () => {
-    test('with HTML from placeholderCanvas for an empty canvas', () => {
-      // Stub loading HTMLMediaElement for jsdom
-      window.HTMLMediaElement.prototype.load = () => { };
+  // describe('displays inaccessible message', () => {
+  //   test('with HTML from placeholderCanvas for an empty canvas', () => {
+  //     // Stub loading HTMLMediaElement for jsdom
+  //     window.HTMLMediaElement.prototype.load = () => { };
 
-      const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
-        initialManifestState: { ...manifestState(emptyCanvasManifest, 1) },
-        initialPlayerState: {},
-      });
-      render(
-        <ErrorBoundary>
-          <PlayerWithManifest />
-        </ErrorBoundary>
-      );
-      expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
-      expect(screen.getByTestId('inaccessible-message-content').textContent)
-        .toEqual('You do not have permission to playback this item. \nPlease ' +
-          'contact support to report this error: admin-list@example.com.\n');
-    });
+  //     const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
+  //       initialManifestState: { ...manifestState(emptyCanvasManifest, 1) },
+  //       initialPlayerState: {},
+  //     });
+  //     render(
+  //       <ErrorBoundary>
+  //         <PlayerWithManifest />
+  //       </ErrorBoundary>
+  //     );
+  //     expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
+  //     expect(screen.getByTestId('inaccessible-message-content').textContent)
+  //       .toEqual('You do not have permission to playback this item. \nPlease ' +
+  //         'contact support to report this error: admin-list@example.com.\n');
+  //   });
 
-    test('for an inaccessible item in a playlist Manifest', () => {
-      // Stub loading HTMLMediaElement for jsdom
-      window.HTMLMediaElement.prototype.load = () => { };
+  //   test('for an inaccessible item in a playlist Manifest', () => {
+  //     // Stub loading HTMLMediaElement for jsdom
+  //     window.HTMLMediaElement.prototype.load = () => { };
 
-      const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
-        initialManifestState: { ...manifestState(playlistManifest, 0, true) },
-        initialPlayerState: {},
-      });
-      render(
-        <ErrorBoundary>
-          <PlayerWithManifest />
-        </ErrorBoundary>
-      );
-      expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
-      expect(screen.getByText('You do not have permission to playback this item.')).toBeInTheDocument();
-    });
+  //     const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
+  //       initialManifestState: { ...manifestState(playlistManifest, 0, true) },
+  //       initialPlayerState: {},
+  //     });
+  //     render(
+  //       <ErrorBoundary>
+  //         <PlayerWithManifest />
+  //       </ErrorBoundary>
+  //     );
+  //     expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
+  //     expect(screen.getByText('You do not have permission to playback this item.')).toBeInTheDocument();
+  //   });
 
-    describe('with auto-advance turned on', () => {
-      test('displays timer and next button for first item', () => {
-        // Stub loading HTMLMediaElement for jsdom
-        window.HTMLMediaElement.prototype.load = () => { };
+  //   describe('with auto-advance turned on', () => {
+  //     test('displays timer and next button for first item', () => {
+  //       // Stub loading HTMLMediaElement for jsdom
+  //       window.HTMLMediaElement.prototype.load = () => { };
 
-        const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
-          initialManifestState: { ...manifestState(playlistManifest, 0, true), autoAdvance: true, },
-          initialPlayerState: {},
-        });
-        render(
-          <ErrorBoundary>
-            <PlayerWithManifest />
-          </ErrorBoundary>
-        );
-        expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
-        expect(screen.getByText('You do not have permission to playback this item.')).toBeInTheDocument();
-        expect(screen.queryByTestId('inaccessible-message-timer')).toBeInTheDocument();
-        expect(screen.queryByTestId('inaccessible-next-button')).toBeInTheDocument();
-        // Does not display previous button for first item
-        expect(screen.queryByTestId('inaccessible-previous-button')).not.toBeInTheDocument();
-      });
+  //       const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
+  //         initialManifestState: { ...manifestState(playlistManifest, 0, true), autoAdvance: true, },
+  //         initialPlayerState: {},
+  //       });
+  //       render(
+  //         <ErrorBoundary>
+  //           <PlayerWithManifest />
+  //         </ErrorBoundary>
+  //       );
+  //       expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
+  //       expect(screen.getByText('You do not have permission to playback this item.')).toBeInTheDocument();
+  //       expect(screen.queryByTestId('inaccessible-message-timer')).toBeInTheDocument();
+  //       expect(screen.queryByTestId('inaccessible-next-button')).toBeInTheDocument();
+  //       // Does not display previous button for first item
+  //       expect(screen.queryByTestId('inaccessible-previous-button')).not.toBeInTheDocument();
+  //     });
 
-      test('displays timer and previous/next button for an inaccessible item nested between other item', () => {
-        // Stub loading HTMLMediaElement for jsdom
-        window.HTMLMediaElement.prototype.load = () => { };
+  //     test('displays timer and previous/next button for an inaccessible item nested between other item', () => {
+  //       // Stub loading HTMLMediaElement for jsdom
+  //       window.HTMLMediaElement.prototype.load = () => { };
 
-        const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
-          initialManifestState: { ...manifestState(playlistManifest, 1, true), autoAdvance: true, },
-          initialPlayerState: {},
-        });
-        render(
-          <ErrorBoundary>
-            <PlayerWithManifest />
-          </ErrorBoundary>
-        );
-        expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
-        expect(screen.getByText('You do not have permission to playback this item.')).toBeInTheDocument();
-        expect(screen.queryByTestId('inaccessible-message-timer')).toBeInTheDocument();
-        expect(screen.queryByTestId('inaccessible-next-button')).toBeInTheDocument();
-        expect(screen.queryByTestId('inaccessible-previous-button')).toBeInTheDocument();
-      });
+  //       const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
+  //         initialManifestState: { ...manifestState(playlistManifest, 1, true), autoAdvance: true, },
+  //         initialPlayerState: {},
+  //       });
+  //       render(
+  //         <ErrorBoundary>
+  //           <PlayerWithManifest />
+  //         </ErrorBoundary>
+  //       );
+  //       expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
+  //       expect(screen.getByText('You do not have permission to playback this item.')).toBeInTheDocument();
+  //       expect(screen.queryByTestId('inaccessible-message-timer')).toBeInTheDocument();
+  //       expect(screen.queryByTestId('inaccessible-next-button')).toBeInTheDocument();
+  //       expect(screen.queryByTestId('inaccessible-previous-button')).toBeInTheDocument();
+  //     });
 
-      test('displays timer and previous button when last item is an inaccessible item', () => {
-        // Stub loading HTMLMediaElement for jsdom
-        window.HTMLMediaElement.prototype.load = () => { };
+  //     test('displays timer and previous button when last item is an inaccessible item', () => {
+  //       // Stub loading HTMLMediaElement for jsdom
+  //       window.HTMLMediaElement.prototype.load = () => { };
 
-        const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
-          initialManifestState: { ...manifestState(playlistManifest, 5, true), autoAdvance: true, },
-          initialPlayerState: {},
-        });
-        render(
-          <ErrorBoundary>
-            <PlayerWithManifest />
-          </ErrorBoundary>
-        );
-        expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
-        expect(screen.getByText('You do not have permission to playback this item.')).toBeInTheDocument();
-        expect(screen.queryByTestId('inaccessible-message-timer')).not.toBeInTheDocument();
-        expect(screen.queryByTestId('inaccessible-next-button')).not.toBeInTheDocument();
-        expect(screen.queryByTestId('inaccessible-previous-button')).toBeInTheDocument();
-      });
+  //       const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
+  //         initialManifestState: { ...manifestState(playlistManifest, 5, true), autoAdvance: true, },
+  //         initialPlayerState: {},
+  //       });
+  //       render(
+  //         <ErrorBoundary>
+  //           <PlayerWithManifest />
+  //         </ErrorBoundary>
+  //       );
+  //       expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
+  //       expect(screen.getByText('You do not have permission to playback this item.')).toBeInTheDocument();
+  //       expect(screen.queryByTestId('inaccessible-message-timer')).not.toBeInTheDocument();
+  //       expect(screen.queryByTestId('inaccessible-next-button')).not.toBeInTheDocument();
+  //       expect(screen.queryByTestId('inaccessible-previous-button')).toBeInTheDocument();
+  //     });
 
-      test('enables navigation to next item with next button', () => {
-        // Stub loading HTMLMediaElement for jsdom
-        window.HTMLMediaElement.prototype.load = () => { };
+  //     test('enables navigation to next item with next button', () => {
+  //       // Stub loading HTMLMediaElement for jsdom
+  //       window.HTMLMediaElement.prototype.load = () => { };
 
-        const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
-          initialManifestState: { ...manifestState(playlistManifest, 1, true), autoAdvance: true, },
-          initialPlayerState: {},
-        });
-        render(
-          <ErrorBoundary>
-            <PlayerWithManifest />
-          </ErrorBoundary>
-        );
-        expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
-        expect(screen.getByText('You do not have permission to playback this item.')).toBeInTheDocument();
-        expect(screen.queryByTestId('inaccessible-message-timer')).toBeInTheDocument();
-        expect(screen.queryByTestId('inaccessible-next-button')).toBeInTheDocument();
-        fireEvent.click(screen.getByTestId('inaccessible-next-button'));
-        // Loads video player for the next item in the list
-        expect(
-          screen.queryAllByTestId('videojs-video-element').length
-        ).toBeGreaterThan(0);
-      });
-    });
+  //       const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
+  //         initialManifestState: { ...manifestState(playlistManifest, 1, true), autoAdvance: true, },
+  //         initialPlayerState: {},
+  //       });
+  //       render(
+  //         <ErrorBoundary>
+  //           <PlayerWithManifest />
+  //         </ErrorBoundary>
+  //       );
+  //       expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
+  //       expect(screen.getByText('You do not have permission to playback this item.')).toBeInTheDocument();
+  //       expect(screen.queryByTestId('inaccessible-message-timer')).toBeInTheDocument();
+  //       expect(screen.queryByTestId('inaccessible-next-button')).toBeInTheDocument();
+  //       fireEvent.click(screen.getByTestId('inaccessible-next-button'));
+  //       // Loads video player for the next item in the list
+  //       expect(
+  //         screen.queryAllByTestId('videojs-video-element').length
+  //       ).toBeGreaterThan(0);
+  //     });
+  //   });
 
-    describe('with auto-advance turned off', () => {
-      test('hides the display timer', () => {
-        // Stub loading HTMLMediaElement for jsdom
-        window.HTMLMediaElement.prototype.load = () => { };
+  //   describe('with auto-advance turned off', () => {
+  //     test('hides the display timer', () => {
+  //       // Stub loading HTMLMediaElement for jsdom
+  //       window.HTMLMediaElement.prototype.load = () => { };
 
-        const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
-          initialManifestState: { ...manifestState(playlistManifest, 0, true), autoAdvance: false, },
-          initialPlayerState: {},
-        });
-        render(
-          <ErrorBoundary>
-            <PlayerWithManifest />
-          </ErrorBoundary>
-        );
-        expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
-        expect(screen.getByText('You do not have permission to playback this item.')).toBeInTheDocument();
-        expect(screen.queryByTestId('inaccessible-message-timer')).toBeInTheDocument();
-        expect(screen.getByTestId('inaccessible-message-timer')).toHaveClass('hidden');
-        expect(screen.queryByTestId('inaccessible-next-button')).toBeInTheDocument();
-      });
+  //       const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
+  //         initialManifestState: { ...manifestState(playlistManifest, 0, true), autoAdvance: false, },
+  //         initialPlayerState: {},
+  //       });
+  //       render(
+  //         <ErrorBoundary>
+  //           <PlayerWithManifest />
+  //         </ErrorBoundary>
+  //       );
+  //       expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
+  //       expect(screen.getByText('You do not have permission to playback this item.')).toBeInTheDocument();
+  //       expect(screen.queryByTestId('inaccessible-message-timer')).toBeInTheDocument();
+  //       expect(screen.getByTestId('inaccessible-message-timer')).toHaveClass('hidden');
+  //       expect(screen.queryByTestId('inaccessible-next-button')).toBeInTheDocument();
+  //     });
 
-      test('enables navigation to next item with next button', () => {
-        // Stub loading HTMLMediaElement for jsdom
-        window.HTMLMediaElement.prototype.load = () => { };
+  //     test('enables navigation to next item with next button', () => {
+  //       // Stub loading HTMLMediaElement for jsdom
+  //       window.HTMLMediaElement.prototype.load = () => { };
 
-        const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
-          initialManifestState: { ...manifestState(playlistManifest, 1, true), autoAdvance: false, },
-          initialPlayerState: {},
-        });
-        render(
-          <ErrorBoundary>
-            <PlayerWithManifest />
-          </ErrorBoundary>
-        );
-        expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
-        expect(screen.getByText('You do not have permission to playback this item.')).toBeInTheDocument();
-        expect(screen.queryByTestId('inaccessible-message-timer')).toBeInTheDocument();
-        expect(screen.getByTestId('inaccessible-message-timer')).toHaveClass('hidden');
-        expect(screen.queryByTestId('inaccessible-next-button')).toBeInTheDocument();
-        fireEvent.click(screen.getByTestId('inaccessible-next-button'));
-        // Loads video player for the next item in the list
-        expect(
-          screen.queryAllByTestId('videojs-video-element').length
-        ).toBeGreaterThan(0);
-      });
-    });
-  });
+  //       const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
+  //         initialManifestState: { ...manifestState(playlistManifest, 1, true), autoAdvance: false, },
+  //         initialPlayerState: {},
+  //       });
+  //       render(
+  //         <ErrorBoundary>
+  //           <PlayerWithManifest />
+  //         </ErrorBoundary>
+  //       );
+  //       expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
+  //       expect(screen.getByText('You do not have permission to playback this item.')).toBeInTheDocument();
+  //       expect(screen.queryByTestId('inaccessible-message-timer')).toBeInTheDocument();
+  //       expect(screen.getByTestId('inaccessible-message-timer')).toHaveClass('hidden');
+  //       expect(screen.queryByTestId('inaccessible-next-button')).toBeInTheDocument();
+  //       fireEvent.click(screen.getByTestId('inaccessible-next-button'));
+  //       // Loads video player for the next item in the list
+  //       expect(
+  //         screen.queryAllByTestId('videojs-video-element').length
+  //       ).toBeGreaterThan(0);
+  //     });
+  //   });
+  // });
 
   describe('sticky settings', () => {
     let mockLocalStorage = {};

--- a/src/components/MediaPlayer/MediaPlayer.test.js
+++ b/src/components/MediaPlayer/MediaPlayer.test.js
@@ -446,177 +446,199 @@ describe('MediaPlayer component', () => {
     });
   });
 
-  // describe('displays inaccessible message', () => {
-  //   test('with HTML from placeholderCanvas for an empty canvas', () => {
-  //     // Stub loading HTMLMediaElement for jsdom
-  //     window.HTMLMediaElement.prototype.load = () => { };
+  describe('displays inaccessible message', () => {
+    const mockHooks = () => {
+      jest.spyOn(hooks, 'useMediaPlayer').mockImplementation(() => ({
+        canvasIsEmpty: true,
+        canvasIndex: 1,
+        lastCanvasIndex: 5
+      }));
+      const switchPlayerMock = jest.fn();
+      jest.spyOn(hooks, 'useSetupPlayer').mockImplementation(() => ({
+        switchPlayer: switchPlayerMock,
+        playerConfig: {
+          error: 'You do not have permission to playback this item.',
+          sources: [], tracks: [], poster: null, targets: []
+        },
+        ready: true,
+        isVideo: false
+      }));
+      return switchPlayerMock;
+    };
+    test('with HTML from placeholderCanvas for an empty canvas', () => {
+      // Stub loading HTMLMediaElement for jsdom
+      window.HTMLMediaElement.prototype.load = () => { };
 
-  //     const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
-  //       initialManifestState: { ...manifestState(emptyCanvasManifest, 1) },
-  //       initialPlayerState: {},
-  //     });
-  //     render(
-  //       <ErrorBoundary>
-  //         <PlayerWithManifest />
-  //       </ErrorBoundary>
-  //     );
-  //     expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
-  //     expect(screen.getByTestId('inaccessible-message-content').textContent)
-  //       .toEqual('You do not have permission to playback this item. \nPlease ' +
-  //         'contact support to report this error: admin-list@example.com.\n');
-  //   });
+      const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
+        initialManifestState: { ...manifestState(emptyCanvasManifest, 1) },
+        initialPlayerState: {},
+      });
+      render(
+        <ErrorBoundary>
+          <PlayerWithManifest />
+        </ErrorBoundary>
+      );
+      expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
+      expect(screen.getByTestId('inaccessible-message-content').textContent)
+        .toEqual('You do not have permission to playback this item. \nPlease ' +
+          'contact support to report this error: admin-list@example.com.\n');
+    });
 
-  //   test('for an inaccessible item in a playlist Manifest', () => {
-  //     // Stub loading HTMLMediaElement for jsdom
-  //     window.HTMLMediaElement.prototype.load = () => { };
+    test('for an inaccessible item in a playlist Manifest', () => {
+      // Stub loading HTMLMediaElement for jsdom
+      window.HTMLMediaElement.prototype.load = () => { };
 
-  //     const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
-  //       initialManifestState: { ...manifestState(playlistManifest, 0, true) },
-  //       initialPlayerState: {},
-  //     });
-  //     render(
-  //       <ErrorBoundary>
-  //         <PlayerWithManifest />
-  //       </ErrorBoundary>
-  //     );
-  //     expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
-  //     expect(screen.getByText('You do not have permission to playback this item.')).toBeInTheDocument();
-  //   });
+      const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
+        initialManifestState: { ...manifestState(playlistManifest, 0, true) },
+        initialPlayerState: {},
+      });
+      render(
+        <ErrorBoundary>
+          <PlayerWithManifest />
+        </ErrorBoundary>
+      );
+      expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
+      expect(screen.getByText('You do not have permission to playback this item.')).toBeInTheDocument();
+    });
 
-  //   describe('with auto-advance turned on', () => {
-  //     test('displays timer and next button for first item', () => {
-  //       // Stub loading HTMLMediaElement for jsdom
-  //       window.HTMLMediaElement.prototype.load = () => { };
+    describe('with auto-advance turned on', () => {
+      test('displays timer and next button for first item', () => {
+        // Stub loading HTMLMediaElement for jsdom
+        window.HTMLMediaElement.prototype.load = () => { };
 
-  //       const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
-  //         initialManifestState: { ...manifestState(playlistManifest, 0, true), autoAdvance: true, },
-  //         initialPlayerState: {},
-  //       });
-  //       render(
-  //         <ErrorBoundary>
-  //           <PlayerWithManifest />
-  //         </ErrorBoundary>
-  //       );
-  //       expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
-  //       expect(screen.getByText('You do not have permission to playback this item.')).toBeInTheDocument();
-  //       expect(screen.queryByTestId('inaccessible-message-timer')).toBeInTheDocument();
-  //       expect(screen.queryByTestId('inaccessible-next-button')).toBeInTheDocument();
-  //       // Does not display previous button for first item
-  //       expect(screen.queryByTestId('inaccessible-previous-button')).not.toBeInTheDocument();
-  //     });
+        const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
+          initialManifestState: { ...manifestState(playlistManifest, 0, true), autoAdvance: true, },
+          initialPlayerState: {},
+        });
+        render(
+          <ErrorBoundary>
+            <PlayerWithManifest />
+          </ErrorBoundary>
+        );
+        expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
+        expect(screen.getByText('You do not have permission to playback this item.')).toBeInTheDocument();
+        expect(screen.queryByTestId('inaccessible-message-timer')).toBeInTheDocument();
+        expect(screen.queryByTestId('inaccessible-next-button')).toBeInTheDocument();
+        // Does not display previous button for first item
+        expect(screen.queryByTestId('inaccessible-previous-button')).not.toBeInTheDocument();
+      });
 
-  //     test('displays timer and previous/next button for an inaccessible item nested between other item', () => {
-  //       // Stub loading HTMLMediaElement for jsdom
-  //       window.HTMLMediaElement.prototype.load = () => { };
+      test('displays timer and previous/next button for an inaccessible item nested between other item', () => {
+        // Stub loading HTMLMediaElement for jsdom
+        window.HTMLMediaElement.prototype.load = () => { };
 
-  //       const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
-  //         initialManifestState: { ...manifestState(playlistManifest, 1, true), autoAdvance: true, },
-  //         initialPlayerState: {},
-  //       });
-  //       render(
-  //         <ErrorBoundary>
-  //           <PlayerWithManifest />
-  //         </ErrorBoundary>
-  //       );
-  //       expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
-  //       expect(screen.getByText('You do not have permission to playback this item.')).toBeInTheDocument();
-  //       expect(screen.queryByTestId('inaccessible-message-timer')).toBeInTheDocument();
-  //       expect(screen.queryByTestId('inaccessible-next-button')).toBeInTheDocument();
-  //       expect(screen.queryByTestId('inaccessible-previous-button')).toBeInTheDocument();
-  //     });
+        const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
+          initialManifestState: { ...manifestState(playlistManifest, 1, true), autoAdvance: true, },
+          initialPlayerState: {},
+        });
+        render(
+          <ErrorBoundary>
+            <PlayerWithManifest />
+          </ErrorBoundary>
+        );
+        expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
+        expect(screen.getByText('You do not have permission to playback this item.')).toBeInTheDocument();
+        expect(screen.queryByTestId('inaccessible-message-timer')).toBeInTheDocument();
+        expect(screen.queryByTestId('inaccessible-next-button')).toBeInTheDocument();
+        expect(screen.queryByTestId('inaccessible-previous-button')).toBeInTheDocument();
+      });
 
-  //     test('displays timer and previous button when last item is an inaccessible item', () => {
-  //       // Stub loading HTMLMediaElement for jsdom
-  //       window.HTMLMediaElement.prototype.load = () => { };
+      test('displays timer and previous button when last item is an inaccessible item', () => {
+        // Stub loading HTMLMediaElement for jsdom
+        window.HTMLMediaElement.prototype.load = () => { };
 
-  //       const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
-  //         initialManifestState: { ...manifestState(playlistManifest, 5, true), autoAdvance: true, },
-  //         initialPlayerState: {},
-  //       });
-  //       render(
-  //         <ErrorBoundary>
-  //           <PlayerWithManifest />
-  //         </ErrorBoundary>
-  //       );
-  //       expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
-  //       expect(screen.getByText('You do not have permission to playback this item.')).toBeInTheDocument();
-  //       expect(screen.queryByTestId('inaccessible-message-timer')).not.toBeInTheDocument();
-  //       expect(screen.queryByTestId('inaccessible-next-button')).not.toBeInTheDocument();
-  //       expect(screen.queryByTestId('inaccessible-previous-button')).toBeInTheDocument();
-  //     });
+        const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
+          initialManifestState: { ...manifestState(playlistManifest, 5, true), autoAdvance: true, },
+          initialPlayerState: {},
+        });
+        render(
+          <ErrorBoundary>
+            <PlayerWithManifest />
+          </ErrorBoundary>
+        );
+        expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
+        expect(screen.getByText('You do not have permission to playback this item.')).toBeInTheDocument();
+        expect(screen.queryByTestId('inaccessible-message-timer')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('inaccessible-next-button')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('inaccessible-previous-button')).toBeInTheDocument();
+      });
 
-  //     test('enables navigation to next item with next button', () => {
-  //       // Stub loading HTMLMediaElement for jsdom
-  //       window.HTMLMediaElement.prototype.load = () => { };
+      test('enables navigation to next item with next button', () => {
+        // Stub loading HTMLMediaElement for jsdom
+        window.HTMLMediaElement.prototype.load = () => { };
+        const switchPlayerMock = mockHooks();
 
-  //       const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
-  //         initialManifestState: { ...manifestState(playlistManifest, 1, true), autoAdvance: true, },
-  //         initialPlayerState: {},
-  //       });
-  //       render(
-  //         <ErrorBoundary>
-  //           <PlayerWithManifest />
-  //         </ErrorBoundary>
-  //       );
-  //       expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
-  //       expect(screen.getByText('You do not have permission to playback this item.')).toBeInTheDocument();
-  //       expect(screen.queryByTestId('inaccessible-message-timer')).toBeInTheDocument();
-  //       expect(screen.queryByTestId('inaccessible-next-button')).toBeInTheDocument();
-  //       fireEvent.click(screen.getByTestId('inaccessible-next-button'));
-  //       // Loads video player for the next item in the list
-  //       expect(
-  //         screen.queryAllByTestId('videojs-video-element').length
-  //       ).toBeGreaterThan(0);
-  //     });
-  //   });
+        const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
+          initialManifestState: { ...manifestState(playlistManifest, 1, true), autoAdvance: true, },
+          initialPlayerState: {},
+        });
+        render(
+          <ErrorBoundary>
+            <PlayerWithManifest />
+          </ErrorBoundary>
+        );
+        expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
+        expect(screen.getByText('You do not have permission to playback this item.')).toBeInTheDocument();
+        expect(screen.queryByTestId('inaccessible-message-timer')).toBeInTheDocument();
+        expect(screen.queryByTestId('inaccessible-next-button')).toBeInTheDocument();
+        fireEvent.click(screen.getByTestId('inaccessible-next-button'));
+        expect(switchPlayerMock).toHaveBeenCalledTimes(1);
+        // Loads video player for the next item in the list
+        waitFor(() => expect(
+          screen.queryAllByTestId('videojs-video-element').length
+        ).toBeGreaterThan(0));
+      });
+    });
 
-  //   describe('with auto-advance turned off', () => {
-  //     test('hides the display timer', () => {
-  //       // Stub loading HTMLMediaElement for jsdom
-  //       window.HTMLMediaElement.prototype.load = () => { };
+    describe('with auto-advance turned off', () => {
+      test('hides the display timer', () => {
+        // Stub loading HTMLMediaElement for jsdom
+        window.HTMLMediaElement.prototype.load = () => { };
 
-  //       const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
-  //         initialManifestState: { ...manifestState(playlistManifest, 0, true), autoAdvance: false, },
-  //         initialPlayerState: {},
-  //       });
-  //       render(
-  //         <ErrorBoundary>
-  //           <PlayerWithManifest />
-  //         </ErrorBoundary>
-  //       );
-  //       expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
-  //       expect(screen.getByText('You do not have permission to playback this item.')).toBeInTheDocument();
-  //       expect(screen.queryByTestId('inaccessible-message-timer')).toBeInTheDocument();
-  //       expect(screen.getByTestId('inaccessible-message-timer')).toHaveClass('hidden');
-  //       expect(screen.queryByTestId('inaccessible-next-button')).toBeInTheDocument();
-  //     });
+        const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
+          initialManifestState: { ...manifestState(playlistManifest, 0, true), autoAdvance: false, },
+          initialPlayerState: {},
+        });
+        render(
+          <ErrorBoundary>
+            <PlayerWithManifest />
+          </ErrorBoundary>
+        );
+        expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
+        expect(screen.getByText('You do not have permission to playback this item.')).toBeInTheDocument();
+        expect(screen.queryByTestId('inaccessible-message-timer')).toBeInTheDocument();
+        expect(screen.getByTestId('inaccessible-message-timer')).toHaveClass('hidden');
+        expect(screen.queryByTestId('inaccessible-next-button')).toBeInTheDocument();
+      });
 
-  //     test('enables navigation to next item with next button', () => {
-  //       // Stub loading HTMLMediaElement for jsdom
-  //       window.HTMLMediaElement.prototype.load = () => { };
+      test('enables navigation to next item with next button', () => {
+        // Stub loading HTMLMediaElement for jsdom
+        window.HTMLMediaElement.prototype.load = () => { };
 
-  //       const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
-  //         initialManifestState: { ...manifestState(playlistManifest, 1, true), autoAdvance: false, },
-  //         initialPlayerState: {},
-  //       });
-  //       render(
-  //         <ErrorBoundary>
-  //           <PlayerWithManifest />
-  //         </ErrorBoundary>
-  //       );
-  //       expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
-  //       expect(screen.getByText('You do not have permission to playback this item.')).toBeInTheDocument();
-  //       expect(screen.queryByTestId('inaccessible-message-timer')).toBeInTheDocument();
-  //       expect(screen.getByTestId('inaccessible-message-timer')).toHaveClass('hidden');
-  //       expect(screen.queryByTestId('inaccessible-next-button')).toBeInTheDocument();
-  //       fireEvent.click(screen.getByTestId('inaccessible-next-button'));
-  //       // Loads video player for the next item in the list
-  //       expect(
-  //         screen.queryAllByTestId('videojs-video-element').length
-  //       ).toBeGreaterThan(0);
-  //     });
-  //   });
-  // });
+        const switchPlayerMock = mockHooks();
+        const PlayerWithManifest = withManifestAndPlayerProvider(MediaPlayer, {
+          initialManifestState: { ...manifestState(playlistManifest, 1, true), autoAdvance: false, },
+          initialPlayerState: {},
+        });
+        render(
+          <ErrorBoundary>
+            <PlayerWithManifest />
+          </ErrorBoundary>
+        );
+        expect(screen.queryByTestId('inaccessible-message-display')).toBeInTheDocument();
+        expect(screen.getByText('You do not have permission to playback this item.')).toBeInTheDocument();
+        expect(screen.queryByTestId('inaccessible-message-timer')).toBeInTheDocument();
+        expect(screen.getByTestId('inaccessible-message-timer')).toHaveClass('hidden');
+        expect(screen.queryByTestId('inaccessible-next-button')).toBeInTheDocument();
+        fireEvent.click(screen.getByTestId('inaccessible-next-button'));
+        expect(switchPlayerMock).toHaveBeenCalledTimes(1);
+        // Loads video player for the next item in the list
+        waitFor(() => expect(
+          screen.queryAllByTestId('videojs-video-element').length
+        ).toBeGreaterThan(0));
+      });
+    });
+  });
 
   describe('sticky settings', () => {
     let mockLocalStorage = {};

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useRef } from 'react';
 import PropTypes from 'prop-types';
 import videojs from 'video.js';
 import throttle from 'lodash/throttle';
@@ -10,16 +10,16 @@ import '@silvermine/videojs-quality-selector/dist/css/quality-selector.css';
 
 import { usePlayerDispatch, usePlayerState } from '../../../context/player-context';
 import { useManifestState, useManifestDispatch } from '../../../context/manifest-context';
-import {
-  CANVAS_MESSAGE_TIMEOUT, checkSrcRange,
-  getMediaFragment, HOTKEY_ACTION_OUTPUT, playerHotKeys
-} from '@Services/utility-helpers';
+import { checkSrcRange, getMediaFragment } from '@Services/utility-helpers';
 import {
   IS_ANDROID, IS_IOS, IS_IPAD, IS_MOBILE,
   IS_SAFARI, IS_TOUCH_ONLY
 } from '@Services/browser';
 import { useLocalStorage } from '@Services/local-storage';
 import { SectionButtonIcon } from '@Services/svg-icons';
+import {
+  useMediaPlayer, useSetupPlayer, useShowInaccessibleMessage, useVideoJSPlayer
+} from '@Services/ramp-hooks';
 import './VideoJSPlayer.scss';
 import './videojs-theme.scss';
 
@@ -31,14 +31,16 @@ import VideoJSNextButton from './components/js/VideoJSNextButton';
 import VideoJSPreviousButton from './components/js/VideoJSPreviousButton';
 import VideoJSTitleLink from './components/js/VideoJSTitleLink';
 import VideoJSTrackScrubber from './components/js/VideoJSTrackScrubber';
-import { useMediaPlayer, useSetupPlayer, useShowInaccessibleMessage } from '@Services/ramp-hooks';
 // import vjsYo from './vjsYo';
 
 function VideoJSPlayer({
   enableFileDownload,
   enableTitleLink,
+  isVideo,
   options,
+  placeholderText,
   scrubberTooltipRef,
+  tracks,
   trackScrubberRef,
   videoJSLangMap,
   withCredentials,
@@ -51,267 +53,170 @@ function VideoJSPlayer({
   const {
     canvasDuration,
     canvasLink,
-    currentNavItem,
     hasMultiItems,
-    srcIndex,
     targets,
     autoAdvance,
-    playlist,
     structures,
     canvasSegments,
     hasStructure,
-    canvasIsEmpty,
   } = manifestState;
-  const {
-    isClicked,
-    isEnded,
-    isPlaying,
-    player,
-    searchMarkers,
-    currentTime,
-  } = playerState;
+  const { isEnded, isPlaying, currentTime } = playerState;
 
-  const [isReady, _setIsReady] = React.useState(false);
-  const [activeId, _setActiveId] = React.useState('');
   const [startVolume, setStartVolume] = useLocalStorage('startVolume', 1);
-  const [startQuality, setStartQuality] = useLocalStorage('startQuality', null);
   const [startMuted, setStartMuted] = useLocalStorage('startMuted', false);
   const [startCaptioned, setStartCaptioned] = useLocalStorage('startCaptioned', true);
-  const [fragmentMarker, setFragmentMarker] = React.useState(null);
+  const [startQuality, setStartQuality] = useLocalStorage('startQuality', null);
 
-  const videoJSRef = React.useRef(null);
-  const playerRef = React.useRef(null);
+  const videoJSRef = useRef(null);
+  const captionsOnRef = useRef();
+  const activeTrackRef = useRef();
 
-  const autoAdvanceRef = React.useRef();
-  autoAdvanceRef.current = autoAdvance;
-
-  const srcIndexRef = React.useRef();
-  srcIndexRef.current = srcIndex;
-
-  let activeIdRef = React.useRef();
-  activeIdRef.current = activeId;
-  const setActiveId = (id) => {
-    _setActiveId(id);
-    activeIdRef.current = id;
-  };
-
-  let currentTimeRef = React.useRef();
-  currentTimeRef.current = currentTime;
-
-  let isReadyRef = React.useRef();
-  isReadyRef.current = isReady;
-  const setIsReady = (r) => {
-    _setIsReady(r);
-    isReadyRef.current = r;
-  };
-
-  let currentNavItemRef = React.useRef();
-  currentNavItemRef.current = currentNavItem;
-
-  let canvasIsEmptyRef = React.useRef();
-  canvasIsEmptyRef.current = canvasIsEmpty;
-
-  let canvasDurationRef = React.useRef();
-  canvasDurationRef.current = canvasDuration;
-
-  let canvasLinkRef = React.useRef();
-  canvasLinkRef.current = canvasLink;
-
-  let isPlayingRef = React.useRef();
-  isPlayingRef.current = isPlaying;
-
-  let isEndedRef = React.useRef();
-  isEndedRef.current = isEnded;
-
-  let captionsOnRef = React.useRef();
-  let activeTrackRef = React.useRef();
-
-  let canvasSegmentsRef = React.useRef();
-  canvasSegmentsRef.current = canvasSegments;
-
-  let structuresRef = React.useRef();
-  structuresRef.current = structures;
-
-  const { canvasIndex, lastCanvasIndex, isPlaylist } = useMediaPlayer();
-  const { isVideo, playerConfig, renderingFiles, switchPlayer }
+  const { canvasIndex, canvasIsEmpty, lastCanvasIndex } = useMediaPlayer();
+  const { isPlaylist, renderingFiles, srcIndex, switchPlayer }
     = useSetupPlayer({ enableFileDownload, withCredentials, lastCanvasIndex });
-  const { tracks } = playerConfig;
   const { messageTime } = useShowInaccessibleMessage({ lastCanvasIndex });
 
-  let cIndexRef = React.useRef();
-  cIndexRef.current = useMemo(() => { return canvasIndex; }, [canvasIndex]);
+  const canvasIsEmptyRef = useRef();
+  canvasIsEmptyRef.current = useMemo(() => { return canvasIsEmpty; }, [canvasIsEmpty]);
 
-  // Dispose Video.js instance when VideoJSPlayer component is removed
-  React.useEffect(() => {
-    return () => {
-      if (playerRef.current != null) {
-        playerRef.current.dispose();
-        document.removeEventListener('keydown', playerHotKeys);
-        setIsReady(false);
-      }
-    };
-  }, []);
+  const isEndedRef = useRef();
+  isEndedRef.current = useMemo(() => { return isEnded; }, [isEnded]);
+
+  const isPlayingRef = useRef();
+  isPlayingRef.current = useMemo(() => { return isPlaying; }, [isPlaying]);
+
+  const autoAdvanceRef = useRef();
+  autoAdvanceRef.current = useMemo(() => { return autoAdvance; }, [autoAdvance]);
+
+  const srcIndexRef = useRef();
+  srcIndexRef.current = useMemo(() => { return srcIndex; }, [srcIndex]);
+
+  const currentTimeRef = useRef();
+  currentTimeRef.current = useMemo(() => { return currentTime; }, [currentTime]);
 
   /**
-   * Initialize Video.js when for the first page load or update
-   * src and other properties of the existing Video.js instance
-   * on Canvas change
+   * Setup player with player-related information parsed from the IIIF
+   * Manifest Canvas. This gets called on both initial page load and each
+   * Canvas switch to setup and update player respectively.
+   * @param {Object} player current player instance from Video.js
    */
-  React.useEffect(() => {
-    // setCIndex(canvasIndex);
+  const playerInitSetup = (player) => {
+    player.on('ready', function () {
+      console.log('Player ready');
 
-    // Set selected quality from localStorage in Video.js options
-    setSelectedQuality(options.sources);
+      // Add this class in mobile/tablet devices to always show the control bar,
+      // since the inactivityTimeout is flaky in some browsers
+      if (IS_MOBILE || IS_IPAD) {
+        player.controlBar.addClass('vjs-mobile-visible');
+      }
 
-    // Video.js player is only initialized on initial page load
-    if (!playerRef.current && options.sources?.length > 0) {
-      videojs.addLanguage(options.language, JSON.parse(videoJSLangMap));
+      player.muted(startMuted);
+      player.volume(startVolume);
+      player.canvasIndex = cIndexRef.current;
+      player.duration(canvasDuration);
+      player.srcIndex = srcIndex;
+      player.targets = targets;
 
-      buildTracksHTML();
+      if (enableTitleLink) player.canvasLink = canvasLink;
 
-      // Turn Video.js logging off and handle errors in this code, to avoid
-      // cluttering the console when loading inaccessible items.
-      videojs.log.level('off');
+      // Need to set this once experimentalSvgIcons option in Video.js options was enabled
+      player.getChild('controlBar').qualitySelector.setIcon('cog');
+    });
 
-      const player = playerRef.current = videojs(videoJSRef.current, options, () => {
-        playerInitSetup(playerRef.current);
-      });
-
-      /* Another way to add a component to the controlBar */
-      // player.getChild('controlBar').addChild('vjsYo', {});
-
-      playerDispatch({
-        player: player,
-        type: 'updatePlayer',
-      });
-
-      // Update player status in state only when pause is initiate by the user
-      player.controlBar.getChild('PlayToggle').on('pointerdown', () => {
-        handlePause();
-      });
-      player.on('pointerdown', (e) => {
-        const elementTag = e.target.nodeName.toLowerCase();
-        if (elementTag == 'video') {
-          handlePause();
+    player.on('progress', () => {
+      // Reveal player if not revealed on 'loadedmetadata' event, allowing user to 
+      // interact with the player since enough data is available for playback
+      if (player.hasClass('vjs-disabled')) { player.removeClass('vjs-disabled'); }
+    });
+    player.on('canplay', () => {
+      // Reset isEnded flag
+      playerDispatch({ isEnded: false, type: 'setIsEnded' });
+    });
+    player.on('play', () => {
+      playerDispatch({ isPlaying: true, type: 'setPlayingStatus' });
+    });
+    player.on('timeupdate', () => {
+      handleTimeUpdate();
+    });
+    player.on('ended', () => {
+      /**
+       * Checking against isReadyRef.current stops from delayed events being executed
+       * when transitioning from a Canvas to the next.
+       * Checking against isPlayingRef.current to distinguish whether this event
+       * triggered intentionally, because Video.js seem to trigger this event when
+       * switching to a media file with a shorter duration in Safari browsers.
+       */
+      setTimeout(() => {
+        if (isReadyRef.current && isPlayingRef.current) {
+          playerDispatch({ isEnded: true, type: 'setIsEnded' });
+          player.pause();
+          if (!canvasIsEmptyRef.current) handleEnded();
         }
-      });
-    } else if (playerRef.current && options.sources?.length > 0) {
-      // Update the existing Video.js player on consecutive Canvas changes
-      const player = playerRef.current;
-
-      // Reset markers
-      if (activeIdRef.current) player.markers?.removeAll();
-      setActiveId(null);
-
-      // Block player while metadata is loaded when canvas is not empty
-      if (!canvasIsEmptyRef.current) {
-        player.addClass('vjs-disabled');
-
-        setIsReady(false);
-        updatePlayer(player);
-        playerLoadedMetadata(player);
-
-        playerDispatch({
-          player: player,
-          type: 'updatePlayer',
-        });
-      } else {
-        // Mark as ready to for inaccessible canvas (empty)
-        setIsReady(true);
+      }, 100);
+    });
+    player.on('volumechange', () => {
+      setStartMuted(player.muted());
+      setStartVolume(player.volume());
+    });
+    player.on('qualityRequested', (e, quality) => {
+      setStartQuality(quality.label);
+    });
+    // Use error event listener for inaccessible item display
+    player.on('error', (e) => {
+      const error = player.error();
+      let errorMessage = 'Something went wrong. Please try again later or contact support for help.';
+      // Handle different error codes
+      switch (error.code) {
+        case 1:
+          console.error('MEDIA_ERR_ABORTED: The fetching process for the media resource was aborted by the user agent\
+             at the user’s request.');
+          break;
+        case 2:
+          errorMessage = 'The media could not be loaded due to a network error. Please try again later.';
+          console.error('MEDIA_ERR_NETWORK: A network error caused the user agent to stop fetching the media resource,\
+             after the resource was established to be usable.');
+          break;
+        case 3:
+          errorMessage = 'Media is corrupt or has features not supported by the browser. \
+          Please try a different media or contact support for help.';
+          console.error('MEDIA_ERR_DECODE: An error occurred while decoding the media resource, after\
+             the resource was established to be usable.');
+          break;
+        case 4:
+          errorMessage = 'Media could not be loaded.  Network error or media format is not supported.';
+          console.error('MEDIA_ERR_SRC_NOT_SUPPORTED: The media resource indicated by the src attribute was not suitable.');
+          break;
+        default:
+          console.error('An unknown error occurred.');
+          break;
       }
-    }
-  }, [options.sources, videoJSRef]);
-
-  React.useEffect(() => {
-    if (playerRef.current) {
-      // Show/hide control bar for valid/inaccessible items respectively
-      if (canvasIsEmptyRef.current) {
-        // Set the player's aspect ratio to video
-        playerRef.current.audioOnlyMode(false);
-        playerRef.current.canvasIsEmpty = true;
-        playerRef.current.aspectRatio('16:9');
-        playerRef.current.controlBar.addClass('vjs-hidden');
-        playerRef.current.removeClass('vjs-disabled');
-        playerRef.current.pause();
-        /**
-         * Update the activeId to update the active item in the structured navigation.
-         * For playable items this is updated in the timeupdate handler.
-         */
-        setActiveId(currentNavItemRef.current?.id);
-      } else {
-        // Reveal control bar; needed when loading a Canvas after an inaccessible item
-        playerRef.current.controlBar.removeClass('vjs-hidden');
+      // Show dismissable error display modal from Video.js
+      var errorDisplay = player.getChild('ErrorDisplay');
+      if (errorDisplay) {
+        errorDisplay.contentEl().innerText = errorMessage;
+        errorDisplay.removeClass('vjs-hidden');
+        player.removeClass('vjs-error');
+        player.removeClass('vjs-disabled');
       }
-    }
-  }, [cIndexRef.current, canvasIsEmptyRef.current, currentNavItemRef.current]);
-
-  // update markers in player
-  React.useEffect(() => {
-    if (playerRef.current && playerRef.current.markers && isReadyRef.current) {
-      // markers plugin not yet initialized
-      if (typeof playerRef.current.markers === 'function') {
-        playerRef.current.markers({
-          markerTip: {
-            display: false, // true,
-            text: marker => marker.text
-          },
-          markerStyle: {},
-          markers: [],
-        });
-      }
-
-      let playlistMarkers = [];
-      if (playlist?.markers?.length) {
-        const canvasMarkers = playlist.markers.filter((m) => m.canvasIndex === canvasIndex)[0].canvasMarkers;
-        playlistMarkers = canvasMarkers.map((m) => ({
-          time: parseFloat(m.time),
-          text: m.value,
-          class: 'ramp--track-marker--playlist'
-        }));
-      }
-
-      playerRef.current.markers?.removeAll();
-      playerRef.current.markers.add([
-        ...(fragmentMarker ? [fragmentMarker] : []),
-        ...searchMarkers,
-        ...playlistMarkers,
-      ]);
-    }
-  }, [
-    fragmentMarker,
-    searchMarkers,
-    canvasDuration,
-    canvasIndex,
-    playerRef.current,
-    isReadyRef.current
-  ]);
-
-  /**
-   * Build track HTML for Video.js player on initial page load
-   */
-  const buildTracksHTML = () => {
-    if (tracks?.length > 0 && videoJSRef.current) {
-      tracks.map((t) => {
-        let trackEl = document.createElement('track');
-        trackEl.setAttribute('key', t.key);
-        trackEl.setAttribute('src', t.src);
-        trackEl.setAttribute('kind', t.kind);
-        trackEl.setAttribute('label', t.label);
-        trackEl.setAttribute('srclang', t.srclang);
-        videoJSRef.current.appendChild(trackEl);
-      });
-    }
+      e.stopPropagation();
+    });
+    playerLoadedMetadata(player);
   };
 
+  /**
+   * Update player properties and data when player is reloaded with
+   * source change, i.e. Canvas change
+   * @param {Object} player 
+   */
   const updatePlayer = (player) => {
-    player.duration(canvasDurationRef.current);
+    player.duration(canvasDuration);
     player.src(options.sources);
     player.poster(options.poster);
     player.canvasIndex = cIndexRef.current;
     player.canvasIsEmpty = canvasIsEmptyRef.current;
     player.srcIndex = srcIndex;
     player.targets = targets;
-    if (enableTitleLink) { player.canvasLink = canvasLinkRef.current; }
+    if (enableTitleLink) player.canvasLink = canvasLink;
 
     // Update textTracks in the player
     var oldTracks = player.remoteTextTracks();
@@ -418,6 +323,8 @@ function VideoJSPlayer({
         }
       }
     }
+
+    playerLoadedMetadata(player);
   };
 
   /**
@@ -429,7 +336,7 @@ function VideoJSPlayer({
     player.one('loadedmetadata', () => {
       console.log('Player loadedmetadata');
 
-      player.duration(canvasDurationRef.current);
+      player.duration(canvasDuration);
 
       isEndedRef.current ? player.currentTime(0) : player.currentTime(currentTimeRef.current);
 
@@ -462,12 +369,12 @@ function VideoJSPlayer({
         player properties. These values are read by track-scrubber component to build
         and update the track-scrubber progress and time in the UI.
       */
-      const mediaRange = getMediaFragment(player.src(), canvasDurationRef.current);
+      const mediaRange = getMediaFragment(player.src(), canvasDuration);
       if (mediaRange != undefined) {
         player.playableDuration = mediaRange.end - mediaRange.start;
         player.altStart = mediaRange.start;
       } else {
-        player.playableDuration = canvasDurationRef.current;
+        player.playableDuration = canvasDuration;
         player.altStart = targets[srcIndex].altStart;
       }
 
@@ -503,131 +410,17 @@ function VideoJSPlayer({
     });
   };
 
-  /**
-   * Setup player with player-related information parsed from the IIIF
-   * Manifest Canvas. This gets called on both initial page load and each
-   * Canvas switch to setup and update player respectively.
-   * @param {Object} player current player instance from Video.js
-   */
-  const playerInitSetup = (player) => {
-    player.on('ready', function () {
-      console.log('Player ready');
+  const {
+    activeId, fragmentMarker, isReadyRef, playerRef, setActiveId, setFragmentMarker, setIsReady
+  } = useVideoJSPlayer({
+    options, playerInitSetup, updatePlayer, startQuality, tracks, videoJSRef, videoJSLangMap
+  });
 
-      // Add this class in mobile/tablet devices to always show the control bar,
-      // since the inactivityTimeout is flaky in some browsers
-      if (IS_MOBILE || IS_IPAD) {
-        player.controlBar.addClass('vjs-mobile-visible');
-      }
+  let cIndexRef = useRef();
+  cIndexRef.current = useMemo(() => { return canvasIndex; }, [canvasIndex]);
 
-      player.muted(startMuted);
-      player.volume(startVolume);
-      player.canvasIndex = cIndexRef.current;
-      player.duration(canvasDurationRef.current);
-      player.srcIndex = srcIndex;
-      player.targets = targets;
-
-      if (enableTitleLink) { player.canvasLink = canvasLinkRef.current; }
-      // Need to set this once experimentalSvgIcons option in Video.js options was enabled
-      player.getChild('controlBar').qualitySelector.setIcon('cog');
-    });
-
-    playerLoadedMetadata(player);
-
-    player.on('progress', () => {
-      // Reveal player if not revealed on 'loadedmetadata' event, allowing user to 
-      // interact with the player since enough data is available for playback
-      if (player.hasClass('vjs-disabled')) { player.removeClass('vjs-disabled'); }
-    });
-    player.on('canplay', () => {
-      // Reset isEnded flag
-      playerDispatch({ isEnded: false, type: 'setIsEnded' });
-    });
-    player.on('play', () => {
-      playerDispatch({ isPlaying: true, type: 'setPlayingStatus' });
-    });
-    player.on('timeupdate', () => {
-      handleTimeUpdate();
-    });
-    player.on('ended', () => {
-      /**
-       * Checking against isReadyRef stops from delayed events being executed
-       * when transitioning from a Canvas to the next.
-       * Checking against isPlayingRef.current to distinguish whether this event
-       * triggered intentionally, because Video.js seem to trigger this event when
-       * switching to a media file with a shorter duration in Safari browsers.
-       */
-      setTimeout(() => {
-        if (isReadyRef.current && isPlayingRef.current) {
-          playerDispatch({ isEnded: true, type: 'setIsEnded' });
-          player.pause();
-          if (!canvasIsEmptyRef.current) handleEnded();
-        }
-      }, 100);
-    });
-    player.on('volumechange', () => {
-      setStartMuted(player.muted());
-      setStartVolume(player.volume());
-    });
-    player.on('qualityRequested', (e, quality) => {
-      setStartQuality(quality.label);
-    });
-    // Use error event listener for inaccessible item display
-    player.on('error', (e) => {
-      const error = player.error();
-      let errorMessage = 'Something went wrong. Please try again later or contact support for help.';
-      // Handle different error codes
-      switch (error.code) {
-        case 1:
-          console.error('MEDIA_ERR_ABORTED: The fetching process for the media resource was aborted by the user agent\
-             at the user’s request.');
-          break;
-        case 2:
-          errorMessage = 'The media could not be loaded due to a network error. Please try again later.';
-          console.error('MEDIA_ERR_NETWORK: A network error caused the user agent to stop fetching the media resource,\
-             after the resource was established to be usable.');
-          break;
-        case 3:
-          errorMessage = 'Media is corrupt or has features not supported by the browser. \
-          Please try a different media or contact support for help.';
-          console.error('MEDIA_ERR_DECODE: An error occurred while decoding the media resource, after\
-             the resource was established to be usable.');
-          break;
-        case 4:
-          errorMessage = 'Media could not be loaded.  Network error or media format is not supported.';
-          console.error('MEDIA_ERR_SRC_NOT_SUPPORTED: The media resource indicated by the src attribute was not suitable.');
-          break;
-        default:
-          console.error('An unknown error occurred.');
-          break;
-      }
-      // Show dismissable error display modal from Video.js
-      var errorDisplay = player.getChild('ErrorDisplay');
-      if (errorDisplay) {
-        errorDisplay.contentEl().innerText = errorMessage;
-        errorDisplay.removeClass('vjs-hidden');
-        player.removeClass('vjs-error');
-        player.removeClass('vjs-disabled');
-      }
-      e.stopPropagation();
-    });
-    /*
-      This event handler helps to execute hotkeys functions related to 'keydown' events
-      before any user interactions with the player or when focused on other non-input 
-      elements on the page
-    */
-    document.addEventListener('keydown', (event) => {
-      const result = playerHotKeys(event, player, canvasIsEmptyRef.current);
-      // Update player status in global state
-      switch (result) {
-        case HOTKEY_ACTION_OUTPUT.pause:
-          handlePause();
-          break;
-        // Handle other cases as needed for each action
-        default:
-          break;
-      }
-    });
-  };
+  const activeIdRef = useRef();
+  activeIdRef.current = useMemo(() => { return activeId; }, [activeId]);
 
   /**
    * Setup captions for the player based on context
@@ -704,26 +497,6 @@ function VideoJSPlayer({
   };
 
   /**
-   * Setting the current time of the player when using structure navigation
-   */
-  React.useEffect(() => {
-    if (playerRef.current !== null && isReadyRef.current) {
-      playerRef.current.currentTime(currentTimeRef.current, playerDispatch({ type: 'resetClick' }));
-    }
-  }, [isClicked, isReady]);
-
-  const setSelectedQuality = (sources) => {
-    //iterate through sources and find source that matches startQuality and source currently marked selected
-    //if found set selected attribute on matching source then remove from currently marked one
-    const originalQuality = sources?.find((source) => source.selected == true);
-    const selectedQuality = sources?.find((source) => source.label == startQuality);
-    if (selectedQuality) {
-      originalQuality.selected = false;
-      selectedQuality.selected = true;
-    }
-  };
-
-  /**
    * Add CSS class to icon to indicate captions are on/off in player control bar
    * @param {Boolean} subsOn flag to indicate captions are on/off
    */
@@ -759,7 +532,7 @@ function VideoJSPlayer({
    * load the correct item into the player, when the user clicks on a different item 
    * (not the next item in list) when the current item is coming to its end.
    */
-  const handleEnded = React.useMemo(() => throttle(() => {
+  const handleEnded = useMemo(() => throttle(() => {
     const isLastCanvas = cIndexRef.current === lastCanvasIndex;
     /**
      * Do nothing if Canvas is not multi-sourced AND autoAdvance is turned off 
@@ -784,8 +557,8 @@ function VideoJSPlayer({
         } else {
           return;
         }
-      } else if (structuresRef.current?.length > 0) {
-        const nextItem = structuresRef.current[cIndexRef.current + 1];
+      } else if (structures?.length > 0) {
+        const nextItem = structures[cIndexRef.current + 1];
 
         if (nextItem) {
           manifestDispatch({
@@ -798,7 +571,7 @@ function VideoJSPlayer({
           playerDispatch({ currentTime: 0, type: 'setCurrentTime' });
 
           // Get first timespan in the next canvas
-          let firstTimespanInNextCanvas = canvasSegmentsRef.current.filter(
+          let firstTimespanInNextCanvas = canvasSegments.filter(
             (t) => t.canvasIndex === nextItem.canvasIndex && t.itemIndex === 1
           );
           // If the nextItem doesn't have an ID (a Canvas media fragment) pick the first timespan
@@ -807,22 +580,17 @@ function VideoJSPlayer({
 
           let start = 0;
           if (nextFirstItem != undefined && nextFirstItem.id != undefined) {
-            start = getMediaFragment(nextFirstItem.id, canvasDurationRef.current).start;
+
+            start = getMediaFragment(nextFirstItem.id, canvasDuration).start;
           }
 
           // If there's a timespan item at the start of the next canvas
           // mark it as the currentNavItem. Otherwise empty out the currentNavItem.
           if (start === 0) {
-            manifestDispatch({
-              item: nextFirstItem,
-              type: 'switchItem',
-            });
+            manifestDispatch({ item: nextFirstItem, type: 'switchItem' });
           } else if (nextFirstItem.isEmpty) {
             // Switch the currentNavItem and clear isEnded flag
-            manifestDispatch({
-              item: nextFirstItem,
-              type: 'switchItem',
-            });
+            manifestDispatch({ item: nextFirstItem, type: 'switchItem' });
             playerRef.current.currentTime(start);
             // Only play if the next item is not an inaccessible item
             if (!nextItem.isEmpty) playerRef.current.play();
@@ -841,9 +609,9 @@ function VideoJSPlayer({
    * Using throttle helps for smooth updates by cancelling and cleaning up intermediate
    * delayed function calls.
    */
-  const handleTimeUpdate = React.useMemo(() => throttle(() => {
+  const handleTimeUpdate = useMemo(() => throttle(() => {
     const player = playerRef.current;
-    if (player !== null && isReadyRef.current) {
+    if (player && isReadyRef.current) {
       let playerTime = player.currentTime() ?? currentTimeRef.current;
 
       if (hasMultiItems && srcIndexRef.current > 0) {
@@ -867,11 +635,7 @@ function VideoJSPlayer({
 
           if (!isPlaylist && player.markers) {
             const { start, end } = getMediaFragment(activeSegment.id, activeSegment.canvasDuration);
-            playerDispatch({
-              endTime: end,
-              startTime: start,
-              type: 'setTimeFragment',
-            });
+            playerDispatch({ endTime: end, startTime: start, type: 'setTimeFragment' });
             if (start !== end) {
               // don't let marker extend past the end of the canvas
               let markerEnd = end > activeSegment.canvasDuration ? activeSegment.canvasDuration : end;
@@ -893,20 +657,11 @@ function VideoJSPlayer({
   }, 10), []);
 
   /**
-   * Update global state only when a user pause the player by using the
-   * player interface or keyboard shortcuts
-   */
-  const handlePause = () => {
-    if (isPlayingRef.current) {
-      playerDispatch({ isPlaying: false, type: 'setPlayingStatus' });
-    }
-  };
-
-  /**
    * Toggle play/pause on video touch for mobile browsers
    * @param {Object} e onTouchEnd event
    */
   const mobilePlayToggle = (e) => {
+    const player = playerRef.current;
     if (e.changedTouches[0].clientX == touchX && e.changedTouches[0].clientY == touchY) {
       if (player.paused()) {
         player.play();
@@ -934,18 +689,12 @@ function VideoJSPlayer({
    * @param {Number} time playhead's current time
    */
   const getActiveSegment = (time) => {
-    // Adjust time for multi-item canvases
-    let currentTime = time;
-    if (hasMultiItems) {
-      currentTime = currentTime + targets[srcIndex].altStart;
-    }
-
     if (isPlaylist) {
       // For playlists timespans and canvasIdex are mapped one-to-one
-      return canvasSegmentsRef.current[cIndexRef.current];
+      return canvasSegments[cIndexRef.current];
     } else {
       // Find the relevant media segment from the structure
-      for (let segment of canvasSegmentsRef.current) {
+      for (let segment of canvasSegments) {
         const { id, isCanvas, canvasIndex } = segment;
         if (canvasIndex == cIndexRef.current + 1) {
           // Canvases without structure has the Canvas information
@@ -956,7 +705,7 @@ function VideoJSPlayer({
           const segmentRange = getMediaFragment(id, canvasDuration);
           const isInRange = checkSrcRange(segmentRange, canvasDuration);
           const isInSegment =
-            currentTime >= segmentRange.start && currentTime < segmentRange.end;
+            time >= segmentRange.start && time < segmentRange.end;
           if (isInSegment && isInRange) {
             return segment;
           }
@@ -966,10 +715,23 @@ function VideoJSPlayer({
     }
   };
 
+  /**
+   * Click event handler for previous/next buttons in inaccessible
+   * message display
+   * @param {Number} c updated Canvas index upon event trigger
+   */
   const handlePrevNextClick = (c) => {
     switchPlayer(c, true);
   };
 
+  /**
+   * Keydown event handler for previou/next buttons in inaccessible
+   * message display.
+   * IMPORTANT: btnName param should be either 'nextBtn' or 'previousBtn'
+   * @param {Event} e keydown event
+   * @param {Number} c update Canvas index upon event trigger
+   * @param {String} btnName name of the pressed button
+   */
   const handlePrevNextKeydown = (e, c, btnName) => {
     if (e.which === 32 || e.which === 13) {
       switchPlayer(c, true, btnName);
@@ -984,29 +746,21 @@ function VideoJSPlayer({
             // These styles needs to be inline for the poster to display within the Video boundaries
             style={{
               position: !playerRef.current ? 'relative' : 'absolute',
-              top: 0,
-              left: 0,
-              right: 0,
-              bottom: 0,
-              display: 'flex',
-              flexDirection: 'column',
-              justifyContent: 'center',
-              alignItems: 'center',
-              fontSize: 'medium',
-              color: '#fff',
-              backgroundColor: 'black',
+              top: 0, left: 0, right: 0, bottom: 0,
+              display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center',
+              fontSize: 'medium', textAlign: 'center',
+              color: '#fff', backgroundColor: 'black',
               zIndex: 101,
               aspectRatio: !playerRef.current ? '16/9' : '',
-              textAlign: 'center',
             }}>
             <p className="ramp--media-player_inaccessible-message-content" data-testid="inaccessible-message-content"
-              dangerouslySetInnerHTML={{ __html: playerConfig.error }}>
+              dangerouslySetInnerHTML={{ __html: placeholderText }}>
             </p>
             <div className="ramp--media-player_inaccessible-message-buttons">
               {canvasIndex >= 1 &&
                 <button aria-label="Go back to previous item"
                   onClick={() => handlePrevNextClick(canvasIndex - 1)}
-                  onKeyDown={(e) => handlePrevNextKeydown(e, canvasIndex - 1, 'previousBtn    ')}
+                  onKeyDown={(e) => handlePrevNextKeydown(e, canvasIndex - 1, 'previousBtn')}
                   data-testid="inaccessible-previous-button">
                   <SectionButtonIcon flip={true} /> Previous
                 </button>
@@ -1057,8 +811,11 @@ function VideoJSPlayer({
 VideoJSPlayer.propTypes = {
   enableFileDownload: PropTypes.bool,
   enableTitleLink: PropTypes.bool,
+  isVideo: PropTypes.bool,
   options: PropTypes.object,
+  placeholderText: PropTypes.string,
   scrubberTooltipRef: PropTypes.object,
+  tracks: PropTypes.array,
   trackScrubberRef: PropTypes.object,
   videoJSLangMap: PropTypes.string,
   withCredentials: PropTypes.bool,

--- a/src/components/MediaPlayer/VideoJS/components/js/VideoJSProgress.js
+++ b/src/components/MediaPlayer/VideoJS/components/js/VideoJSProgress.js
@@ -42,6 +42,10 @@ class VideoJSProgress extends SeekBar {
       this.buildProgressBar();
     });
 
+    this.player.on('loadeddata', () => {
+      this.setInitTime(this.player.currentTime());
+    });
+
     // Update our progress bar after the user leaves full screen
     this.player.on('fullscreenchange', (e) => {
       if (!this.player.isFullscreen()) {

--- a/src/components/MediaPlayer/VideoJS/components/js/VideoJSTrackScrubber.js
+++ b/src/components/MediaPlayer/VideoJS/components/js/VideoJSTrackScrubber.js
@@ -75,7 +75,6 @@ class VideoJSTrackScrubber extends Button {
         this.playerInterval = setInterval(() => {
           this.handleTimeUpdate();
         }, 100);
-        this.attachListeners();
       }
     });
 
@@ -132,7 +131,6 @@ class VideoJSTrackScrubber extends Button {
 
   attachListeners() {
     const { trackScrubberRef } = this.options;
-    this.updateComponent();
     if (trackScrubberRef.current) {
       // Initialize the track scrubber's current time and duration
       this.populateTrackScrubber();
@@ -172,6 +170,7 @@ class VideoJSTrackScrubber extends Button {
     // Reset refs to initial value
     this.zoomedOutRef.current = true;
     this.currentTrackRef.current = {};
+    this.attachListeners();
   }
 
   /**

--- a/src/components/MediaPlayer/VideoJS/components/styles/VideoJSTrackScrubber.scss
+++ b/src/components/MediaPlayer/VideoJS/components/styles/VideoJSTrackScrubber.scss
@@ -141,7 +141,7 @@
     width: 6px !important;
   }
 
-  top: 0px;
+  top: 0.25em;
   height: 6px;
   opacity: 0.75;
   transition: opacity 200ms ease-out,

--- a/src/context/manifest-context.js
+++ b/src/context/manifest-context.js
@@ -3,7 +3,7 @@ import { getAnnotationService, getIsPlaylist, parsePlaylistAnnotations } from '@
 import React from 'react';
 
 export const ManifestStateContext = React.createContext();
-const ManifestDispatchContext = React.createContext();
+export const ManifestDispatchContext = React.createContext();
 
 /**
  * Definition of all state variables in this Context

--- a/src/services/ramp-hooks.js
+++ b/src/services/ramp-hooks.js
@@ -133,6 +133,8 @@ export const useSetupPlayer = ({
   const renderingFiles = useMemo(() => {
     if (enableFileDownload && renderings != {}) {
       return (renderings?.manifest)?.concat(renderings?.canvas[canvasIndex]?.files);
+    } else {
+      return [];
     }
   }, [renderings, canvasIndex]);
 
@@ -577,7 +579,7 @@ export const useShowInaccessibleMessage = ({ lastCanvasIndex }) => {
         clearDisplayTimeInterval();
       }
     }, 1000);
-  }, []);
+  });
 
   // Cleanup interval created for timer display for inaccessible message
   const clearDisplayTimeInterval = useCallback(() => {

--- a/src/services/ramp-hooks.test.js
+++ b/src/services/ramp-hooks.test.js
@@ -1,0 +1,397 @@
+import React, { act, useEffect } from 'react';
+import { fireEvent, render } from "@testing-library/react";
+import * as hooks from "./ramp-hooks";
+import { manifestState, withManifestAndPlayerProvider } from "./testing-helpers";
+import playlist from "@TestData/playlist";
+import singleCanvas from '@TestData/single-canvas';
+import multiSourceManifest from '@TestData/multi-source-manifest';
+import lunchroomManners from '@TestData/lunchroom-manners';
+import audioManifest from '@TestData/transcript-canvas';
+
+describe('useMarkers', () => {
+  // not a real ref because react throws warning if we use outside a component
+  const resultRef = { current: null };
+  let UIComponent;
+  beforeEach(() => {
+    UIComponent = () => {
+      const results = hooks.useMarkers();
+      useEffect(() => {
+        resultRef.current = results;
+      }, [results]);
+      return (
+        <div></div>
+      );
+    };
+  });
+
+  test('returns isDisabled = false by default', () => {
+    const CustomComponent = withManifestAndPlayerProvider(UIComponent, {
+      initialManifestState: {
+        ...manifestState(playlist)
+      },
+      initialPlayerState: {},
+    });
+    render(<CustomComponent />);
+    expect(resultRef.current.isDisabled).toBeFalsy();
+  });
+
+  test('returns isDisabled = false when editing a marker', () => {
+    const CustomComponent = withManifestAndPlayerProvider(UIComponent, {
+      initialManifestState: {
+        playlist: {
+          ...manifestState(playlist),
+          isEditing: true
+        },
+      },
+      initialPlayerState: {},
+    });
+    render(<CustomComponent />);
+    expect(resultRef.current.isDisabled).toBeTruthy();
+  });
+});
+
+describe('useMediaPlayer', () => {
+  // not a real ref because react throws warning if we use outside a component
+  const resultRef = { current: null };
+  let UIComponent;
+  beforeEach(() => {
+    UIComponent = () => {
+      const results = hooks.useMediaPlayer();
+      useEffect(() => {
+        resultRef.current = results;
+      }, [results]);
+      return (
+        <div></div>
+      );
+    };
+  });
+
+  test('returns isMultiCanvased = true for multi-canvas Manifest', () => {
+    const CustomComponent = withManifestAndPlayerProvider(UIComponent, {
+      initialManifestState: {
+        ...manifestState(playlist)
+      },
+      initialPlayerState: {},
+    });
+    render(<CustomComponent />);
+    expect(resultRef.current.isMultiCanvased).toBeTruthy();
+  });
+
+  test('returns isMultiCanvased = false for single-canvas Manifest', () => {
+    const CustomComponent = withManifestAndPlayerProvider(UIComponent, {
+      initialManifestState: {
+        ...manifestState(singleCanvas)
+      },
+      initialPlayerState: {},
+    });
+    render(<CustomComponent />);
+    expect(resultRef.current.isMultiCanvased).toBeFalsy();
+  });
+
+  test('returns lastCanvasIndex', () => {
+    const CustomComponent = withManifestAndPlayerProvider(UIComponent, {
+      initialManifestState: {
+        ...manifestState(playlist)
+      },
+      initialPlayerState: {},
+    });
+    render(<CustomComponent />);
+    expect(resultRef.current.lastCanvasIndex).toEqual(5);
+  });
+});
+
+describe('useSetupPlayer', () => {
+  let originalError;
+  beforeEach(() => {
+    originalError = console.error;
+    console.error = jest.fn();
+  });
+
+  afterAll(() => {
+    console.error = originalError;
+  });
+
+  // not a real ref because react throws warning if we use outside a component
+  const resultRef = { current: null };
+  const renderHook = (props = {}) => {
+    const UIComponent = () => {
+      const results = hooks.useSetupPlayer({
+        ...props
+      });
+      useEffect(() => {
+        resultRef.current = results;
+      }, [results]);
+      return (
+        <div></div>
+      );
+    };
+    return UIComponent;
+  };
+
+  test('returns isVideo = true for video Canvas', () => {
+    const UIComponent = renderHook({});
+    const CustomComponent = withManifestAndPlayerProvider(UIComponent, {
+      initialManifestState: {
+        ...manifestState(lunchroomManners)
+      },
+      initialPlayerState: {},
+    });
+    render(<CustomComponent />);
+    expect(resultRef.current.isVideo).toBeTruthy();
+  });
+
+  test('returns isVideo = false for audio Canvas', () => {
+    const UIComponent = renderHook({});
+    const CustomComponent = withManifestAndPlayerProvider(UIComponent, {
+      initialManifestState: {
+        ...manifestState(audioManifest)
+      },
+      initialPlayerState: {},
+    });
+    render(<CustomComponent />);
+    expect(resultRef.current.isVideo).toBeFalsy();
+  });
+
+  test('returns isMultiSourced = true for multi-source Canvas', () => {
+    const UIComponent = renderHook({});
+    const CustomComponent = withManifestAndPlayerProvider(UIComponent, {
+      initialManifestState: {
+        ...manifestState(multiSourceManifest)
+      },
+      initialPlayerState: {},
+    });
+    render(<CustomComponent />);
+    expect(resultRef.current.isMultiSourced).toBeTruthy();
+  });
+
+  test('returns isMultiSourced = false for multi-source Canvas', () => {
+    const UIComponent = renderHook({});
+    const CustomComponent = withManifestAndPlayerProvider(UIComponent, {
+      initialManifestState: {
+        ...manifestState(lunchroomManners)
+      },
+      initialPlayerState: {},
+    });
+    render(<CustomComponent />);
+    expect(resultRef.current.isMultiSourced).toBeFalsy();
+  });
+
+  test('returns renderingFiles is empty when enableFileDownload = false (default)', () => {
+    const UIComponent = renderHook({});
+    const CustomComponent = withManifestAndPlayerProvider(UIComponent, {
+      initialManifestState: {
+        ...manifestState(lunchroomManners)
+      },
+      initialPlayerState: {},
+    });
+    render(<CustomComponent />);
+    expect(resultRef.current.renderingFiles).toEqual([]);
+  });
+
+  test('returns renderingFiles when enableFileDownload = true', () => {
+    const UIComponent = renderHook({ enableFileDownload: true });
+    const CustomComponent = withManifestAndPlayerProvider(UIComponent, {
+      initialManifestState: {
+        ...manifestState(lunchroomManners)
+      },
+      initialPlayerState: {},
+    });
+    render(<CustomComponent />);
+    expect(resultRef.current.renderingFiles.length).toEqual(2);
+    const files = resultRef.current.renderingFiles;
+    expect(files[0].label).toEqual('Transcript rendering file (.vtt)');
+  });
+
+  test('returns placeholderCanvas text for inaccessible Canvas', () => {
+    const UIComponent = renderHook();
+    const CustomComponent = withManifestAndPlayerProvider(UIComponent, {
+      initialManifestState: {
+        ...manifestState(playlist, 5, true), autoAdvance: true
+      },
+      initialPlayerState: {},
+    });
+    render(<CustomComponent />);
+    expect(resultRef.current.playerConfig.error)
+      .toEqual('You do not have permission to playback this item.');
+    expect(resultRef.current.playerConfig.sources).toEqual([]);
+  });
+});
+
+describe('useShowInaccessibleMessage', () => {
+  // not a real ref because react throws warning if we use outside a component
+  const resultRef = { current: null };
+  let UIComponent;
+  beforeEach(() => {
+    // Fake timers using Jest
+    jest.useFakeTimers('modern');
+    UIComponent = () => {
+      const results = hooks.useShowInaccessibleMessage({
+        lastCanvasIndex: 5
+      });
+      useEffect(() => {
+        resultRef.current = results;
+      }, [results]);
+      return (
+        <div></div>
+      );
+    };
+  });
+
+  // Running all pending timers and switching to real timers using Jest
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  test('returns messageTime = 10 when autoAdvance = false (default)', () => {
+    const CustomComponent = withManifestAndPlayerProvider(UIComponent, {
+      initialManifestState: {
+        ...manifestState(playlist, 1, true)
+      },
+      initialPlayerState: {},
+    });
+    render(<CustomComponent />);
+    expect(resultRef.current.messageTime).toEqual(10);
+  });
+
+  // FIXME:: cannot return updated messageTime, 
+  // eventhough the state variable messageTime is updated in the hook
+  test.skip('returns messageTime to change when autoAdvance = true', () => {
+    const CustomComponent = withManifestAndPlayerProvider(UIComponent, {
+      initialManifestState: {
+        ...manifestState(playlist, 1, true),
+        autoAdvance: true, canvasIsEmpty: true
+      },
+      initialPlayerState: {},
+    });
+    render(<CustomComponent />);
+
+    act(() => {
+      // Fast-forward time by 2.5 second
+      jest.advanceTimersByTime(2500);
+
+      expect(resultRef.current.messageTime).toEqual(7);
+    });
+  });
+});
+
+describe('useActiveStructure', () => {
+  const liRef = { current: '' };
+  const sectionRef = { current: '' };
+  // not a real ref because react throws warning if we use outside a component
+  const resultRef = { current: null };
+  const renderHook = (props = {}) => {
+    const UIComponent = () => {
+      const results = hooks.useActiveStructure({
+        ...props
+      });
+      useEffect(() => {
+        resultRef.current = results;
+      }, [results]);
+      return (
+        <div></div>
+      );
+    };
+    return UIComponent;
+  };
+
+  describe('with ListItem type structure item', () => {
+    let UIComponent;
+    beforeEach(() => {
+      UIComponent = renderHook({
+        itemId: 'https://example.com/manifest/lunchroom_manners/canvas/1#t=0,160',
+        liRef,
+        isCanvas: false,
+        canvasDuration: 660,
+        sectionRef
+      });
+    });
+    test('returns isActiveLi = false when currentNavItem = null', () => {
+      const CustomComponent = withManifestAndPlayerProvider(UIComponent, {
+        initialManifestState: { ...manifestState(lunchroomManners) },
+        initialPlayerState: {},
+      });
+      render(<CustomComponent />);
+      expect(resultRef.current.isActiveLi).toBeFalsy();
+    });
+
+    test('returns isActiveLi = true when currentNavItem is current structure item', () => {
+      const CustomComponent = withManifestAndPlayerProvider(UIComponent, {
+        initialManifestState: {
+          ...manifestState(lunchroomManners),
+          currentNavItem: {
+            canvasDuration: 660,
+            canvasIndex: 1,
+            duration: '00:16',
+            homepage: '',
+            id: 'https://example.com/manifest/lunchroom_manners/canvas/1#t=0,160',
+            isCanvas: false,
+            isClickable: true,
+            isEmpty: false,
+            isRoot: false,
+            isTitle: false,
+            itemIndex: 1,
+            items: [],
+            label: 'Using Soap',
+            rangeId: 'https://example.com/manifest/lunchroom_manners/range/1-1-1',
+            summary: undefined
+          }
+        },
+        initialPlayerState: {},
+      });
+      render(<CustomComponent />);
+      expect(resultRef.current.isActiveLi).toBeTruthy();
+    });
+  });
+
+  describe('with SectionHeading type structure item', () => {
+    const setIsOpenMock = jest.fn();
+    let props = {
+      isCanvas: true,
+      canvasDuration: 660,
+      liRef: sectionRef,
+      setIsOpen: setIsOpenMock,
+    };
+
+    test('returns isActiveSection = true when Canvas is selected', () => {
+      const UIComponent = renderHook({
+        ...props,
+        itemIndex: 1, // itemIndex = canvasIndex + 1
+      });
+      const CustomComponent = withManifestAndPlayerProvider(UIComponent, {
+        initialManifestState: { ...manifestState(lunchroomManners, 0) },
+        initialPlayerState: {},
+      });
+      render(<CustomComponent />);
+      expect(resultRef.current.isActiveSection).toBeTruthy();
+    });
+
+    test('returns isActiveSection = false when another Canvas is selected', () => {
+      const UIComponent = renderHook({
+        ...props,
+        itemIndex: 2, // itemIndex = canvasIndex + 1
+      });
+      const CustomComponent = withManifestAndPlayerProvider(UIComponent, {
+        initialManifestState: { ...manifestState(lunchroomManners, 0) },
+        initialPlayerState: {},
+      });
+      render(<CustomComponent />);
+      expect(resultRef.current.isActiveSection).toBeFalsy();
+    });
+
+    test('returns isActiveSection = false when structure item has isRoot = true', () => {
+      const UIComponent = renderHook({
+        ...props,
+        itemIndex: 1, // itemIndex = canvasIndex + 1
+        isRoot: true
+      });
+      const CustomComponent = withManifestAndPlayerProvider(UIComponent, {
+        initialManifestState: { ...manifestState(lunchroomManners, 0) },
+        initialPlayerState: {},
+      });
+      render(<CustomComponent />);
+      expect(resultRef.current.isActiveSection).toBeFalsy();
+    });
+  });
+
+});

--- a/src/test_data/multi-source-manifest.js
+++ b/src/test_data/multi-source-manifest.js
@@ -1,0 +1,102 @@
+export default {
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  id: "https://example.com/multi-source-manifest/manifest.json",
+  type: "Manifest",
+  label: { "en": ["The Elixir of Love"] },
+  items: [
+    {
+      id: "https://example.com/multi-source-manifest/canvas/1",
+      type: "Canvas",
+      width: 1920,
+      height: 1080,
+      duration: 7278.422,
+      items: [
+        {
+          id: "https://example.com/multi-source-manifest/canvas/1/annotation_page/1",
+          type: "AnnotationPage",
+          items: [
+            {
+              id: "https://example.com/multi-source-manifest/canvas/1/annotation_page/1/annotation/1",
+              type: "Annotation",
+              motivation: "painting",
+              target: "https://example.com/multi-source-manifest/canvas/1#t=0,3971.24",
+              body: {
+                id: "https://example.com/video/donizetti-elixir/low_act_1.mp4",
+                type: "Video",
+                format: "video/mp4",
+                height: 1080,
+                width: 1920,
+                duration: 3971.24
+              }
+            },
+            {
+              id: "https://example.com/multi-source-manifest/canvas/1/annotation_page/1/annotation/2",
+              type: "Annotation",
+              motivation: "painting",
+              target: "https://example.com/multi-source-manifest/canvas/1#t=3971.24",
+              body: {
+                id: "https://example.com/video/donizetti-elixir/low_act_2.mp4",
+                type: "Video",
+                format: "video/mp4",
+                height: 1080,
+                width: 1920,
+                duration: 3307.22
+              }
+            }
+          ]
+        }
+      ],
+    }
+  ],
+  "structures": [
+    {
+      type: "Range",
+      id: "https://example.com/multi-source-manifest/range/1",
+      label: { "it": ["Gaetano Donizetti, L'Elisir D'Amore"] },
+      items: [
+        {
+          type: "Range",
+          id: "https://example.com/multi-source-manifest/range/2",
+          label: { "it": ["Atto Primo"] },
+          items: [
+            {
+              type: "Range",
+              id: "https://example.com/multi-source-manifest/range/3",
+              label: { "it": ["Preludio e Coro d'introduzione – Bel conforto al mietitore"] },
+              items: [
+                {
+                  type: "Canvas",
+                  id: "https://example.com/multi-source-manifest/canvas/1#t=0,302.05"
+                }
+              ]
+            },
+            {
+              type: "Range",
+              id: "https://example.com/multi-source-manifest/range/4",
+              label: { "en": ["Remainder of Atto Primo"] },
+              items: [
+                {
+                  type: "Canvas",
+                  id: "https://example.com/multi-source-manifest/canvas/1#t=302.05,3971.24"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          type: "Range",
+          id: "https://example.com/multi-source-manifest/range/5",
+          label: {
+            "it": ["Atto Secondo"]
+          },
+          items: [
+            {
+              type: "Canvas",
+              id: "https://example.com/multi-source-manifest/canvas/1#t=3971.24,7278.422"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};


### PR DESCRIPTION
Related issue: #630 

Includes custom hook implementations for player related state updates.

For some of the functionality in the custom hooks, unit tests are added. Most of the code in these hooks are covered by the unit tests in respective components' test-cases. Test coverage in the new module `@Services/ramp-hooks.js` added in this work (#630) is around 70%. The parts that are not covered in tests are either impossible/hard to write tests with just the custom hook functionality. 