### PR TITLE
Convert data from linked annotations to the same data format

### DIFF
--- a/src/services/annotation-parser.test.js
+++ b/src/services/annotation-parser.test.js
@@ -363,14 +363,15 @@ describe('annotation-parser', () => {
       expect(label).toEqual('Default');
     });
 
-    test('returns annotations for AnnotationPage without TextualBody annotations', () => {
+    test('returns linked annotations for AnnotationPage without TextualBody annotations', () => {
       const { canvasIndex, annotationSets } = annotationParser.parseAnnotationSets(lunchroomManners, 0);
       expect(canvasIndex).toEqual(0);
       expect(annotationSets.length).toEqual(1);
 
-      const { items, label } = annotationSets[0];
-      expect(items.length).toEqual(1);
-      expect(label).toEqual('');
+      const { format, label, url } = annotationSets[0];
+      expect(label).toEqual('Captions in WebVTT format');
+      expect(format).toEqual('text/vtt');
+      expect(url).toEqual('https://example.com/manifest/lunchroom_manners.vtt');
     });
 
     test('returns AnnotationPage info for AnnotationPage without items property', () => {
@@ -441,9 +442,9 @@ describe('annotation-parser', () => {
       expect(items.length).toEqual(4);
       expect(items[0].motivation).toEqual(['commenting', 'tagging']);
       expect(items[0].id).toEqual('https://example.com/avannotate-test/canvas-1/canvas/page/1');
-      expect(items[0].times).toEqual({ start: 0, end: 39 });
+      expect(items[0].time).toEqual({ start: 0, end: 39 });
       expect(items[0].canvasId).toEqual('https://example.com/avannotate-test/canvas-1/canvas');
-      expect(items[0].body).toEqual([
+      expect(items[0].value).toEqual([
         { format: 'text/plain', purpose: ['commenting'], value: 'Men singing' },
         { format: 'text/plain', purpose: ['tagging'], value: 'Unknown' }]);
     });
@@ -469,13 +470,12 @@ describe('annotation-parser', () => {
       const items = annotationParser.parseAnnotationItems(annotations, 572.34);
       expect(items[0].motivation).toEqual(['supplementing']);
       expect(items[0].id).toEqual('https://example.com/manifest/lunchroom_manners/canvas/1/annotation/1');
-      expect(items[0].times).toBeUndefined();
+      expect(items[0].time).toBeUndefined();
       expect(items[0].canvasId).toEqual('https://example.com/manifest/lunchroom_manners/canvas/1');
-      expect(items[0].body).toEqual([{
+      expect(items[0].value).toEqual([{
         format: 'text/vtt',
-        value: 'Captions in WebVTT format',
+        label: 'Captions in WebVTT format',
         url: 'https://example.com/manifest/lunchroom_manners.vtt',
-        isExternal: true,
       }]);
     });
 
@@ -496,7 +496,7 @@ describe('annotation-parser', () => {
         const items = annotationParser.parseAnnotationItems(annotations, 809.0);
 
         expect(items.length).toEqual(1);
-        expect(items[0].body).toEqual([
+        expect(items[0].value).toEqual([
           { format: 'text/plain', purpose: ['commenting'], value: '[Inaudible]' },
           { format: 'text/plain', purpose: ['tagging'], value: 'Inaudible' }]);
       });
@@ -517,7 +517,7 @@ describe('annotation-parser', () => {
         const items = annotationParser.parseAnnotationItems(annotations, 809.0);
 
         expect(items.length).toEqual(1);
-        expect(items[0].body).toEqual([
+        expect(items[0].value).toEqual([
           { format: 'text/plain', purpose: ['commenting'], value: '[Inaudible]' },
           { format: 'text/plain', purpose: ['tagging'], value: 'Inaudible' }]);
       });
@@ -539,7 +539,7 @@ describe('annotation-parser', () => {
         ];
         const items = annotationParser.parseAnnotationItems(annotations, 809.0);
 
-        expect(items[0].times).toEqual({ start: 52, end: 60 });
+        expect(items[0].time).toEqual({ start: 52, end: 60 });
         expect(items[0].canvasId).toEqual('https://example.com/avannotate-test/canvas-1/canvas');
       });
 
@@ -573,7 +573,7 @@ describe('annotation-parser', () => {
         ];
         const items = annotationParser.parseAnnotationItems(annotations, 809.0);
 
-        expect(items[0].times).toEqual({ start: 52, end: 60 });
+        expect(items[0].time).toEqual({ start: 52, end: 60 });
         expect(items[0].canvasId).toEqual('https://example.com/avannotate-test/canvas-1/canvas');
       });
 
@@ -606,7 +606,7 @@ describe('annotation-parser', () => {
         ];
         const items = annotationParser.parseAnnotationItems(annotations, 809.0);
 
-        expect(items[0].times).toEqual({ start: 52, end: undefined });
+        expect(items[0].time).toEqual({ start: 52, end: undefined });
         expect(items[0].canvasId).toEqual('https://example.com/avannotate-test/canvas-1/canvas');
       });
     });
@@ -642,9 +642,9 @@ describe('annotation-parser', () => {
         expect(items[0]).toEqual({
           motivation: ['supplementing', 'commenting'],
           id: 'default-annotation-0.json',
-          times: { start: 2761.474609, end: 2764.772727 },
+          time: { start: 2761.474609, end: 2764.772727 },
           canvasId: 'http://example.com/s1576-t86-244/canvas-1/canvas',
-          body: [
+          value: [
             { format: 'text/plain', purpose: ['commenting'], value: 'Alabama Singleton. I am 33-years-old.' },
             { format: 'text/plain', purpose: ['tagging'], value: 'Default' }
           ]
@@ -656,9 +656,9 @@ describe('annotation-parser', () => {
         expect(items[1]).toEqual({
           motivation: ['supplementing', 'commenting'],
           id: 'default-annotation-1.json',
-          times: { start: 2766.438533, end: undefined },
+          time: { start: 2766.438533, end: undefined },
           canvasId: 'http://example.com/s1576-t86-244/canvas-1/canvas',
-          body: [
+          value: [
             { format: 'text/plain', purpose: ['commenting'], value: 'Savannah, GA' },
             { format: 'text/plain', purpose: ['tagging'], value: 'Default' }
           ]

--- a/src/services/ramp-hooks.js
+++ b/src/services/ramp-hooks.js
@@ -1006,7 +1006,7 @@ export const useTranscripts = ({
     } else {
       // Parse new transcript data from the given sources
       await Promise.resolve(
-        parseTranscriptData(url, canvasIndexRef.current, format)
+        parseTranscriptData(url, format, canvasIndexRef.current)
       ).then(function (value) {
         if (value != null) {
           const { tData, tUrl, tType, tFileExt } = value;

--- a/src/services/transcript-parser.js
+++ b/src/services/transcript-parser.js
@@ -243,11 +243,11 @@ export function groupByIndex(objectArray, indexKey, selectKey) {
  * doc viewer is rendered, IIIF manifest -> extract and parse transcript data
  * within the manifest.
  * @param {String} url URL of the transcript file selected
- * @param {Number} canvasIndex Current canvas rendered in the player
  * @param {String} format transcript file format read from Annotation
+ * @param {Number} canvasIndex Current canvas rendered in the player
  * @returns {Object}  Array of trancript data objects with download URL
  */
-export async function parseTranscriptData(url, canvasIndex, format) {
+export async function parseTranscriptData(url, format, canvasIndex) {
   let tData = [];
   let tUrl = url;
 
@@ -297,17 +297,17 @@ export async function parseTranscriptData(url, canvasIndex, format) {
     fileType = filteredExt.length > 0 ? urlExt : '';
   }
 
-  // Return empty array to display an error message
-  if (canvasIndex === undefined) {
-    return { tData, tUrl, tType: TRANSCRIPT_TYPES.noTranscript };
-  }
-
   let textData, textLines;
   switch (fileType) {
     case 'json':
       let jsonData = await fileData.json();
       if (jsonData?.type === 'Manifest') {
-        return parseManifestTranscript(jsonData, url, canvasIndex);
+        // Return empty array to display an error message
+        if (canvasIndex === undefined) {
+          return { tData, tUrl, tType: TRANSCRIPT_TYPES.noTranscript };
+        } else {
+          return parseManifestTranscript(jsonData, url, canvasIndex);
+        }
       } else {
         let json = parseJSONData(jsonData);
         return { tData: json.tData, tUrl, tType: json.tType, tFileExt: fileType };

--- a/src/services/transcript-parser.test.js
+++ b/src/services/transcript-parser.test.js
@@ -217,6 +217,7 @@ describe('transcript-parser', () => {
 
       const response = await transcriptParser.parseTranscriptData(
         'https://example.com/volleyball-for-boys.json',
+        'application/json',
         0
       );
 
@@ -257,6 +258,7 @@ describe('transcript-parser', () => {
 
       const response = await transcriptParser.parseTranscriptData(
         'https://example.com/transcript.json',
+        'application/json',
         0
       );
 
@@ -275,6 +277,7 @@ describe('transcript-parser', () => {
       });
       const response = await transcriptParser.parseTranscriptData(
         'https://example.com/transcript.json',
+        'application/json',
         0
       );
 
@@ -320,6 +323,7 @@ describe('transcript-parser', () => {
 
       const response = await transcriptParser.parseTranscriptData(
         'https://example.com/transcript.json',
+        'application/json',
         0
       );
 
@@ -337,6 +341,7 @@ describe('transcript-parser', () => {
       });
       const response = await transcriptParser.parseTranscriptData(
         'https://example.com/transcript.txt',
+        'text/plain',
         0
       );
 
@@ -370,6 +375,7 @@ describe('transcript-parser', () => {
 
       const response = await transcriptParser.parseTranscriptData(
         'https://example.com/transcript.docx',
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
         0
       );
 
@@ -418,6 +424,7 @@ describe('transcript-parser', () => {
 
       const response = await transcriptParser.parseTranscriptData(
         'https://example.com/transcript.vtt',
+        'text/vtt',
         0
       );
 
@@ -467,6 +474,7 @@ describe('transcript-parser', () => {
 
         const response = await transcriptParser.parseTranscriptData(
           'https://example.com/transcript.srt',
+          'text/srt',
           0
         );
 
@@ -515,6 +523,7 @@ describe('transcript-parser', () => {
 
         const response = await transcriptParser.parseTranscriptData(
           'https://example.com/transcript.srt',
+          'text/srt',
           0
         );
 
@@ -532,6 +541,7 @@ describe('transcript-parser', () => {
       });
       const response = await transcriptParser.parseTranscriptData(
         'https://example.com/transcript_image.png',
+        'image',
         0
       );
       expect(fetchImage).toHaveBeenCalledTimes(1);
@@ -547,6 +557,7 @@ describe('transcript-parser', () => {
       });
       const response = await transcriptParser.parseTranscriptData(
         'https://example.com/section/2/supplemental_files/12',
+        '',
         0
       );
       expect(fetchDoc).toHaveBeenCalledTimes(1);
@@ -563,6 +574,7 @@ describe('transcript-parser', () => {
 
       const response = await transcriptParser.parseTranscriptData(
         'htt://example.com/transcript.json',
+        'application/json',
         0
       );
 
@@ -578,8 +590,8 @@ describe('transcript-parser', () => {
 
       const response = await transcriptParser.parseTranscriptData(
         undefined,
-        0,
-        ''
+        '',
+        0
       );
 
       expect(fetchSpy).not.toHaveBeenCalled();
@@ -598,6 +610,7 @@ describe('transcript-parser', () => {
 
       const response = await transcriptParser.parseTranscriptData(
         'https://example.com/manifest.json',
+        'application/json',
         0
       );
 


### PR DESCRIPTION
This is not specifically related to parsing multiple TextualBody annotations, as this was covered in the work done in #431.
The changes in this PR converts the data parsed from any linked annotation resource which is not an AnnotationPage into the same data format expected in annotations.
Ramp parses these annotations into a very simple data format, which only has start time, end time, and text to be used in the Transcript component.
Related issue: #436 