### PR TITLE
Replace volume control with muteToggle/volumePanel, popup menus above progress-bar

### DIFF
--- a/src/components/MediaPlayer/MediaPlayer.js
+++ b/src/components/MediaPlayer/MediaPlayer.js
@@ -146,6 +146,7 @@ const MediaPlayer = ({
             'videoJSCurrentTime',
             'timeDivider',
             'durationDisplay',
+            'customControlSpacer', // Spacer element from VideoJS
             IS_MOBILE ? 'muteToggle' : 'volumePanel',
             (tracks.length > 0 && isVideo) ? 'subsCapsButton' : '',
             (hasStructure || isPlaylist) ? 'videoJSTrackScrubber' : '',
@@ -157,6 +158,8 @@ const MediaPlayer = ({
             // 'vjsYo',             custom component
           ],
           videoJSProgress: { nextItemClicked },
+          // Make the volume slider horizontal for audio in non-mobile browsers
+          volumePanel: !IS_MOBILE && { inline: !isVideo },
           videoJSCurrentTime: {
             srcIndex, targets, currentTime: currentTime || 0
           },

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -252,6 +252,8 @@ function VideoJSPlayer({
     /*
       Update player control bar for;
        - track scrubber button
+       - volume panel
+       - if tracks exists: captions button for video players
        - appearance of the player: big play button and aspect ratio of the player 
         based on media type
        - file download menu
@@ -276,6 +278,27 @@ function VideoJSPlayer({
           { trackScrubberRef, timeToolRef: scrubberTooltipRef },
           volumeIndex + 1
         );
+      }
+      /**
+       * Volume panel display on desktop browsers:
+       * For audio: volume panel is inline with a sticky volume slider
+       * For video: volume panel is not inline.
+       * For mobile devices the player uses MuteToggle for both audio
+       * and video.
+       */
+      if (!IS_MOBILE) {
+        controlBar.removeChild('volumePanel');
+        if (!isVideo) {
+          controlBar.addChild('volumePanel', { inline: true }, volumeIndex);
+        } else {
+          controlBar.addChild('volumePanel', { inline: false }, volumeIndex);
+        }
+        /* 
+          Trigger ready event to reset the volume slider in the refreshed 
+          volume panel. This is needed on player reload, since volume slider 
+          is set on either 'ready' or 'volumechange' events.
+        */
+        player.trigger('volumechange');
       }
 
       if (tracks?.length > 0 && isVideo && !controlBar.getChild('subsCapsButton')) {
@@ -814,7 +837,7 @@ function VideoJSPlayer({
       }
     </div >
   );
-}
+};
 
 VideoJSPlayer.propTypes = {
   enableFileDownload: PropTypes.bool,

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -288,11 +288,7 @@ function VideoJSPlayer({
        */
       if (!IS_MOBILE) {
         controlBar.removeChild('volumePanel');
-        if (!isVideo) {
-          controlBar.addChild('volumePanel', { inline: true }, volumeIndex);
-        } else {
-          controlBar.addChild('volumePanel', { inline: false }, volumeIndex);
-        }
+        controlBar.addChild('volumePanel', { inline: !isVideo }, volumeIndex);
         /* 
           Trigger ready event to reset the volume slider in the refreshed 
           volume panel. This is needed on player reload, since volume slider 

--- a/src/components/MediaPlayer/VideoJS/videojs-theme.scss
+++ b/src/components/MediaPlayer/VideoJS/videojs-theme.scss
@@ -88,39 +88,35 @@
   text-transform: capitalize;
 }
 
-/* The following CSS was adapted from vertical volume control animation in VideoJS */
-// Hide popup menu when pointer is not hovering over the button
-.vjs-theme-ramp .vjs-menu-button-popup .vjs-menu {
-  opacity: 0;
-  display: block !important;
-  visibility: visible;
-  left: -3000em;
-  transition: visibility 1s, opacity 1s, height 1s 1s, width 1s 1s, left 0.20s 0.20s, top 1s 1s;
+// Not display popup menu on hover event
+.vjs-theme-ramp.vjs-workinghover .vjs-menu-button-popup:hover .vjs-menu {
+  display: none;
 }
 
-// Place popup menu above progres control
+// Place popup menu above and on top of progress control
 .vjs-theme-ramp .vjs-menu-button-popup .vjs-menu {
   bottom: 1.5em;
+  z-index: 1;
 }
 
-// Show popup menu on pointer hover event
-.vjs-theme-ramp .vjs-menu-button-popup:hover .vjs-menu,
-.vjs-theme-ramp .vjs-menu-button-popup:focus-within .vjs-menu {
-  opacity: 1;
-  visibility: visible;
-  left: -3.5em;
-  transition: left 0s;
-  display: block;
+// Show volume control panel on top time-tooltip
+.vjs-volume-panel-vertical .vjs-volume-control {
+  z-index: 1;
 }
 
-// Reduce left offset for playback rate menu when displayed
-.vjs-theme-ramp .vjs-playback-rate.vjs-menu-button-popup:hover .vjs-menu,
-.vjs-theme-ramp .vjs-playback-rate.vjs-menu-button-popup:focus-within .vjs-menu {
-  left: -0.5em;
+// Shift the captions menu to the left so that, volume control is 
+// visible when captions menu is open
+.vjs-theme-ramp .vjs-subs-caps-button .vjs-menu {
+  left: 0.01em
 }
 
-// Align file download menu in audio players with the edge of the player boundary
-.vjs-theme-ramp.vjs-audio-only-mode .vjs-file-download:hover .vjs-menu,
-.vjs-theme-ramp.vjs-audio-only-mode .vjs-file-download:focus-within .vjs-menu {
+// Align file download menu with the edge of the player boundary
+// For audio players
+.vjs-theme-ramp.vjs-audio-only-mode .vjs-file-download .vjs-menu {
   left: -6.65em
+}
+
+// For video players
+.vjs-theme-ramp .vjs-file-download .vjs-menu {
+  left: -3.5em;
 }

--- a/src/components/MediaPlayer/VideoJS/videojs-theme.scss
+++ b/src/components/MediaPlayer/VideoJS/videojs-theme.scss
@@ -16,7 +16,7 @@
 
 .vjs-theme-ramp .vjs-control-bar {
   height: 5em;
-  padding-top: 1em;
+  padding-top: 2em;
   background: none;
   background-image: linear-gradient(to top, #000, rgba(0, 0, 0, 0));
   display: flex;
@@ -38,9 +38,19 @@
   top: 0.01em;
 }
 
+/* Spacer to separate controls */
+.vjs-theme-ramp .vjs-custom-control-spacer {
+  display: block;
+  -webkit-box-flex: 1;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  width: 0;
+  visibility: hidden;
+}
+
 /* Time controls */
 .vjs-theme-ramp .vjs-control-bar .vjs-time-control {
-  line-height: 4em;
+  line-height: 3em;
 }
 
 /* Remove padding around time-divider (/) */
@@ -52,135 +62,65 @@
   padding-left: 0;
 }
 
-/* Play action controls */
-.vjs-theme-ramp .vjs-control-bar .vjs-play-control {
-  float: inline-start;
+/* Volume controls */
+.vjs-theme-ramp .vjs-volume-panel .vjs-volume-control.vjs-volume-vertical {
+  margin-top: -1.5em;
 }
 
-/* Rest of the controls */
-.vjs-theme-ramp .vjs-mute-control,
-.vjs-theme-ramp .vjs-volume-panel {
-  margin-left: auto;
-}
-.vjs-theme-ramp .vjs-picture-in-picture-control,
-.vjs-theme-ramp .vjs-fullscreen-control,
-.vjs-theme-ramp .vjs-track-scrubber,
-.vjs-theme-ramp .vjs-playback-rate.vjs-control,
-.vjs-theme-ramp .vjs-quality-selector,
-.vjs-theme-ramp .vjs-file-download,
-.vjs-theme-ramp .vjs-subs-caps-button {
-  margin-left: 0;
-}
+// Make the horizontal volume panel always visible for audio
+.vjs-theme-ramp .vjs-volume-panel.vjs-volume-panel-horizontal {
+  transition: none !important;
+  width: 8em !important;
 
-/* Reduce height of full-screen toggle for easy scrubbing on progress */
-.vjs-theme-ramp .vjs-control-bar .vjs-fullscreen-control,
-.vjs-theme-ramp .vjs-control-bar .vjs-track-scrubber {
-  margin-top: 0.5em;
-  height: 70%;
-}
-
-/* Mute control */
-.vjs-theme-ramp .vjs-mute-control {
-  display: none; // Hide mute control by default
-}
-
-.vjs-theme-ramp.vjs-touch-enabled .vjs-mute-control {
-  margin-left: auto;
-  display: block !important; // Show mute control only on mobile devices
-}
-
-/* Popup-menu button controls */
-.vjs-theme-ramp .vjs-menu-button>.vjs-icon-placeholder {
-  margin-top: 0.5em;
-}
-
-.vjs-theme-ramp .vjs-menu-button-popup .vjs-menu {
-  margin-bottom: 0.75em;
-}
-
-.vjs-theme-ramp div.vjs-menu-button {
-  height: 60%;
-  margin-top: 0.5em;
-}
-
-/* Volume stuff */
-.vjs-theme-ramp .vjs-volume-panel:hover .vjs-volume-control.vjs-volume-horizontal {
-  height: 100%;
-}
-
-.vjs-theme-ramp .vjs-volume-panel {
-  margin-right: 0.5em;
-}
-
-.vjs-theme-ramp .vjs-volume-panel,
-.vjs-theme-ramp .vjs-volume-panel:hover,
-.vjs-theme-ramp .vjs-volume-panel.vjs-volume-panel-horizontal:hover,
-.vjs-theme-ramp .vjs-volume-panel:focus .vjs-volume-control.vjs-volume-horizontal,
-.vjs-theme-ramp .vjs-volume-panel:hover .vjs-volume-control.vjs-volume-horizontal,
-.vjs-theme-ramp .vjs-volume-panel:active .vjs-volume-control.vjs-volume-horizontal,
-.vjs-theme-ramp .vjs-volume-panel.vjs-volume-panel-horizontal:hover,
-.vjs-theme-ramp .vjs-volume-bar.vjs-slider-horizontal {
-  width: 3em;
-}
-
-.vjs-theme-ramp .vjs-volume-level::before {
-  font-size: 1em;
-}
-
-.vjs-theme-ramp .vjs-volume-panel .vjs-volume-control {
-  opacity: 1;
-  width: 100%;
-  height: 100%;
-}
-
-.vjs-theme-ramp .vjs-volume-bar {
-  background-color: transparent;
-  margin: 0;
-}
-
-.vjs-theme-ramp .vjs-slider-horizontal .vjs-volume-level {
-  height: 100%;
-}
-
-.vjs-theme-ramp .vjs-volume-bar.vjs-slider-horizontal {
-  margin-top: 1em;
-  margin-bottom: 0;
-  height: 100%;
-}
-
-.vjs-theme-ramp .vjs-volume-bar::before {
-  content: '';
-  z-index: 0;
-  width: 0;
-  height: 0;
-  position: absolute;
-  top: 0px;
-  left: 0;
-
-  border-style: solid;
-  border-width: 0 0 1.75em 3em;
-  border-color: transparent transparent rgba(255, 255, 255, 0.25) transparent;
-}
-
-.vjs-theme-ramp .vjs-volume-level {
-  overflow: hidden;
-  background-color: transparent;
-
-  .vjs-icon-placeholder {
-    display: none;
+  // Align volume slider thumb
+  .vjs-volume-horizontal span.vjs-icon-placeholder {
+    margin-top: 0.1em;
   }
 }
 
-.vjs-theme-ramp .vjs-volume-level::before {
-  content: '';
-  z-index: 1;
-  width: 0;
-  height: 0;
-  position: absolute;
-  top: 0;
-  left: 0;
+.vjs-theme-ramp.vjs-audio-only-mode .vjs-volume-panel .vjs-volume-control {
+  opacity: 1 !important;
+  width: 4em !important;
+}
 
-  border-style: solid;
-  border-width: 0 0 1.75em 3em;
-  border-color: transparent transparent #fff transparent;
+/* Popup-menu button controls */
+.vjs-theme-ramp .vjs-menu li.vjs-menu-title {
+  text-transform: capitalize;
+}
+
+/* The following CSS was adapted from vertical volume control animation in VideoJS */
+// Hide popup menu when pointer is not hovering over the button
+.vjs-theme-ramp .vjs-menu-button-popup .vjs-menu {
+  opacity: 0;
+  display: block !important;
+  visibility: visible;
+  left: -3000em;
+  transition: visibility 1s, opacity 1s, height 1s 1s, width 1s 1s, left 0.20s 0.20s, top 1s 1s;
+}
+
+// Place popup menu above progres control
+.vjs-theme-ramp .vjs-menu-button-popup .vjs-menu {
+  bottom: 1.5em;
+}
+
+// Show popup menu on pointer hover event
+.vjs-theme-ramp .vjs-menu-button-popup:hover .vjs-menu,
+.vjs-theme-ramp .vjs-menu-button-popup:focus-within .vjs-menu {
+  opacity: 1;
+  visibility: visible;
+  left: -3.5em;
+  transition: left 0s;
+  display: block;
+}
+
+// Reduce left offset for playback rate menu when displayed
+.vjs-theme-ramp .vjs-playback-rate.vjs-menu-button-popup:hover .vjs-menu,
+.vjs-theme-ramp .vjs-playback-rate.vjs-menu-button-popup:focus-within .vjs-menu {
+  left: -0.5em;
+}
+
+// Align file download menu in audio players with the edge of the player boundary
+.vjs-theme-ramp.vjs-audio-only-mode .vjs-file-download:hover .vjs-menu,
+.vjs-theme-ramp.vjs-audio-only-mode .vjs-file-download:focus-within .vjs-menu {
+  left: -6.65em
 }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -59,7 +59,7 @@
 
 /* Center the CC button in mobile devices */
 .vjs-subs-caps-button>button {
-  padding: 0 0 3em 0;
+  padding: 0;
 }
 
 .video-js .vjs-progress-control:hover .vjs-play-progress:after {


### PR DESCRIPTION
Related issue: #657 

This PR includes the following changes;
1. Revert volume bar to the previous state where video players have vertical volume control and audio players have sticky horizontal volume control as follows.

<img width="622" alt="Screenshot 2024-10-17 at 4 54 48 PM" src="https://github.com/user-attachments/assets/ea0dd3eb-ec61-496d-aec4-4ca990a225dc">
<img width="636" alt="Screenshot 2024-10-17 at 4 55 30 PM" src="https://github.com/user-attachments/assets/e368b4db-2368-4da6-b82e-93cd52633859">

2. Move all popup menus above the progress-control. As part of this work display of the popup menus on `hover` event on the buttons are removed. This seems to be the common practice in other platforms e.g. LinkedInLearning and YouTube.