### PR TITLE
Invoke handleTimeupdate to update markers on player reload

### DIFF
--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -226,6 +226,8 @@ function VideoJSPlayer({
      */
     player.on('loadeddata', function () {
       setIsReady(true);
+      // Invoke timeupdate handler to update fragmentMarkers in the progress-bar
+      handleTimeUpdate();
     });
     player.on('qualityRequested', (e, quality) => {
       setStartQuality(quality.label);


### PR DESCRIPTION
When switching between canvases the fragment markers do not get reset when player is paused. This creates overflowing fragment markers for the progress-bar. This was introduced when `setIsReady(true)` was moved from `loadedmetadata` event to `loadeddata` event to update playlist markers in Safari browsers (related PR: https://github.com/samvera-labs/ramp/pull/726).

Example: Load second section of https://avalon-dev.dlib.indiana.edu/media_objects/3j3332278

 <img width="1086" alt="Screenshot 2024-11-12 at 3 23 58 PM" src="https://github.com/user-attachments/assets/af363fe4-3b56-46f1-8fda-88f6f16e475b">
