### PR TITLE
Display line breaks within a cue for WebVTT and SRT transcripts

### DIFF
--- a/src/services/transcript-parser.js
+++ b/src/services/transcript-parser.js
@@ -713,10 +713,15 @@ function groupTimedTextLines(lines) {
       t.line = isNote ? line.replace(/^NOTE\s*/, 'NOTE ') : '';
       i++;
 
+      // Counter to keep track of lines within a cue
+      let cueLineCount = 0;
       // Increment until an empty line is encountered marking the end of the block
       while (i < lines.length
         && !(lines[i] == '\r' || lines[i] == '\n' || lines[i] == '\r\n' || lines[i] == '')) {
+        // Add a line break only between lines within a cue, omit start and end of cue
+        if (cueLineCount > 0) t.line += '<br>';
         t.line += lines[i].endsWith('-') ? lines[i] : lines[i].replace(/\s*$/, ' ');
+        cueLineCount++;
         i++;
       }
       t.line = t.line.trimEnd();

--- a/src/services/transcript-parser.test.js
+++ b/src/services/transcript-parser.test.js
@@ -393,7 +393,7 @@ describe('transcript-parser', () => {
         {
           end: 26.6,
           begin: 22.2,
-          text: 'Just before lunch one day, a puppet show was put on at school.',
+          text: 'Just before lunch one day, a puppet show <br>was put on at school.',
           tag: 'TIMED_CUE'
         },
         {
@@ -411,7 +411,7 @@ describe('transcript-parser', () => {
         {
           end: 41.3,
           begin: 36.1,
-          text: "In the puppet show, Mr. Bungle came to the boys' room on his way to lunch.",
+          text: "In the puppet show, Mr. Bungle came to the <br>boys' room on his way to lunch.",
           tag: 'TIMED_CUE'
         },
       ];
@@ -442,7 +442,7 @@ describe('transcript-parser', () => {
           {
             end: 26.6,
             begin: 22.2,
-            text: 'Just before lunch one day, a puppet show was put on at school.',
+            text: 'Just before lunch one day, a puppet show <br>was put on at school.',
             tag: 'TIMED_CUE'
           },
           {
@@ -460,7 +460,7 @@ describe('transcript-parser', () => {
           {
             end: 41.3,
             begin: 36.1,
-            text: "In the puppet show, Mr. Bungle came to the boys' room on his way to lunch.",
+            text: "In the puppet show, Mr. Bungle came to the <br>boys' room on his way to lunch.",
             tag: 'TIMED_CUE'
           },
         ];
@@ -490,7 +490,7 @@ describe('transcript-parser', () => {
           {
             end: 26.6,
             begin: 22.2,
-            text: 'Just before lunch one day, a puppet show was put on at school.',
+            text: 'Just before lunch one day, a puppet show <br>was put on at school.',
             tag: 'TIMED_CUE'
           },
           {
@@ -508,7 +508,7 @@ describe('transcript-parser', () => {
           {
             end: 41.3,
             begin: 36.1,
-            text: "In the puppet show, Mr. Bungle came to the boys' room on his way to lunch.",
+            text: "In the puppet show, Mr. Bungle came to the <br>boys' room on his way to lunch.",
             tag: 'TIMED_CUE'
           },
         ];
@@ -762,7 +762,7 @@ describe('transcript-parser', () => {
             tag: 'TIMED_CUE'
           });
           expect(tData[4]).toEqual({
-            text: "In the puppet show, Mr. Bungle came to the boys' room on his way to lunch.",
+            text: "In the puppet show, Mr. Bungle came to the <br>boys' room on his way to lunch.",
             begin: 36.1,
             end: 41.3,
             tag: 'TIMED_CUE'
@@ -785,7 +785,7 @@ describe('transcript-parser', () => {
             tag: 'TIMED_CUE'
           });
           expect(tData[4]).toEqual({
-            text: "In the puppet show, Mr. Bungle came to the boys' room on his way to lunch.",
+            text: "In the puppet show, Mr. Bungle came to the <br>boys' room on his way to lunch.",
             begin: 36.1,
             end: 41.3,
             tag: 'TIMED_CUE'
@@ -808,7 +808,7 @@ describe('transcript-parser', () => {
             tag: 'TIMED_CUE'
           });
           expect(tData[4]).toEqual({
-            text: "In the puppet show, Mr. Bungle came to the boys' room on his way to lunch.",
+            text: "In the puppet show, Mr. Bungle came to the <br>boys' room on his way to lunch.",
             begin: 36.1,
             end: 41.3,
             tag: 'TIMED_CUE'
@@ -845,7 +845,7 @@ describe('transcript-parser', () => {
           tag: 'NOTE',
           begin: 0,
           end: 0,
-          text: 'NOTE This is a multi-line comment'
+          text: 'NOTE This is a multi-<br>line comment'
         });
         expect(tType).toEqual(transcriptParser.TRANSCRIPT_TYPES.timedText);
       });
@@ -859,13 +859,13 @@ describe('transcript-parser', () => {
 
         expect(tData).toHaveLength(5);
         expect(tData[1]).toEqual({
-          text: 'NOTE: Just before lunch one day, a puppet show was put on at school.',
+          text: 'NOTE: Just before lunch one day, a puppet show <br>was put on at school.',
           begin: 22.2,
           end: 26.6,
           tag: 'TIMED_CUE'
         });
         expect(tData[4]).toEqual({
-          text: 'In the puppet show, Mr. Bungle had a note to go to the boys\' room on his way to lunch.',
+          text: 'In the puppet show, Mr. Bungle had a <br>note to go to the boys\' room on his way to lunch.',
           begin: 36.1,
           end: 41.3,
           tag: 'TIMED_CUE'


### PR DESCRIPTION
Related issue: #750 

For the following WebVTT file the display looks as follows;
```
1
00:00:01.200 --> 00:00:21.000 region:fred align:left
[music]

NOTE End of music, and starting dialog

2
00:00:22.200 --> 00:00:26.600 region:bill align:right
<em>Just</em> before lunch one day, a puppet show 
was put on at school.

3
00:00:26.700 --> 00:00:31.500 region:fred align:left
It was called "Mister Bungle Goes to Lunch".

4
00:00:31.600 --> 00:00:34.500
It was fun to watch.

5
00:00:36.100 --> 00:00:41.300
In the puppet show, Mr. Bungle came to the 
boys' room on his way to lunch.

6
00:00:41.400 --> 00:00:46.200
He looked at his hands. His hands were dirty 
and his hair was messy.

7
00:00:46.300 --> 00:00:51.100
But Mr. Bungle didn't stop to wash his hands 
or comb his hair.
```

| Before  | After |
| ------------- | ------------- |
| <img width="562" alt="Screenshot 2024-12-17 at 10 11 40 AM" src="https://github.com/user-attachments/assets/8cc9fbf2-d915-4ccc-b9e9-07346b2b5d08" />  | <img width="562" alt="Screenshot 2024-12-17 at 10 11 06 AM" src="https://github.com/user-attachments/assets/f8674266-4803-4e32-ac25-f040e9b05146" />  |
