### PR TITLE
Adjust progress-bar spacing to display menus above it

### DIFF
--- a/src/components/MediaPlayer/VideoJS/videojs-theme.scss
+++ b/src/components/MediaPlayer/VideoJS/videojs-theme.scss
@@ -25,7 +25,7 @@
 .vjs-theme-ramp .vjs-custom-progress-bar {
   position: absolute;
   width: 100% !important;
-  top: 0.25em;
+  top: 0.5em;
   margin: 0;
 }
 


### PR DESCRIPTION
Before:
<img width="622" alt="Screenshot 2024-10-22 at 9 49 48 AM" src="https://github.com/user-attachments/assets/f5db5338-e44f-430c-9c97-f837d1c0e8aa">
After:
<img width="511" alt="Screenshot 2024-10-22 at 9 50 20 AM" src="https://github.com/user-attachments/assets/3eabf196-0e8d-46b4-80ec-4c13c366b13c">
