### PR TITLE
Force player to load in Safari and iOS browsers

### DIFF
--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -412,16 +412,18 @@ function VideoJSPlayer({
       }
 
       /**
-       * When either player/browser tab is muted Safari and Chrome in iOS doesn't seem to 
-       * load enough data related to audio-only media for the Video.js instance to play 
-       * on page load.
+       * By default VideoJS instance doesn't load enough data on page load for Safari browsers,
+       * to seek to timepoints using structured navigation/markers. Therefore, force the player
+       * reach a ready state, where enough information is available for the user to use these
+       * functionalities by invoking player.load().
+       * This is especially required, when player/tab is muted for audio players in Safari.
        * Since, it is not possible to detect muted tabs in JS the condition avoids
        * checking for muted state altogether.
        * Without this, Safari will not reach player.readyState() = 4, the state
        * which indicates the player that enough data is available on the media
        * for playback.
        */
-      if (!isVideo && (IS_SAFARI || IS_IOS) && player.readyState() != 4) {
+      if ((IS_SAFARI || IS_IOS) && player.readyState() != 4) {
         player.load();
       }
 


### PR DESCRIPTION
Related issue: #694 

Extend `player.load()` for all Safari and iOS browsers, to make the player ready before playback starts. This allows the user to use structured navigation to seek the player to the start time of a track and start playback from there.


https://github.com/user-attachments/assets/ddb23445-de9b-4b9d-82e8-10b281b56332

