### PR TITLE
Fix collapse/expand all button behavior with each section status change

### DIFF
--- a/src/components/StructuredNavigation/NavUtils/List.test.js
+++ b/src/components/StructuredNavigation/NavUtils/List.test.js
@@ -70,8 +70,15 @@ describe('List component', () => {
         structureContainerRef,
         isPlaylist: false,
       };
+      const manifestState = {
+        ...initialManifestState,
+        structures: {
+          ...initialManifestState.structures,
+          structItems: [items]
+        }
+      };
       const ListWithManifest = withManifestAndPlayerProvider(List, {
-        initialManifestState: { ...initialManifestState, playlist: { isPlaylist: false } },
+        initialManifestState: { ...manifestState, playlist: { isPlaylist: false } },
         initialPlayerState: {},
         ...props
       });
@@ -129,8 +136,15 @@ describe('List component', () => {
       structureContainerRef,
       isPlaylist: false,
     };
+    const manifestState = {
+      ...initialManifestState,
+      structures: {
+        ...initialManifestState.structures,
+        structItems: [items]
+      }
+    };
     const ListWithManifest = withManifestAndPlayerProvider(List, {
-      initialManifestState: { ...initialManifestState, playlist: { isPlaylist: false } },
+      initialManifestState: { ...manifestState, playlist: { isPlaylist: false } },
       initialPlayerState: {},
       ...props
     });
@@ -162,9 +176,16 @@ describe('List component', () => {
       structureContainerRef,
       isPlaylist: true,
     };
+    const manifestState = {
+      ...initialManifestState,
+      structures: {
+        ...initialManifestState.structures,
+        structItems: [playlistItem]
+      }
+    };
     beforeEach(() => {
       const ListWithManifest = withManifestAndPlayerProvider(List, {
-        initialManifestState: { ...initialManifestState, playlist: { isPlaylist: true } },
+        initialManifestState: { ...manifestState, playlist: { isPlaylist: true } },
         initialPlayerState: {},
         ...props
       });

--- a/src/components/StructuredNavigation/NavUtils/SectionHeading.js
+++ b/src/components/StructuredNavigation/NavUtils/SectionHeading.js
@@ -30,12 +30,13 @@ const SectionHeading = ({
   sectionRef,
   structureContainerRef,
 }) => {
-  const { isCollapsed } = useCollapseExpandAll();
+  const { isCollapsed, updateSectionStatus } = useCollapseExpandAll();
   // root structure items are always expanded
   const [sectionIsCollapsed, setSectionIsCollapsed] = useState(isRoot ? false : true);
 
   const toggleOpen = () => {
     setSectionIsCollapsed(!sectionIsCollapsed);
+    updateSectionStatus(itemIndex - 1, !sectionIsCollapsed);
   };
 
   const { isActiveSection, canvasIndex, handleClick } = useActiveStructure({

--- a/src/components/StructuredNavigation/NavUtils/SectionHeading.js
+++ b/src/components/StructuredNavigation/NavUtils/SectionHeading.js
@@ -31,11 +31,17 @@ const SectionHeading = ({
   structureContainerRef,
 }) => {
   const { isCollapsed, updateSectionStatus } = useCollapseExpandAll();
-  // root structure items are always expanded
+  // Root structure items are always expanded
   const [sectionIsCollapsed, setSectionIsCollapsed] = useState(isRoot ? false : true);
 
   const toggleOpen = () => {
+    // Update collapse/expand status in the component state
     setSectionIsCollapsed(!sectionIsCollapsed);
+    /**
+     * Update section status in 'useCollapseExpandAll' hook, to keep track of
+     * collapse/expand statuses of each section in UI. When all these are manually updated,
+     * use it to change the 'isCollapsed' global state variable accordingly.
+     */
     updateSectionStatus(itemIndex - 1, !sectionIsCollapsed);
   };
 

--- a/src/services/ramp-hooks.js
+++ b/src/services/ramp-hooks.js
@@ -753,6 +753,7 @@ export const useCollapseExpandAll = () => {
   const updateSectionStatus = (index, status) => {
     updateSection(index, status);
 
+    // Convert global status into a string value
     const allSectionStatus = isCollapsed ? 'isCollapsed' : 'isExpanded';
 
     // Get all sections' statuses
@@ -760,7 +761,9 @@ export const useCollapseExpandAll = () => {
       .filter(c => c != undefined);
 
     if (eachSectionStatus?.length > 0) {
-      const allSectionsHaveChanged = eachSectionStatus.every(s => s === eachSectionStatus[0]);
+      // Check all sections have the same status
+      const allSectionsHaveChanged = eachSectionStatus
+        .every(s => s === eachSectionStatus[0]);
 
       // Update global state when all sections have been updated manually
       if (allSectionsHaveChanged && eachSectionStatus[0] != allSectionStatus) {
@@ -776,6 +779,7 @@ export const useCollapseExpandAll = () => {
    * @param {Boolean} status 
    */
   const updateSection = (index, status) => {
+    // Only update 'collapseStatus' property for sections with children
     if (collapsibleStructure[index]?.items?.length > 0) {
       collapsibleStructure[index].collapseStatus = status ? 'isCollapsed' : 'isExpanded';
     }


### PR DESCRIPTION
Related issue: #645 

Update collapse/expand all button when each section is changed manually:

https://github.com/user-attachments/assets/f66ec740-b8c2-47f1-9eaf-e1856be08053

Expand current section when playback status changes for it:

https://github.com/user-attachments/assets/7b455d27-6291-4517-b235-482b91e857d3




