### PR TITLE
Use control-bar width to add padding to progress-bar on sides

### DIFF
--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -123,6 +123,8 @@ function VideoJSPlayer({
     player.on('ready', function () {
       console.log('Player ready');
 
+      setControlBar(player);
+
       // Add this class in mobile/tablet devices to always show the control bar,
       // since the inactivityTimeout is flaky in some browsers
       if (IS_MOBILE || IS_IPAD) {
@@ -156,6 +158,9 @@ function VideoJSPlayer({
     });
     player.on('timeupdate', () => {
       handleTimeUpdate();
+    });
+    player.on('resize', () => {
+      setControlBar(player);
     });
     player.on('ended', () => {
       /**
@@ -220,6 +225,17 @@ function VideoJSPlayer({
       e.stopPropagation();
     });
     playerLoadedMetadata(player);
+  };
+
+  /**
+   * Set control bar width to offset 12px from left/right edges of player.
+   * This is set on player.ready and player.resize events.
+   * @param {Object} player 
+   */
+  const setControlBar = (player) => {
+    const playerWidth = player.currentWidth();
+    const controlBarWidth = playerWidth - 24;
+    player.controlBar.width(`${controlBarWidth}px`);
   };
 
   /**
@@ -351,6 +367,9 @@ function VideoJSPlayer({
   const playerLoadedMetadata = (player) => {
     player.one('loadedmetadata', () => {
       console.log('Player loadedmetadata');
+
+      // Update control-bar width on player reload
+      setControlBar(player);
 
       player.duration(canvasDuration);
 

--- a/src/components/MediaPlayer/VideoJS/videojs-theme.scss
+++ b/src/components/MediaPlayer/VideoJS/videojs-theme.scss
@@ -32,15 +32,39 @@
   height: 5em;
   background: linear-gradient(to bottom, rgba(0, 0, 0, 0), rgba(0, 0, 0, .75), rgba(0, 0, 0, .75));
   display: flex;
-  padding: 2em 1em 0 1em;
+  padding-top: 2em;
+  left: 1em;
+
+  // Set faded effect background before and after control bar
+  &::before {
+    content: '';
+    width: 1em;
+    height: 100%;
+    background: linear-gradient(to bottom, rgba(0, 0, 0, 0), rgba(0, 0, 0, .75), rgba(0, 0, 0, .75)),
+      linear-gradient(to left, transparent, rgba(0, 0, 0, 0));
+    position: absolute;
+    left: 0.215em;
+    top: 0em;
+    transform: translateX(-120%);
+  }
+  &::after {
+    content: '';
+    width: 1em;
+    height: 100%;
+    background: linear-gradient(to bottom, rgba(0, 0, 0, 0), rgba(0, 0, 0, .75), rgba(0, 0, 0, .75)),
+      linear-gradient(to left, transparent, rgba(0, 0, 0, 0));
+    position: absolute;
+    right: -2.215em;
+    top: 0em;
+    transform: translateX(-121%);
+  }
 }
 
 .vjs-theme-ramp .vjs-custom-progress-bar {
   position: absolute;
-  width: 98.75% !important;
+  width: 100% !important;
   top: 1.25em;
   margin: 0;
-  left: 1em;
 }
 
 .vjs-theme-ramp .vjs-progress-control .vjs-progress-holder {

--- a/src/services/ramp-hooks.js
+++ b/src/services/ramp-hooks.js
@@ -486,6 +486,11 @@ export const useVideoJSPlayer = ({
           break;
       }
     });
+
+    // Listen for resize events and trigger player.resize event
+    window.addEventListener('resize', () => {
+      player.trigger('resize');
+    });
   };
 
   /**


### PR DESCRIPTION
Related issue: #687

Use control-bar width to add space on either side of the progress-bar in between the player borders and progress-bar. The previous implementation used only CSS by adjusting the width of the progress-bar which was not responding well to player resize.

<img width="699" alt="Screenshot 2024-11-04 at 4 19 11 PM" src="https://github.com/user-attachments/assets/22f29f9e-2916-42ce-90e1-c45fc759f285">
