### PR TITLE
Fix minor bugs in player introduced in refactor/cleanup work

### DIFF
--- a/src/components/MediaPlayer/MediaPlayer.js
+++ b/src/components/MediaPlayer/MediaPlayer.js
@@ -38,7 +38,7 @@ const MediaPlayer = ({
 
   const { srcIndex, hasStructure, playlist } = manifestState;
   const { isPlaylist } = playlist;
-  const { playerFocusElement, currentTime } = playerState;
+  const { currentTime } = playerState;
 
   const trackScrubberRef = useRef();
   const timeToolRef = useRef();
@@ -54,7 +54,7 @@ const MediaPlayer = ({
     renderingFiles,
     nextItemClicked,
     switchPlayer
-  } = useSetupPlayer({ enableFileDownload, withCredentials, lastCanvasIndex });
+  } = useSetupPlayer({ enableFileDownload, lastCanvasIndex, withCredentials });
 
   const { error, poster, sources, targets, tracks } = playerConfig;
 
@@ -147,14 +147,14 @@ const MediaPlayer = ({
             'timeDivider',
             'durationDisplay',
             // These icons are in reverse order to support `float: inline-end` in CSS
-            'fullscreenToggle',
-            enableFileDownload ? 'videoJSFileDownload' : '',
-            enablePIP ? 'pictureInPictureToggle' : '',
-            enablePlaybackRate ? 'playbackRateMenuButton' : '',
-            'qualitySelector',
-            (hasStructure || isPlaylist) ? 'videoJSTrackScrubber' : '',
+            IS_MOBILE ? 'muteToggle' : 'volumePanel',
             (tracks.length > 0 && isVideo) ? 'subsCapsButton' : '',
-            IS_MOBILE ? 'muteToggle' : 'volumePanel'
+            (hasStructure || isPlaylist) ? 'videoJSTrackScrubber' : '',
+            'qualitySelector',
+            enablePlaybackRate ? 'playbackRateMenuButton' : '',
+            enablePIP ? 'pictureInPictureToggle' : '',
+            enableFileDownload ? 'videoJSFileDownload' : '',
+            'fullscreenToggle',
             // 'vjsYo',             custom component
           ],
           videoJSProgress: {

--- a/src/components/MediaPlayer/MediaPlayer.js
+++ b/src/components/MediaPlayer/MediaPlayer.js
@@ -146,7 +146,6 @@ const MediaPlayer = ({
             'videoJSCurrentTime',
             'timeDivider',
             'durationDisplay',
-            // These icons are in reverse order to support `float: inline-end` in CSS
             IS_MOBILE ? 'muteToggle' : 'volumePanel',
             (tracks.length > 0 && isVideo) ? 'subsCapsButton' : '',
             (hasStructure || isPlaylist) ? 'videoJSTrackScrubber' : '',

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -259,9 +259,10 @@ function VideoJSPlayer({
     */
     if (player.getChild('controlBar') != null && !canvasIsEmpty) {
       const controlBar = player.getChild('controlBar');
-      // Index of the full-screen toggle in the player's control bar
-      const fullscreenIndex = controlBar.children()
-        .findIndex((c) => c.name_ == 'FullscreenToggle');
+      // Index of the volumepanel/mutetoggle in the player's control bar
+      const volumeIndex = IS_MOBILE
+        ? controlBar.children().findIndex((c) => c.name_ == 'MuteToggle')
+        : controlBar.children().findIndex((c) => c.name_ == 'VolumePanel');
       /*
         Track-scrubber button: remove if the Manifest is not a playlist manifest
         or the current Canvas doesn't have structure items. Or add back in if it's
@@ -273,7 +274,8 @@ function VideoJSPlayer({
         // Add track-scrubber button after duration display if it is not available
         controlBar.addChild(
           'videoJSTrackScrubber',
-          { trackScrubberRef, timeToolRef: scrubberTooltipRef }
+          { trackScrubberRef, timeToolRef: scrubberTooltipRef },
+          volumeIndex + 1
         );
       }
 
@@ -282,7 +284,7 @@ function VideoJSPlayer({
           ? controlBar.children().findIndex((c) => c.name_ == 'MuteToggle')
           : controlBar.children().findIndex((c) => c.name_ == 'VolumePanel');
         let subsCapBtn = controlBar.addChild(
-          'subsCapsButton', {}, captionIndex + 1
+          'subsCapsButton', {}, volumeIndex + 1
         );
         // Add CSS to mark captions-on
         subsCapBtn.children_[0].addClass('captions-on');
@@ -313,7 +315,7 @@ function VideoJSPlayer({
       */
       if (!IS_MOBILE) {
         controlBar.removeChild('VolumePanel');
-        controlBar.addChild('VolumePanel');
+        controlBar.addChild('VolumePanel', {}, volumeIndex);
         /* 
           Trigger ready event to reset the volume slider in the refreshed 
           volume panel. This is needed on player reload, since volume slider 
@@ -322,7 +324,7 @@ function VideoJSPlayer({
         player.trigger('volumechange');
       } else {
         controlBar.removeChild('MuteToggle');
-        controlBar.addChild('MuteToggle');
+        controlBar.addChild('MuteToggle', {}, volumeIndex);
       }
 
       if (enableFileDownload) {

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -254,7 +254,6 @@ function VideoJSPlayer({
        - track scrubber button
        - appearance of the player: big play button and aspect ratio of the player 
         based on media type
-       - volume panel based on media type
        - file download menu
     */
     if (player.getChild('controlBar') != null && !canvasIsEmpty) {
@@ -280,9 +279,6 @@ function VideoJSPlayer({
       }
 
       if (tracks?.length > 0 && isVideo && !controlBar.getChild('subsCapsButton')) {
-        const captionIndex = IS_MOBILE
-          ? controlBar.children().findIndex((c) => c.name_ == 'MuteToggle')
-          : controlBar.children().findIndex((c) => c.name_ == 'VolumePanel');
         let subsCapBtn = controlBar.addChild(
           'subsCapsButton', {}, volumeIndex + 1
         );
@@ -305,26 +301,6 @@ function VideoJSPlayer({
         player.removeClass('vjs-audio');
         player.aspectRatio('16:9');
         player.addChild('bigPlayButton');
-      }
-
-      /*
-        Re-add volumePanel/muteToggle icon: ensures the correct order of controls
-        on player reload.
-        On mobile device browsers, the volume panel is replaced by muteToggle
-        for both audio and video.
-      */
-      if (!IS_MOBILE) {
-        controlBar.removeChild('VolumePanel');
-        controlBar.addChild('VolumePanel', {}, volumeIndex);
-        /* 
-          Trigger ready event to reset the volume slider in the refreshed 
-          volume panel. This is needed on player reload, since volume slider 
-          is set on either 'ready' or 'volumechange' events.
-        */
-        player.trigger('volumechange');
-      } else {
-        controlBar.removeChild('MuteToggle');
-        controlBar.addChild('MuteToggle', {}, volumeIndex);
       }
 
       if (enableFileDownload) {

--- a/src/components/MediaPlayer/VideoJS/components/js/VideoJSNextButton.js
+++ b/src/components/MediaPlayer/VideoJS/components/js/VideoJSNextButton.js
@@ -45,22 +45,19 @@ class VideoJSNextButton extends Button {
   }
 
   handleClick() {
-    this.handleNextClick(false);
+    this.handleNextClick();
   }
 
   handleKeyDown(e) {
     if (e.which === 32 || e.which === 13) {
       e.stopPropagation();
-      this.handleNextClick(true);
+      this.handleNextClick();
     }
   }
 
-  handleNextClick(isKeyDown) {
+  handleNextClick() {
     if (this.cIndex != this.options.lastCanvasIndex) {
-      this.options.switchPlayer(
-        this.cIndex + 1,
-        true,
-        isKeyDown ? 'nextBtn' : '');
+      this.options.switchPlayer(this.cIndex + 1, true);
     }
   }
 }

--- a/src/components/MediaPlayer/VideoJS/components/js/VideoJSPreviousButton.js
+++ b/src/components/MediaPlayer/VideoJS/components/js/VideoJSPreviousButton.js
@@ -44,22 +44,19 @@ class VideoJSPreviousButton extends Button {
   }
 
   handleClick() {
-    this.handlePreviousClick(false);
+    this.handlePreviousClick();
   }
 
   handleKeyDown(e) {
     if (e.which === 32 || e.which === 13) {
       e.stopPropagation();
-      this.handlePreviousClick(true);
+      this.handlePreviousClick();
     }
   }
 
-  handlePreviousClick(isKeyDown) {
+  handlePreviousClick() {
     if (this.cIndex > -1 && this.cIndex != 0) {
-      this.options.switchPlayer(
-        this.cIndex - 1,
-        true,
-        isKeyDown ? 'previousBtn' : '');
+      this.options.switchPlayer(this.cIndex - 1, true);
     } else if (this.cIndex == 0) {
       this.player.currentTime(0);
     }

--- a/src/components/MediaPlayer/VideoJS/videojs-theme.scss
+++ b/src/components/MediaPlayer/VideoJS/videojs-theme.scss
@@ -79,9 +79,14 @@
   height: 70%;
 }
 
-/* Mute control on mobile devices */
+/* Mute control */
+.vjs-theme-ramp .vjs-mute-control {
+  display: none; // Hide mute control by default
+}
+
 .vjs-theme-ramp.vjs-touch-enabled .vjs-mute-control {
   margin-left: auto;
+  display: block !important; // Show mute control only on mobile devices
 }
 
 /* Popup-menu button controls */
@@ -93,18 +98,14 @@
   margin-bottom: 0.75em;
 }
 
-/* Volume stuff */
-.vjs-theme-ramp .vjs-volume-panel:hover .vjs-volume-control.vjs-volume-horizontal {
-  height: 100%;
-}
-
-.vjs-theme-ramp .vjs-mute-control {
-  display: none;
-}
-
 .vjs-theme-ramp div.vjs-menu-button {
   height: 60%;
   margin-top: 0.5em;
+}
+
+/* Volume stuff */
+.vjs-theme-ramp .vjs-volume-panel:hover .vjs-volume-control.vjs-volume-horizontal {
+  height: 100%;
 }
 
 .vjs-theme-ramp .vjs-volume-panel {

--- a/src/components/MediaPlayer/VideoJS/videojs-theme.scss
+++ b/src/components/MediaPlayer/VideoJS/videojs-theme.scss
@@ -19,7 +19,7 @@
   padding-top: 1em;
   background: none;
   background-image: linear-gradient(to top, #000, rgba(0, 0, 0, 0));
-  display: inline-block;
+  display: flex;
 }
 
 .vjs-theme-ramp .vjs-custom-progress-bar {
@@ -41,7 +41,6 @@
 /* Time controls */
 .vjs-theme-ramp .vjs-control-bar .vjs-time-control {
   line-height: 4em;
-  float: inline-start;
 }
 
 /* Remove padding around time-divider (/) */
@@ -60,7 +59,9 @@
 
 /* Rest of the controls */
 .vjs-theme-ramp .vjs-mute-control,
-.vjs-theme-ramp .vjs-volume-panel,
+.vjs-theme-ramp .vjs-volume-panel {
+  margin-left: auto;
+}
 .vjs-theme-ramp .vjs-picture-in-picture-control,
 .vjs-theme-ramp .vjs-fullscreen-control,
 .vjs-theme-ramp .vjs-track-scrubber,
@@ -68,7 +69,7 @@
 .vjs-theme-ramp .vjs-quality-selector,
 .vjs-theme-ramp .vjs-file-download,
 .vjs-theme-ramp .vjs-subs-caps-button {
-  float: inline-end;
+  margin-left: 0;
 }
 
 /* Reduce height of full-screen toggle for easy scrubbing on progress */
@@ -80,8 +81,7 @@
 
 /* Mute control on mobile devices */
 .vjs-theme-ramp.vjs-touch-enabled .vjs-mute-control {
-  display: block !important;
-  float: inline-end;
+  margin-left: auto;
 }
 
 /* Popup-menu button controls */
@@ -108,7 +108,6 @@
 }
 
 .vjs-theme-ramp .vjs-volume-panel {
-  margin-left: 0.5em;
   margin-right: 0.5em;
 }
 

--- a/src/context/player-context.js
+++ b/src/context/player-context.js
@@ -16,7 +16,6 @@ const defaultState = {
   isEnded: false,
   currentTime: null,
   searchMarkers: [],
-  playerFocusElement: ''
 };
 
 function PlayerReducer(state = defaultState, action) {
@@ -55,12 +54,6 @@ function PlayerReducer(state = defaultState, action) {
     }
     case 'setCurrentTime': {
       return { ...state, currentTime: action.currentTime };
-    }
-    case 'setPlayerFocusElement': {
-      return {
-        ...state,
-        playerFocusElement: action.element ? action.element : '',
-      };
     }
     default: {
       throw new Error(`Unhandled action type: ${action.type}`);

--- a/src/services/ramp-hooks.js
+++ b/src/services/ramp-hooks.js
@@ -330,27 +330,6 @@ export const useVideoJSPlayer = ({
   };
 
   useEffect(() => {
-    /*
-      This event handler helps to execute hotkeys functions related to 'keydown' events
-      before any user interactions with the player or when focused on other non-input 
-      elements on the page
-    */
-    document.addEventListener('keydown', (event) => {
-      const result = playerHotKeys(event, playerRef.current, canvasIsEmpty);
-      // Update player status in global state
-      switch (result) {
-        case HOTKEY_ACTION_OUTPUT.pause:
-          handlePause(false);
-          break;
-        case HOTKEY_ACTION_OUTPUT.play:
-          handlePause(true);
-          break;
-        // Handle other cases as needed for each action
-        default:
-          break;
-      }
-    });
-
     // Dispose Video.js instance when VideoJSPlayer component is removed
     return () => {
       if (playerRef.current) {
@@ -386,16 +365,7 @@ export const useVideoJSPlayer = ({
 
       playerDispatch({ player: player, type: 'updatePlayer' });
 
-      // Update player status in state only when pause is initiate by the user
-      player.controlBar.getChild('PlayToggle').on('pointerdown', () => {
-        handlePause(player.paused());
-      });
-      player.on('pointerdown', (e) => {
-        const elementTag = e.target.nodeName.toLowerCase();
-        if (elementTag == 'video') {
-          handlePause(player.paused());
-        }
-      });
+      initializeEventHandlers(player);
     } else if (playerRef.current && options.sources?.length > 0) {
       // Update the existing Video.js player on consecutive Canvas changes
       const player = playerRef.current;
@@ -491,6 +461,41 @@ export const useVideoJSPlayer = ({
     playerRef.current,
     isReady
   ]);
+
+  /**
+   * Attach events related to player on initial setup of the VideoJS
+   * instance
+   * @param {Object} player 
+   */
+  const initializeEventHandlers = (player) => {
+    // Update player status in state only when pause is initiate by the user
+    player.controlBar.getChild('PlayToggle').on('pointerdown', () => {
+      handlePause();
+    });
+    player.on('pointerdown', (e) => {
+      const elementTag = e.target.nodeName.toLowerCase();
+      if (elementTag == 'video') {
+        handlePause();
+      }
+    });
+    /*
+      This event handler helps to execute hotkeys functions related to 'keydown' events
+      before any user interactions with the player or when focused on other non-input 
+      elements on the page
+    */
+    document.addEventListener('keydown', (event) => {
+      const result = playerHotKeys(event, playerRef.current, canvasIsEmpty);
+      // Update player status in global state
+      switch (result) {
+        case HOTKEY_ACTION_OUTPUT.pause:
+          handlePause();
+          break;
+        // Handle other cases as needed for each action
+        default:
+          break;
+      }
+    });
+  };
 
   /**
    * Update global state only when a user pause the player by using the

--- a/src/services/ramp-hooks.js
+++ b/src/services/ramp-hooks.js
@@ -420,7 +420,8 @@ export const useVideoJSPlayer = ({
   }, [options.sources, videoJSRef]);
 
   useEffect(() => {
-    if (player) {
+    if (playerRef.current) {
+      const player = playerRef.current;
       // Show/hide control bar for valid/inaccessible items respectively
       if (canvasIsEmpty) {
         // Set the player's aspect ratio to video

--- a/src/services/ramp-hooks.js
+++ b/src/services/ramp-hooks.js
@@ -99,8 +99,8 @@ export const useMediaPlayer = () => {
  */
 export const useSetupPlayer = ({
   enableFileDownload = false,
+  lastCanvasIndex,
   withCredentials = false,
-  lastCanvasIndex
 }) => {
   const manifestDispatch = useContext(ManifestDispatchContext);
   const playerDispatch = useContext(PlayerDispatchContext);
@@ -239,14 +239,13 @@ export const useSetupPlayer = ({
    * @param {String} focusElement element to be focused within the player when using
    * next or previous buttons with keyboard
    */
-  const switchPlayer = (index, fromStart, focusElement = '') => {
+  const switchPlayer = (index, fromStart) => {
     if (index != undefined && index > -1 && index <= lastCanvasIndex) {
       manifestDispatch({
         canvasIndex: index,
         type: 'switchCanvas',
       });
       initCanvas(index, fromStart);
-      playerDispatch({ element: focusElement, type: 'setPlayerFocusElement' });
     }
   };
 
@@ -308,7 +307,7 @@ export const useVideoJSPlayer = ({
   const playerState = useContext(PlayerStateContext);
   const playerDispatch = useContext(PlayerDispatchContext);
   const { canvasDuration, canvasIndex, canvasIsEmpty, currentNavItem, playlist } = manifestState;
-  const { currentTime, isClicked, isPlaying, player, searchMarkers } = playerState;
+  const { currentTime, isClicked, player, searchMarkers } = playerState;
 
   const [activeId, setActiveId] = useState('');
   const [fragmentMarker, setFragmentMarker] = useState(null);
@@ -341,7 +340,10 @@ export const useVideoJSPlayer = ({
       // Update player status in global state
       switch (result) {
         case HOTKEY_ACTION_OUTPUT.pause:
-          handlePause();
+          handlePause(false);
+          break;
+        case HOTKEY_ACTION_OUTPUT.play:
+          handlePause(true);
           break;
         // Handle other cases as needed for each action
         default:
@@ -386,12 +388,12 @@ export const useVideoJSPlayer = ({
 
       // Update player status in state only when pause is initiate by the user
       player.controlBar.getChild('PlayToggle').on('pointerdown', () => {
-        handlePause();
+        handlePause(player.paused());
       });
       player.on('pointerdown', (e) => {
         const elementTag = e.target.nodeName.toLowerCase();
         if (elementTag == 'video') {
-          handlePause();
+          handlePause(player.paused());
         }
       });
     } else if (playerRef.current && options.sources?.length > 0) {
@@ -493,10 +495,8 @@ export const useVideoJSPlayer = ({
    * Update global state only when a user pause the player by using the
    * player interface or keyboard shortcuts
    */
-  const handlePause = () => {
-    if (isPlaying) {
-      playerDispatch({ isPlaying: false, type: 'setPlayingStatus' });
-    }
+  const handlePause = (isPlaying) => {
+    playerDispatch({ isPlaying, type: 'setPlayingStatus' });
   };
 
   const setSelectedQuality = (sources) => {


### PR DESCRIPTION
This PR includes the following;
1. Cleanup of `playerFocusElement` global state variable, as this is not needed anymore to retain focus for previous/next button keyboard navigation with the changes done on these custom components with new implementation
2. Remove `float: inline-end` styling with `display: inline-block` for player controls to right align some of the controls in the player, as this reverses the tab order of the controls when using keyboard navigation. Replace this styling to use `display: flex`
3. Fix a bug in the state updates for persisting the player's play/pause status as `isPlaying` in global state with hotkey implementation and pointer events
4. Set aspect ratio for inaccessible message display as 16/9 (equivalent to video player) when switching from an audio item to inaccessible item
5. Attach player hotkeys event handler upon player creation, as hotkeys doesn't work as expected with the previous implementation when the first item is an inaccessible item.