### PR TITLE
Call player.load() in Safari/iOS browsers before calling play()

### DIFF
--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -354,6 +354,22 @@ function VideoJSPlayer({
 
       player.duration(canvasDuration);
 
+      /**
+       * When either player/browser tab is muted Safari and Chrome in iOS doesn't seem to 
+       * load enough data related to audio-only media for the Video.js instance to play 
+       * on page load.
+       * Since, it is not possible to detect muted tabs in JS the condition avoids
+       * checking for muted state altogether.
+       * Without this, Safari will not reach player.readyState() = 4, the state
+       * which indicates the player that enough data is available on the media
+       * for playback.
+       * Have this execute before handling player events, so that the player functions as
+       * expected across all browsers.
+       */
+      if (!isVideo && (IS_SAFARI || IS_IOS) && player.readyState() != 4) {
+        player.load();
+      }
+
       isEndedRef.current ? player.currentTime(0) : player.currentTime(currentTimeRef.current);
       /**
        * Set structStart variable in the updated player to update the progressBar with the
@@ -409,20 +425,6 @@ function VideoJSPlayer({
        */
       if (IS_SAFARI) {
         handleTimeUpdate();
-      }
-
-      /**
-       * When either player/browser tab is muted Safari and Chrome in iOS doesn't seem to 
-       * load enough data related to audio-only media for the Video.js instance to play 
-       * on page load.
-       * Since, it is not possible to detect muted tabs in JS the condition avoids
-       * checking for muted state altogether.
-       * Without this, Safari will not reach player.readyState() = 4, the state
-       * which indicates the player that enough data is available on the media
-       * for playback.
-       */
-      if (!isVideo && (IS_SAFARI || IS_IOS) && player.readyState() != 4) {
-        player.load();
       }
 
       // Reveal player if not revealed on 'progress' event, allowing user to 


### PR DESCRIPTION
Related issue: #672 