### PR TITLE
Show timetool-tip above search marker when hovering

### DIFF
--- a/src/components/MediaPlayer/VideoJS/components/js/VideoJSProgress.js
+++ b/src/components/MediaPlayer/VideoJS/components/js/VideoJSProgress.js
@@ -326,6 +326,11 @@ class CustomSeekBar extends SeekBar {
       : e.offsetX; // fallback in desktop browsers when nativeEvent is undefined
     let currentTime;
     const duration = this.totalDuration ?? this.player.duration();
+    // When pointer is on top of a search marker on the progress bar
+    if (eSrcElement.classList.contains('ramp--track-marker--search')) {
+      const markerTime = e.target.dataset.markerTime ?? 0;
+      return { currentTime: markerTime, offsetx: e.target.offsetLeft };
+    }
     if (offsetx && offsetx != undefined) {
       if (this.isMultiSourceRef.current) {
         /**


### PR DESCRIPTION
When hovering over a search marker on the progress-bar the timetool-tip appears at 0:00 time-point instead of at the correct offset above the search marker

Before:
<img width="1276" alt="Screenshot 2024-11-01 at 11 00 17 AM" src="https://github.com/user-attachments/assets/d589e69c-353f-4a12-8b64-f531f2de047f">

After:
<img width="1276" alt="Screenshot 2024-11-01 at 10 59 42 AM" src="https://github.com/user-attachments/assets/1850e45d-08f2-4bd9-b8bf-c018c3aa779a">
