### PR TITLE
Fix error message display and general parsing error for AVAnnotate manifests

### DIFF
--- a/src/components/MediaPlayer/MediaPlayer.js
+++ b/src/components/MediaPlayer/MediaPlayer.js
@@ -179,6 +179,11 @@ const MediaPlayer = ({
         sources: isMultiSourced
           ? [sources[srcIndex]]
           : sources,
+        errorDisplay: {
+          // If only one source is available and it is not playable remove 
+          // close button for the error modal dialog
+          uncloseable: sources?.length > 1 ? false : true,
+        },
       } : { ...defaultOptions, sources: [] };
   }, [isVideo, playerConfig, srcIndex]);
 

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -134,17 +134,25 @@ function VideoJSPlayer({
         player.controlBar.addClass('vjs-mobile-visible');
       }
 
-      player.muted(startMuted);
-      player.volume(startVolume);
-      player.canvasIndex = cIndexRef.current;
-      player.duration(canvasDuration);
-      player.srcIndex = srcIndex;
-      player.targets = targets;
+      /**
+       * When source is not supported in VideoJS handle re-direct the error to the
+       * custom function in the 'error' event handler in this code.
+       */
+      if (player.error()) {
+        player.trigger('error');
+      } else {
+        player.muted(startMuted);
+        player.volume(startVolume);
+        player.canvasIndex = cIndexRef.current;
+        player.duration(canvasDuration);
+        player.srcIndex = srcIndex;
+        player.targets = targets;
 
-      if (enableTitleLink) player.canvasLink = canvasLink;
+        if (enableTitleLink) player.canvasLink = canvasLink;
 
-      // Need to set this once experimentalSvgIcons option in Video.js options was enabled
-      player.getChild('controlBar').qualitySelector.setIcon('cog');
+        // Need to set this once experimentalSvgIcons option in Video.js options was enabled
+        player.getChild('controlBar').qualitySelector.setIcon('cog');
+      }
     });
 
     player.on('emptied', () => {

--- a/src/components/MediaPlayer/VideoJS/videojs-theme.scss
+++ b/src/components/MediaPlayer/VideoJS/videojs-theme.scss
@@ -156,3 +156,8 @@
 .vjs-theme-ramp .vjs-file-download .vjs-menu {
   left: -3.5em;
 }
+
+// Center error message horizontally in the error modal dialog
+.vjs-error-display.vjs-modal-dialog .vjs-modal-dialog-content {
+  padding: 20px 25%;
+}

--- a/src/context/manifest-context.js
+++ b/src/context/manifest-context.js
@@ -60,7 +60,8 @@ function manifestReducer(state = defaultState, action) {
       const manifestBehavior = parseAutoAdvance(manifest.behavior);
       const isPlaylist = getIsPlaylist(manifest.label);
       const annotationService = getAnnotationService(manifest.service);
-      const playlistMarkers = parsePlaylistAnnotations(manifest);
+      // Parse playlist markers only for playlist manifests
+      const playlistMarkers = isPlaylist ? parsePlaylistAnnotations(manifest) : [];
 
       return {
         ...state,


### PR DESCRIPTION
Related issue: #710 

The error message was displaying the in player, but it had a grey overlay on top of it without letting the user access the error message modal. This is because the error message was created by VideoJS instead of the override we've implemented in Ramp.
 
<img width="939" alt="Screenshot 2024-11-19 at 3 32 23 PM" src="https://github.com/user-attachments/assets/824c269c-c05d-47e4-9a84-1697f73144ab">


The fix in this PR catches `player.error()` in the `player.ready()` event handler and trigger the custom event handler for player errors. When there is only one source for the Canvas and VideoJS is facing issues playing it, the error display modal dialog is shown as non-dismiss-able modal by setting the following option for VideoJS;
```
errorDisplay: {
  uncloseable: sources?.length > 1 ? false : true,
}, ...
```

In addition to that, this PR adds a check in `manifest-context.js` for playlist manifests before trying to read `highlighting` annotations in a Manifest, as some AVAnnotate manifests fails to load without this check. 
Example manifest from AVAnnotate which had problem loading without this check:
- https://lgsump.github.io/maya-deren-example/meshes-of-the-afternoon/manifest.json
- https://tanyaclement.github.io/znh_jacksonville_1939/s1576-t86-244/manifest.json

This PR needs to be merged after #740, as the changes in parsing in the other PR are needed to load the manifests in this issue.