### PR TITLE
Wrap long labels w/o spaces in structure to new lines

### DIFF
--- a/src/components/StructuredNavigation/NavUtils/List.test.js
+++ b/src/components/StructuredNavigation/NavUtils/List.test.js
@@ -174,7 +174,7 @@ describe('List component', () => {
       expect(screen.queryAllByTestId('list')).toHaveLength(1);
       expect(screen.queryAllByTestId('list-item').length).toEqual(1);
       expect(screen.queryAllByTestId('list-item')[0])
-        .toHaveTextContent('1. Beginning Responsibility: Lunchroom Manners (09:32)');
+        .toHaveTextContent('1.Beginning Responsibility: Lunchroom Manners (09:32)');
       // Has tracker UI element attached 
       expect(screen.queryAllByTestId('list-item')[0].children[0]).toHaveClass('tracker');
     });

--- a/src/components/StructuredNavigation/NavUtils/List.test.js
+++ b/src/components/StructuredNavigation/NavUtils/List.test.js
@@ -84,12 +84,14 @@ describe('List component', () => {
     test('displays canvas level structure item w/o mediafragment as a span', () => {
       expect(screen.queryByTestId('listitem-section-span')).toBeInTheDocument();
       expect(screen.getByTestId('listitem-section-span'))
-        .toHaveTextContent('1. Lunchroom Manners09:32');
+        .toHaveTextContent('1.Lunchroom Manners09:32');
     });
 
     test('displays structures with the correct ListItems', () => {
-      expect(screen.getByText('1. Part I (00:45)'));
+      expect(screen.getByText('Part I (00:45)'));
+      expect(screen.getByText('Part I (00:45)').parentElement.tagName).toEqual('A');
       expect(screen.getByText('Introduction'));
+      expect(screen.getByText('Introduction')).toHaveClass('ramp--structured-nav__item-title');
     });
   });
 
