### PR TITLE
Create inaccessible message interval only in a single custom hook

### DIFF
--- a/src/services/ramp-hooks.js
+++ b/src/services/ramp-hooks.js
@@ -107,7 +107,6 @@ export const useSetupPlayer = ({
   const manifestState = useContext(ManifestStateContext);
   const {
     allCanvases,
-    autoAdvance,
     canvasIndex,
     customStart,
     manifest,
@@ -116,10 +115,6 @@ export const useSetupPlayer = ({
     srcIndex
   } = manifestState;
   const { isPlaylist } = playlist;
-
-  const {
-    clearDisplayTimeInterval, createDisplayTimeInterval
-  } = useShowInaccessibleMessage({ lastCanvasIndex });
 
   const [isVideo, setIsVideo] = useState();
   const [playerConfig, setPlayerConfig] = useState({
@@ -167,7 +162,6 @@ export const useSetupPlayer = ({
    * @param {Boolean} fromStart flag to indicate how to start new player instance
    */
   const initCanvas = (canvasId, fromStart) => {
-    clearDisplayTimeInterval();
     const {
       isMultiSource, sources, tracks, canvasTargets, mediaType, error, poster
     } = getMediaInfo({
@@ -221,10 +215,6 @@ export const useSetupPlayer = ({
       manifestDispatch({ type: 'setCanvasIsEmpty', isEmpty: true });
       // Set poster as playerConfig.error to be used for empty Canvas message in VideoJSPlayer
       setPlayerConfig({ ...playerConfig, error: poster });
-      // Create timer to display the message when autoadvance is ON
-      if (autoAdvance) {
-        createDisplayTimeInterval();
-      }
     }
     setIsMultiSourced(isMultiSource || false);
 
@@ -563,9 +553,6 @@ export const useShowInaccessibleMessage = ({ lastCanvasIndex }) => {
 
   const [messageTime, setMessageTime] = useState(CANVAS_MESSAGE_TIMEOUT / 1000);
 
-  let canvasIndexRef = useRef();
-  canvasIndexRef.current = useMemo(() => { return canvasIndex; }, [canvasIndex]);
-
   let messageIntervalRef = useRef(null);
 
   useEffect(() => {
@@ -592,9 +579,9 @@ export const useShowInaccessibleMessage = ({ lastCanvasIndex }) => {
         setMessageTime(Math.ceil(timeRemaining));
       } else {
         // Advance to next Canvas when timer ends
-        if (canvasIndexRef.current < lastCanvasIndex && autoAdvance) {
+        if (canvasIndex < lastCanvasIndex && autoAdvance) {
           manifestDispatch({
-            canvasIndex: canvasIndexRef.current + 1,
+            canvasIndex: canvasIndex + 1,
             type: 'switchCanvas',
           });
         }


### PR DESCRIPTION
Related issue: #673 

Only invoke `createDisplayTimeInterval()` method within `useShowInaccessibleMessage` custom hook. When this was called within `initCanvas()` in `useSetupPlayer` hook, it creates multiple intervals disabling the remaining time updates in the timer on display.
Use `canvasIndex` instead of `canvasIndexRef` in the dispatch to update manifest-state when timer ends. 
It was observed that, in Safari and Chrome using `canvasIndexRef` causes to skip an item when auto-advancing (most probably due to timing of these updates are getting overlapped) in avalon's playlists where there are inaccessible items. However this was not seen in these browsers in the demo site.