### PR TITLE
Check player is not null before player.trigger('resize') event

### DIFF
--- a/src/services/ramp-hooks.js
+++ b/src/services/ramp-hooks.js
@@ -489,7 +489,9 @@ export const useVideoJSPlayer = ({
 
     // Listen for resize events on desktop browsers and trigger player.resize event
     window.addEventListener('resize', () => {
-      player.trigger('resize');
+      // Check if player is initialized before triggering resize event, especially helpful
+      // when switching the Manifest in the demo site without a page reload
+      if (player?.player_) player.trigger('resize');
     });
 
     /**
@@ -499,7 +501,9 @@ export const useVideoJSPlayer = ({
      */
     if (window.visualViewport) {
       window.visualViewport.addEventListener('resize', () => {
-        player.trigger('resize');
+        // Check if player is initialized before triggering resize event, especially helpful
+        // when switching the Manifest in the demo site without a page reload
+        if (player?.player_) player.trigger('resize');
       });
     }
   };


### PR DESCRIPTION
When switching manifests in demo site using `Set Manifest` form, the player instance is set to null momentarily. During this window `player.trigger('resize')` is getting called because, the resize event on window is fired when the component tree is cleared when manifest URL in the `Set Manifest` form is emptied or changed.

Adding this check prevents the code from trying to emit the 'resize' event on a null instance of the player causing the page to crash. However this doesn't break the resize functionality, as this function is called again when player instance is properly set.