### PR TITLE
Change UI for structured nav to include collapse all button

### DIFF
--- a/src/components/StructuredNavigation/StructuredNavigation.js
+++ b/src/components/StructuredNavigation/StructuredNavigation.js
@@ -19,7 +19,7 @@ import CollapseExpandButton from './NavUtils/CollapseExpandButton';
  * @param {Object} props
  * @param {String} props.showAllSectionsButton
  */
-const StructuredNavigation = ({ showAllSectionsButton = false }) => {
+const StructuredNavigation = ({ showAllSectionsButton = false, sectionsHeading = 'Sections' }) => {
   const manifestDispatch = useManifestDispatch();
   const playerDispatch = usePlayerDispatch();
 
@@ -215,7 +215,7 @@ const StructuredNavigation = ({ showAllSectionsButton = false }) => {
     )}>
       {hasCollapsibleStructRef.current &&
         <div className='ramp--structured-nav__sections'>
-          <span className='ramp--structured-nav__sections-text'>Sections</span>
+          <span className='ramp--structured-nav__sections-text'>{sectionsHeading}</span>
           <CollapseExpandButton numberOfSections={structureItemsRef.current?.length} />
         </div>
       }

--- a/src/components/StructuredNavigation/StructuredNavigation.js
+++ b/src/components/StructuredNavigation/StructuredNavigation.js
@@ -214,7 +214,10 @@ const StructuredNavigation = ({ showAllSectionsButton = false }) => {
       hasCollapsibleStructRef.current ? ' display' : ''
     )}>
       {hasCollapsibleStructRef.current &&
-        <CollapseExpandButton numberOfSections={structureItemsRef.current?.length} />
+        <div className='ramp--structured-nav__sections'>
+          <span className='ramp--structured-nav__sections-text'>Sections</span>
+          <CollapseExpandButton numberOfSections={structureItemsRef.current?.length} />
+        </div>
       }
       <div className="ramp--structured-nav__border">
         <div

--- a/src/components/StructuredNavigation/StructuredNavigation.md
+++ b/src/components/StructuredNavigation/StructuredNavigation.md
@@ -2,6 +2,7 @@ StructuredNavigation component, renders any available structural properties in a
 
 `StructuredNavigation` component has the following prop;
 - `showAllSectionsButton`: accepts a Boolean value, which has a default value of `false` and is _not required_. This allows to display the collapse/expand all sections button above the structure for manifests with collapsible structures.
+- `sectionsHeading`: accepts a String value, which has a default value of `Sections` and is _not required_. This allows to customize the text that is shown next to collapse/expand all sections button at the top of collapsible structures.
 
 To import this component from the library;
 

--- a/src/components/StructuredNavigation/StructuredNavigation.scss
+++ b/src/components/StructuredNavigation/StructuredNavigation.scss
@@ -3,41 +3,55 @@
 .ramp--structured-nav.display {
   display: flow-root;
 
-  .ramp--structured-nav__collapse-all-btn {
-    float: right;
-    width: fit-content;
+  .ramp--structured-nav__sections {
+    margin-top: 1em;
+    display: flex;
+    justify-content: space-between;
+    padding: 0.5em 0.5em 0;
+    background-color: $primaryLightest;
+    border: 1px solid $primaryLight;
+    border-radius: 0.25em 0.25em 0 0;
+    border-bottom: none;
 
-    background-color: $primaryGreenDark;
-    color: $primaryLightest;
-    padding: 0.5em 0.75em;
-    border: none;
-    border-radius: 0.3em;
-    cursor: pointer;
-    margin-bottom: 0.5rem;
-
-    .arrow {
-      border: solid $primaryLightest;
-      border-width: 0 0.1em 0.1em 0;
-      display: inline-block;
-      padding: 0.25em;
-      margin-left: 0.5em;
+    .ramp--structured-nav__sections-text {
+      font-weight: bold;
+      font-size: 1.25em;
     }
 
-    .up {
-      transform: rotate(-135deg);
-      -webkit-transform: rotate(-135deg);
-      transition: transform .35s ease-in-out;
-    }
+    .ramp--structured-nav__collapse-all-btn {
+      background-color: $primaryGreenDark;
+      color: $primaryLightest;
+      padding: 0.5em 0.75em;
+      border: none;
+      border-radius: 0.3em;
+      cursor: pointer;
+      margin-bottom: 0.5rem;
 
-    .down {
-      transform: rotate(45deg);
-      -webkit-transform: rotate(45deg);
-      transition: transform .35s ease-in-out;
+      .arrow {
+        border: solid $primaryLightest;
+        border-width: 0 0.1em 0.1em 0;
+        display: inline-block;
+        padding: 0.25em;
+        margin-left: 0.5em;
+      }
+
+      .up {
+        transform: rotate(-135deg);
+        -webkit-transform: rotate(-135deg);
+        transition: transform .35s ease-in-out;
+      }
+
+      .down {
+        transform: rotate(45deg);
+        -webkit-transform: rotate(45deg);
+        transition: transform .35s ease-in-out;
+      }
     }
   }
 
   .ramp--structured-nav__border {
-    margin-top: 2.5em;
+    margin-top: 0 !important;
+    border-radius: 0 0 0.25em 0.25em;
     width: 100%;
   }
 }


### PR DESCRIPTION
This PR changes the UI of the structured navigation component to include collapse/expand all sections button as part of the structures in the display. This helps to mimic the collapse/expand all button we had in Avalon in the previous implementation as below;
<img width="717" alt="Screenshot 2024-10-28 at 11 12 45 AM" src="https://github.com/user-attachments/assets/10d17b4e-ee61-4442-913b-4a193b91826f">

Before:
<img width="538" alt="Screenshot 2024-10-28 at 11 11 09 AM" src="https://github.com/user-attachments/assets/cf4162a0-2c3a-489a-8855-2a9c58eb240d">

After:
<img width="538" alt="Screenshot 2024-10-28 at 11 10 26 AM" src="https://github.com/user-attachments/assets/44eb057d-896a-4054-88b8-5e2ba14a088e">

For non-collapsible structures:
<img width="538" alt="Screenshot 2024-10-28 at 11 10 44 AM" src="https://github.com/user-attachments/assets/182f589c-1904-481f-8a1d-6479f3af76f1">