### PR TITLE
Truncate label

### DIFF
--- a/src/components/StructuredNavigation/NavUtils/List.test.js
+++ b/src/components/StructuredNavigation/NavUtils/List.test.js
@@ -2,10 +2,14 @@ import React from 'react';
 import List from './List';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { withManifestAndPlayerProvider } from '../../../services/testing-helpers';
+import * as utils from '@Services/utility-helpers';
 
 describe('List component', () => {
   const sectionRef = { current: '' };
   const structureContainerRef = { current: { scrollTop: 0 } };
+  jest.spyOn(utils, 'truncateCenter').mockImplementation((str) => {
+    return str;
+  });
   describe('with a regular manifest', () => {
     const items =
     {

--- a/src/components/StructuredNavigation/NavUtils/SectionHeading.js
+++ b/src/components/StructuredNavigation/NavUtils/SectionHeading.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
-import { autoScroll } from '@Services/utility-helpers';
+import { autoScroll, truncateCenter } from '@Services/utility-helpers';
 import List from './List';
 import { useActiveStructure } from '@Services/ramp-hooks';
 
@@ -89,9 +89,11 @@ const SectionHeading = ({
           <span className="ramp--structured-nav__title"
             aria-label={label}
             role="listitem"
+            title={label}
           >
             {isRoot ? '' : `${itemIndex}. `}
             {label}
+            {truncateCenter(label, Math.ceil(structureContainerRef.current.clientWidth / 15))}
             {duration != '' &&
               <span className="ramp--structured-nav__section-duration">
                 {duration}

--- a/src/components/StructuredNavigation/NavUtils/SectionHeading.js
+++ b/src/components/StructuredNavigation/NavUtils/SectionHeading.js
@@ -92,7 +92,6 @@ const SectionHeading = ({
             title={label}
           >
             {isRoot ? '' : `${itemIndex}. `}
-            {label}
             {truncateCenter(label, Math.ceil(structureContainerRef.current.clientWidth / 15))}
             {duration != '' &&
               <span className="ramp--structured-nav__section-duration">

--- a/src/components/StructuredNavigation/NavUtils/SectionHeading.test.js
+++ b/src/components/StructuredNavigation/NavUtils/SectionHeading.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import * as hooks from '@Services/ramp-hooks';
+import * as utils from '@Services/utility-helpers';
 import SectionHeading from './SectionHeading';
 
 describe('SectionHeading component', () => {
@@ -10,7 +11,9 @@ describe('SectionHeading component', () => {
   jest.spyOn(hooks, 'useActiveStructure').mockImplementation(() => ({
     isActiveSection: false
   }));
-
+  jest.spyOn(utils, 'truncateCenter').mockImplementation((str) => {
+    return str;
+  });
   test('renders canvas with children items', () => {
     render(
       <SectionHeading

--- a/src/components/StructuredNavigation/StructuredNavigation.test.js
+++ b/src/components/StructuredNavigation/StructuredNavigation.test.js
@@ -13,6 +13,7 @@ import {
 } from '../../services/testing-helpers';
 import { ErrorBoundary } from 'react-error-boundary';
 import playlist from '@TestData/playlist';
+import * as utils from '@Services/utility-helpers';
 
 describe('StructuredNavigation component', () => {
   // Jest does not support the ResizeObserver API so mock it here to allow tests to run.
@@ -23,6 +24,11 @@ describe('StructuredNavigation component', () => {
   }));
 
   window.ResizeObserver = ResizeObserver;
+
+  // Mock utl method, since maxLeght sets to zero in test dom
+  jest.spyOn(utils, 'truncateCenter').mockImplementation((str) => {
+    return str;
+  });
 
   describe('with manifest', () => {
     describe('with structures including Canvas references for sections', () => {
@@ -54,8 +60,7 @@ describe('StructuredNavigation component', () => {
       });
 
       test('renders root Range as a collapsible span', () => {
-        expect(screen.queryByText('Table of Contents')).not.toBeNull();
-
+        expect(screen.getAllByTestId('listitem-section').length).toEqual(2);
         const rootRange = screen.getAllByTestId('listitem-section')[0];
         expect(rootRange).toHaveClass('ramp--structured-nav__section');
         expect(rootRange.children[0]).toHaveClass('section-head-buttons');
@@ -65,7 +70,7 @@ describe('StructuredNavigation component', () => {
           .toHaveClass('ramp--structured-nav__section-title');
 
         const sectionHead = rootRange.children[0];
-        expect(sectionHead.children[0]).toHaveTextContent('Table of Contents');
+        expect(sectionHead.children[0].children[0]).toHaveTextContent('Table of Contents');
         expect(sectionHead.children[0]).toHaveClass(
           'ramp--structured-nav__section-title not-clickable'
         );
@@ -77,10 +82,8 @@ describe('StructuredNavigation component', () => {
       });
 
       test('first Canvas item is a section title as a button', () => {
-        expect(screen.queryByText('Table of Contents')).toBeInTheDocument();
-
         const firstCanvas = screen.queryAllByTestId('listitem-section')[1];
-        expect(firstCanvas.children[0]).toHaveTextContent('1. Lunchroom Manners11:00');
+        expect(firstCanvas.children[0].children[0]).toHaveTextContent('1. Lunchroom Manners11:00');
         expect(firstCanvas.children[0]).toHaveClass('section-head-buttons');
         expect(firstCanvas.children[0].children[1]).toHaveClass('collapse-expand-button');
       });

--- a/src/services/utility-helpers.js
+++ b/src/services/utility-helpers.js
@@ -706,3 +706,13 @@ export const groupBy = (arry, key) => {
     return rv;
   }, {});
 };
+
+export const truncateCenter = (label, maxLength = 100) => {
+  if (label.length <= maxLength) return label;
+
+  const halfLength = Math.floor((maxLength - 3) / 2);
+  const start = label.slice(0, halfLength);
+  const end = label.slice(-halfLength);
+
+  return `${start}...${end}`;
+};

--- a/src/services/utility-helpers.test.js
+++ b/src/services/utility-helpers.test.js
@@ -737,4 +737,21 @@ describe('util helper', () => {
       expect(util.GENERIC_ERROR_MESSAGE).toEqual("Error occurred. Please try again later.");
     });
   });
+
+  describe('truncateCenter()', () => {
+    test('with default maxLength and shorter label', () => {
+      const value = util.truncateCenter('Lunchroom Manners');
+      expect(value).toEqual('Lunchroom Manners');
+    });
+
+    test('with default maxLength and longer label', () => {
+      const value = util.truncateCenter('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua');
+      expect(value).toEqual('Lorem ipsum dolor sit amet, consectetur adipisci...mpor incididunt ut labore et dolore magna aliqua');
+    });
+
+    test('with maxLength = 50', () => {
+      const value = util.truncateCenter('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua', 50);
+      expect(value).toEqual('Lorem ipsum dolor sit a... et dolore magna aliqua');
+    });
+  });
 });


### PR DESCRIPTION
Truncate section heading label to display without horizontal scrolling

Before:
<img width="596" alt="Screenshot 2024-10-22 at 5 28 09 PM" src="https://github.com/user-attachments/assets/f4a72c7a-1c0d-4948-a491-3d635cddc4a1">

After: 
<img width="596" alt="Screenshot 2024-10-22 at 5 27 52 PM" src="https://github.com/user-attachments/assets/0f4e0579-577f-4bea-80fb-f247817de7b0">
