### PR TITLE
Specify player's min-height for audio in mobile browsers

### DIFF
--- a/src/components/MediaPlayer/VideoJS/videojs-theme.scss
+++ b/src/components/MediaPlayer/VideoJS/videojs-theme.scss
@@ -12,6 +12,7 @@
 .vjs-theme-ramp.vjs-audio-only-mode.vjs-device-iphone,
 .vjs-theme-ramp.vjs-audio-only-mode.vjs-device-android {
   min-width: 380px;
+  min-height: 40px;
 }
 
 /* Minimum height and width for video player */


### PR DESCRIPTION
Related issue: #700 
