### PR TITLE
Center align progressbar in audio, and add padding

### DIFF
--- a/src/components/MediaPlayer/VideoJS/videojs-theme.scss
+++ b/src/components/MediaPlayer/VideoJS/videojs-theme.scss
@@ -29,17 +29,17 @@
 
 .vjs-theme-ramp .vjs-control-bar {
   height: 5em;
-  padding-top: 2em;
-  background: none;
-  background-image: linear-gradient(to top, #000, rgba(0, 0, 0, 0));
+  background: linear-gradient(to bottom, rgba(0, 0, 0, 0), rgba(0, 0, 0, .75), rgba(0, 0, 0, .75));
   display: flex;
+  padding: 2em 1em 0 1em;
 }
 
 .vjs-theme-ramp .vjs-custom-progress-bar {
   position: absolute;
-  width: 100% !important;
-  top: 0.5em;
+  width: 98.75% !important;
+  top: 1.25em;
   margin: 0;
+  left: 1em;
 }
 
 .vjs-theme-ramp .vjs-progress-control .vjs-progress-holder {
@@ -77,7 +77,7 @@
 
 /* Volume controls */
 .vjs-theme-ramp .vjs-volume-panel .vjs-volume-control.vjs-volume-vertical {
-  margin-top: -1.5em;
+  margin-top: -0.75em;
 }
 
 // Make the horizontal volume panel always visible for audio
@@ -108,7 +108,7 @@
 
 // Place popup menu above and on top of progress control
 .vjs-theme-ramp .vjs-menu-button-popup .vjs-menu {
-  bottom: 1.5em;
+  bottom: 0.75em;
   z-index: 1;
 }
 


### PR DESCRIPTION
Related issue: #687 

<img width="1169" alt="Screenshot 2024-10-31 at 11 34 32 AM" src="https://github.com/user-attachments/assets/77dfa1a9-0577-4f3d-8985-db67195f1c46">
<img width="1169" alt="Screenshot 2024-10-31 at 11 35 43 AM" src="https://github.com/user-attachments/assets/ceacbc98-b114-45e5-9bb2-80eb87ff080c">