@@ -135,7 +137,7 @@ describe('List component', () => {
     render(<ListWithManifest />);
     expect(screen.queryByTestId('listitem-section-button')).toBeInTheDocument();
     expect(screen.getByTestId('listitem-section-button'))
-      .toHaveTextContent('1. Lunchroom Manners');
+      .toHaveTextContent('1.Lunchroom Manners09:32');
   });
 
   describe('with playlist manifest', () => {

--- a/src/components/StructuredNavigation/NavUtils/ListItem.js
+++ b/src/components/StructuredNavigation/NavUtils/ListItem.js
@@ -109,13 +109,13 @@ const ListItem = ({
                   <div className="tracker"></div>
                   {isClickable ? (
                     <>
-                      {isEmpty && <LockedSVGIcon />}
                       <a role='link'
                         className='ramp--structured-nav__item-link'
                         href={homepage && homepage != '' ? homepage : id}
                         onClick={handleClick}>
-                        {`${itemIndex}. `}
-                        <span aria-label={label}>
+                        {isEmpty && <LockedSVGIcon />}
+                        {`${itemIndex}.`}
+                        <span className='structured-nav__item-label' aria-label={label}>
                           {label} {duration.length > 0 ? ` (${duration})` : ''}
                         </span>
                       </a>

--- a/src/components/StructuredNavigation/NavUtils/ListItem.js
+++ b/src/components/StructuredNavigation/NavUtils/ListItem.js
@@ -114,7 +114,10 @@ const ListItem = ({
                         className='ramp--structured-nav__item-link'
                         href={homepage && homepage != '' ? homepage : id}
                         onClick={handleClick}>
-                        {`${itemIndex}. `}{label} {duration.length > 0 ? ` (${duration})` : ''}
+                        {`${itemIndex}. `}
+                        <span aria-label={label}>
+                          {label} {duration.length > 0 ? ` (${duration})` : ''}
+                        </span>
                       </a>
                     </>
                   ) : (

--- a/src/components/StructuredNavigation/NavUtils/ListItem.test.js
+++ b/src/components/StructuredNavigation/NavUtils/ListItem.test.js
@@ -106,7 +106,7 @@ describe('ListItem component', () => {
 
     test('renders successfully', () => {
       expect(screen.getByTestId('list-item'));
-      expect(screen.getByText('1. Track 1. I Krafting (00:01:14)'));
+      expect(screen.getByText('Track 1. I Krafting (00:01:14)'));
     });
   });
 
@@ -227,9 +227,10 @@ describe('ListItem component', () => {
     });
 
     test('creates an anchor element and title for an item', () => {
-      const anchorElement = screen.getByText('2. Rinsing Well (00:05)');
-      expect(anchorElement.tagName).toEqual('A');
-      expect(anchorElement).toHaveAttribute(
+      const anchorElement = screen.getByText('Rinsing Well (00:05)');
+      expect(anchorElement.tagName).toEqual('SPAN');
+      expect(anchorElement.parentElement.tagName).toEqual('A');
+      expect(anchorElement.parentElement).toHaveAttribute(
         'href',
         'https://example.com/manifest/lunchroom_manners/canvas/1#t=165,170'
       );
@@ -301,7 +302,7 @@ describe('ListItem component', () => {
       });
       render(<ListItemWithManifest />);
       expect(screen.queryAllByTestId('list-item').length).toEqual(1);
-      expect(screen.queryAllByTestId('list-item')[0]).toHaveTextContent('1. Beginning Responsibility: Lunchroom Manners (09:32)');
+      expect(screen.queryAllByTestId('list-item')[0]).toHaveTextContent('Beginning Responsibility: Lunchroom Manners (09:32)');
       expect(screen.queryAllByTestId('list-item')[0].getAttribute('data-label')).toEqual('Beginning Responsibility: Lunchroom Manners');
       expect(screen.queryAllByTestId('list-item')[0].getAttribute('data-summary')).toEqual('Mind your manners!');
     });
@@ -321,10 +322,9 @@ describe('ListItem component', () => {
         render(<ListItemWithManifest />);
 
         expect(screen.queryAllByTestId('list-item').length).toEqual(1);
-        expect(screen.queryByText('1. Beginning Responsibility: Lunchroom Manners (09:32)')).toBeInTheDocument();
-        expect(screen
-          .queryByText('1. Beginning Responsibility: Lunchroom Manners (09:32)')
-          .getAttribute('href'))
+        expect(screen.queryByText('Beginning Responsibility: Lunchroom Manners (09:32)')).toBeInTheDocument();
+        const structItem = screen.getByText('Beginning Responsibility: Lunchroom Manners (09:32)');
+        expect(structItem.parentElement.getAttribute('href'))
           .toEqual('https://example.com/playlists/1?position=1');
       });
 
@@ -342,10 +342,9 @@ describe('ListItem component', () => {
         render(<ListItemWithManifest />);
         expect(screen.queryAllByTestId('list')).toHaveLength(1);
         expect(screen.queryAllByTestId('list-item').length).toEqual(3);
-        expect(screen.queryByText('1. Part I (00:45)')).toBeInTheDocument();
-        expect(screen
-          .queryByText('1. Part I (00:45)')
-          .getAttribute('href'))
+        expect(screen.queryByText('Part I (00:45)')).toBeInTheDocument();
+        const structItem = screen.getByText('Part I (00:45)');
+        expect(structItem.parentElement.getAttribute('href'))
           .toEqual('https://example.com/manifest/lunchroome_manners/canvas/1#t=0.0,45.321');
       });
     });

--- a/src/components/StructuredNavigation/NavUtils/SectionHeading.js
+++ b/src/components/StructuredNavigation/NavUtils/SectionHeading.js
@@ -84,24 +84,22 @@ const SectionHeading = ({
       'ramp--structured-nav__section',
       isActiveSection ? 'active' : ''
     )}
-      role="listitem" data-testid="listitem-section"
+      role='listitem' data-testid='listitem-section'
       ref={sectionRef} data-label={label}
       data-mediafrag={itemId ?? ''}>
-      <div className="section-head-buttons">
+      <div className='ramp--structured-nav__section-head-buttons'>
         <button
-          data-testid={itemId == undefined ? "listitem-section-span" : "listitem-section-button"}
+          data-testid={itemId == undefined ? 'listitem-section-span' : 'listitem-section-button'}
           ref={sectionRef} onClick={handleClick}
           className={cx(
             'ramp--structured-nav__section-title',
             !itemId && 'not-clickable'
           )}>
-          <span className="ramp--structured-nav__title"
-            aria-label={label}
-          >
-            {isRoot ? '' : `${itemIndex}. `}
-            {label}
+          <span className='ramp--structured-nav__title' aria-label={label}>
+            {isRoot ? '' : `${itemIndex}.`}
+            <span className='ramp--structured-nav__section-label'>{label}</span>
             {duration != '' &&
-              <span className="ramp--structured-nav__section-duration">
+              <span className='ramp--structured-nav__section-duration'>
                 {duration}
               </span>}
           </span>

--- a/src/components/StructuredNavigation/NavUtils/SectionHeading.test.js
+++ b/src/components/StructuredNavigation/NavUtils/SectionHeading.test.js
@@ -29,7 +29,7 @@ describe('SectionHeading component', () => {
     expect(screen.queryAllByTestId('listitem-section-button')).toHaveLength(0);
     expect(screen.queryByTestId('section-collapse-icon')).toBeInTheDocument();
     expect(screen.getByTestId('listitem-section-span'))
-      .toHaveTextContent('1. Lunchroom Manners09:32');
+      .toHaveTextContent('1.Lunchroom Manners09:32');
   });
 
   test('renders canvas without children items', () => {
@@ -48,7 +48,7 @@ describe('SectionHeading component', () => {
     expect(screen.queryAllByTestId('listitem-section-button')).toHaveLength(0);
     expect(screen.queryByTestId('section-collapse-icon')).not.toBeInTheDocument();
     expect(screen.getByTestId('listitem-section-span'))
-      .toHaveTextContent('1. Lunchroom Manners09:32');
+      .toHaveTextContent('1.Lunchroom Manners09:32');
   });
 
   test('renders canvas with mediafragment as a button', () => {
@@ -67,7 +67,7 @@ describe('SectionHeading component', () => {
     expect(screen.queryAllByTestId('listitem-section-span')).toHaveLength(0);
     expect(screen.queryAllByTestId('listitem-section-button')).toHaveLength(1);
     expect(screen.getByTestId('listitem-section-button'))
-      .toHaveTextContent('1. Lunchroom Manners09:32');
+      .toHaveTextContent('1.Lunchroom Manners09:32');
     expect(screen.getByTestId('listitem-section')).toHaveAttribute('data-mediafrag');
     expect(screen.getByTestId('listitem-section').getAttribute('data-mediafrag'))
       .toEqual('https://example.com/manifest/canvas#t=0.0,572');
@@ -91,7 +91,7 @@ describe('SectionHeading component', () => {
     expect(screen.queryAllByTestId('listitem-section-span')).toHaveLength(1);
     expect(screen.queryAllByTestId('listitem-section-button')).toHaveLength(0);
     expect(screen.getByTestId('listitem-section-span'))
-      .toHaveTextContent('1. Lunchroom Manners09:32');
+      .toHaveTextContent('1.Lunchroom Manners09:32');
     expect(screen.queryByTestId('section-collapse-icon')).not.toBeInTheDocument();
     expect(screen.getByTestId('listitem-section')).toHaveAttribute('data-mediafrag');
     expect(screen.getByTestId('listitem-section').getAttribute('data-mediafrag')).toEqual('');

--- a/src/components/StructuredNavigation/StructuredNavigation.scss
+++ b/src/components/StructuredNavigation/StructuredNavigation.scss
@@ -112,6 +112,10 @@
   ul.ramp--structured-nav__list>li:last-child {
     padding: 0
   }
+  // Change display to align locked-icon with label in playlists
+  a {
+    display: inline-block;
+  }
 }
 
 // Border box
@@ -181,6 +185,10 @@ ul.ramp--structured-nav__list {
     // Set line-height to create clickable space around link
     .ramp--structured-nav__item-link {
       line-height: 1.65em;
+
+      .structured-nav__item-label {
+        margin-left: 0.2em;
+      }
     }
 
     ul {
@@ -289,10 +297,11 @@ ul.ramp--structured-nav__list {
 
   .ramp--structured-nav__section-title {
     display: flex;
-    gap: 0.1em;
+    gap: 0.2em;
 
     span.ramp--structured-nav__section-label {
       overflow-wrap: anywhere;
+      margin-left: 0.2em;
     }
 
     span.ramp--structured-nav__section-duration {
@@ -304,7 +313,7 @@ ul.ramp--structured-nav__list {
       line-height: 1.6;
       padding: 0 0.5rem;
       margin-left: 0.5rem;
-      height: fit-content;
+      text-wrap: nowrap;
     }
   }
 }

--- a/src/components/StructuredNavigation/StructuredNavigation.scss
+++ b/src/components/StructuredNavigation/StructuredNavigation.scss
@@ -67,6 +67,8 @@
     color: $primaryGreenDark;
     transition: 0.25s;
     text-decoration: none;
+    display: inline-flex;
+    gap: 0.1em;
 
     &:hover {
       color: $primaryDarker;
@@ -76,6 +78,10 @@
   p {
     padding-top: 1em;
     color: $primaryDarker;
+  }
+
+  span {
+    overflow-wrap: anywhere;
   }
 
   // Remove top border for first SectionHeading (causes double lines)
@@ -219,7 +225,7 @@ ul.ramp--structured-nav__list {
 }
 
 .ramp--structured-nav__section {
-  .section-head-buttons {
+  .ramp--structured-nav__section-head-buttons {
     display: grid;
     grid-template-columns: 1fr auto;
 
@@ -281,18 +287,24 @@ ul.ramp--structured-nav__list {
     }
   }
 
-  // span {
-  //   padding: 1rem;
-  // }
+  .ramp--structured-nav__section-title {
+    display: flex;
+    gap: 0.1em;
 
-  span.ramp--structured-nav__section-duration {
-    border: 1px solid $primaryDark;
-    border-radius: 999px;
-    color: $primaryDarkest;
-    font-size: 0.75rem;
-    letter-spacing: 0.02rem;
-    line-height: 1.6;
-    padding: 0 0.5rem;
-    margin-left: 0.5rem;
+    span.ramp--structured-nav__section-label {
+      overflow-wrap: anywhere;
+    }
+
+    span.ramp--structured-nav__section-duration {
+      border: 1px solid $primaryDark;
+      border-radius: 999px;
+      color: $primaryDarkest;
+      font-size: 0.75rem;
+      letter-spacing: 0.02rem;
+      line-height: 1.6;
+      padding: 0 0.5rem;
+      margin-left: 0.5rem;
+      height: fit-content;
+    }
   }
 }

--- a/src/components/StructuredNavigation/StructuredNavigation.test.js
+++ b/src/components/StructuredNavigation/StructuredNavigation.test.js
@@ -59,7 +59,7 @@ describe('StructuredNavigation component', () => {
 
         const rootRange = screen.getAllByTestId('listitem-section')[0];
         expect(rootRange).toHaveClass('ramp--structured-nav__section');
-        expect(rootRange.children[0]).toHaveClass('section-head-buttons');
+        expect(rootRange.children[0]).toHaveClass('ramp--structured-nav__section-head-buttons');
         expect(rootRange.children[0].children[0])
           .toHaveAttribute('data-testid', 'listitem-section-span');
         expect(rootRange.children[0].children[0])
@@ -82,8 +82,8 @@ describe('StructuredNavigation component', () => {
         expect(screen.queryByText('Table of Contents')).toBeInTheDocument();
 
         const firstCanvas = screen.queryAllByTestId('listitem-section')[1];
-        expect(firstCanvas.children[0]).toHaveTextContent('1. Lunchroom Manners11:00');
-        expect(firstCanvas.children[0]).toHaveClass('section-head-buttons');
+        expect(firstCanvas.children[0]).toHaveTextContent('1.Lunchroom Manners11:00');
+        expect(firstCanvas.children[0]).toHaveClass('ramp--structured-nav__section-head-buttons');
         expect(firstCanvas.children[0].children[1]).toHaveClass('collapse-expand-button');
       });
     });
@@ -112,9 +112,12 @@ describe('StructuredNavigation component', () => {
       });
 
       test('first item is a section title as a span', () => {
-        expect(screen.queryAllByTestId('listitem-section').length).toBeGreaterThan(0);
-        expect(screen.queryAllByTestId('listitem-section')[0])
-          .toHaveTextContent('1. CD1 - Mahler, Symphony No.309:32');
+        expect(screen.queryAllByTestId('listitem-section').length).toBe(2);
+        expect(screen.queryAllByTestId('listitem-section')[0].children[0])
+          .toHaveTextContent('1.CD1 - Mahler, Symphony No.309:32');
+
+        // Two sections w/o Canvas references are rendered as text
+        expect(screen.queryAllByTestId('listitem-section-span').length).toBe(2);
 
         const firstItem = screen.getAllByTestId('list-item')[0];
         expect(firstItem).toHaveAttribute('data-label', 'Track 1. I. Kraftig');

--- a/src/components/StructuredNavigation/StructuredNavigation.test.js
+++ b/src/components/StructuredNavigation/StructuredNavigation.test.js
@@ -122,7 +122,7 @@ describe('StructuredNavigation component', () => {
         const firstItem = screen.getAllByTestId('list-item')[0];
         expect(firstItem).toHaveAttribute('data-label', 'Track 1. I. Kraftig');
         expect(firstItem).toHaveTextContent(
-          '1. Track 1. I. Kraftig (06:14)'
+          '1.Track 1. I. Kraftig (06:14)'
         );
         expect(firstItem).toHaveClass(
           'ramp--structured-nav__list-item'


### PR DESCRIPTION
Related issue: #675 

Section headings:
Before: 
<img width="673" alt="Screenshot 2024-10-29 at 5 39 45 PM" src="https://github.com/user-attachments/assets/2327c018-e12f-4f96-b63a-a3100e9f3d63">

After: 
<img width="673" alt="Screenshot 2024-10-29 at 5 38 25 PM" src="https://github.com/user-attachments/assets/f42b86c4-9170-48d3-9f91-0834e5365258">

Child structure items:
Before:
<img width="673" alt="Screenshot 2024-10-29 at 5 39 56 PM" src="https://github.com/user-attachments/assets/d0e9aabc-549f-497e-9d55-e8b66e5da187">

After:
<img width="533" alt="Screenshot 2024-10-29 at 5 35 56 PM" src="https://github.com/user-attachments/assets/c457ec09-5bb5-4fab-8c9a-7b25af5899ce">
