### PR TITLE
Remove progress-bar shadow on focus

### DIFF
--- a/src/components/MediaPlayer/VideoJS/components/styles/VideoJSProgress.scss
+++ b/src/components/MediaPlayer/VideoJS/components/styles/VideoJSProgress.scss
@@ -6,6 +6,12 @@
   align-items: center;
   min-width: 4em;
   height: 0.5em;
+
+  // Remove highlight on focus (scrub/seek)
+  &:focus {
+    text-shadow: none;
+    box-shadow: none;
+  }
 }
 
 .video-js .vjs-custom-progress-bar {


### PR DESCRIPTION
Before:
<img width="878" alt="Screenshot 2024-11-06 at 4 38 15 PM" src="https://github.com/user-attachments/assets/563a52f8-9ab0-4559-a0a5-0534b2d54702">

After:
<img width="878" alt="Screenshot 2024-11-06 at 4 37 58 PM" src="https://github.com/user-attachments/assets/d83283a1-1d96-4fe9-bd18-9b5689f51fc8">