### PR TITLE
Annotations functionalities

### DIFF
--- a/src/components/MarkersDisplay/Annotations/AnnotationLayerSelect.js
+++ b/src/components/MarkersDisplay/Annotations/AnnotationLayerSelect.js
@@ -5,7 +5,13 @@ import {
   parseExternalAnnotationResource
 } from '@Services/annotations-parser';
 
-const AnnotationLayerSelect = ({ annotationLayers = [], duration = 0, setDisplayedAnnotationLayers }) => {
+const AnnotationLayerSelect = ({
+  annotationLayers = [],
+  duration = 0,
+  setDisplayedAnnotationLayers,
+  setAutoScrollEnabled,
+  autoScrollEnabled,
+}) => {
   const [selectedAnnotationLayers, setSelectedAnnotationLayers] = useState([]);
   const [isOpen, setIsOpen] = useState(false);
   const [selectedAll, setSelectedAll] = useState(false);
@@ -105,7 +111,7 @@ const AnnotationLayerSelect = ({ annotationLayers = [], duration = 0, setDisplay
   };
 
   return (
-    <div className="ramp--annotatations__multi-select">
+    <div className="ramp--annotations__multi-select">
       <div className="ramp--annotations__multi-select-header" onClick={toggleDropdown}>
         {selectedAnnotationLayers.length > 0
           ? `${selectedAnnotationLayers.length} of ${annotationLayers.length} layers selected`
@@ -142,6 +148,20 @@ const AnnotationLayerSelect = ({ annotationLayers = [], duration = 0, setDisplay
           ))}
         </ul>
       )}
+      <div className="ramp--annotations__scroll" data-testid="annotations-scroll">
+        <input
+          type="checkbox"
+          id="scroll-check"
+          name="scrollcheck"
+          aria-checked={autoScrollEnabled}
+          title='Auto-scroll with media'
+          checked={autoScrollEnabled}
+          onChange={() => { setAutoScrollEnabled(!autoScrollEnabled); }}
+        />
+        <label htmlFor="scroll-check" title='Auto-scroll with media'>
+          Auto-scroll with media
+        </label>
+      </div>
     </div>
   );
 };
@@ -149,7 +169,9 @@ const AnnotationLayerSelect = ({ annotationLayers = [], duration = 0, setDisplay
 AnnotationLayerSelect.propTypes = {
   annotationLayers: PropTypes.array.isRequired,
   duration: PropTypes.number.isRequired,
-  setDisplayedAnnotationLayers: PropTypes.func.isRequired
+  setDisplayedAnnotationLayers: PropTypes.func.isRequired,
+  setAutoScrollEnabled: PropTypes.func.isRequired,
+  autoScrollEnabled: PropTypes.bool.isRequired,
 };
 
 export default AnnotationLayerSelect;

--- a/src/components/MarkersDisplay/Annotations/AnnotationLayerSelect.js
+++ b/src/components/MarkersDisplay/Annotations/AnnotationLayerSelect.js
@@ -110,60 +110,64 @@ const AnnotationLayerSelect = ({
     setDisplayedAnnotationLayers((prev) => [...prev, annotationLayer]);
   };
 
-  return (
-    <div className="ramp--annotations__multi-select">
-      <div className="ramp--annotations__multi-select-header" onClick={toggleDropdown}>
-        {selectedAnnotationLayers.length > 0
-          ? `${selectedAnnotationLayers.length} of ${annotationLayers.length} layers selected`
-          : "Select Annotation layer(s)"}
-        <span className={`annotations-dropdown-arrow ${isOpen ? "open" : ""}`}>▼</span>
+  if (annotationLayers?.length > 0) {
+    return (
+      <div className="ramp--annotations__multi-select" data-testid="annotation-multi-select">
+        <div className="ramp--annotations__multi-select-header" onClick={toggleDropdown}>
+          {selectedAnnotationLayers.length > 0
+            ? `${selectedAnnotationLayers.length} of ${annotationLayers.length} layers selected`
+            : "Select Annotation layer(s)"}
+          <span className={`annotations-dropdown-arrow ${isOpen ? "open" : ""}`}>▼</span>
+        </div>
+        {isOpen && (
+          <ul className="annotations-dropdown-menu">
+            {
+              // Only show select all option when there's more than one annotation layer
+              annotationLayers?.length > 1 &&
+              <li key="select-all" className="annotations-dropdown-item">
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={selectedAll}
+                    onChange={handleSelectAll}
+                  />
+                  Show all Annotation layers
+                </label>
+              </li>
+            }
+            {annotationLayers.map((annotationLayer, index) => (
+              <li key={`annotaion-layer-${index}`} className="annotations-dropdown-item">
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={isSelected(annotationLayer)}
+                    onChange={() => handleSelect(annotationLayer)}
+                  />
+                  {annotationLayer.label}
+                </label>
+              </li>
+            ))}
+          </ul>
+        )}
+        <div className="ramp--annotations__scroll" data-testid="annotations-scroll">
+          <input
+            type="checkbox"
+            id="scroll-check"
+            name="scrollcheck"
+            aria-checked={autoScrollEnabled}
+            title='Auto-scroll with media'
+            checked={autoScrollEnabled}
+            onChange={() => { setAutoScrollEnabled(!autoScrollEnabled); }}
+          />
+          <label htmlFor="scroll-check" title='Auto-scroll with media'>
+            Auto-scroll with media
+          </label>
+        </div>
       </div>
-      {isOpen && (
-        <ul className="annotations-dropdown-menu">
-          {
-            // Only show select all option when there's more than one annotation layer
-            annotationLayers?.length > 1 &&
-            <li key="select-all" className="annotations-dropdown-item">
-              <label>
-                <input
-                  type="checkbox"
-                  checked={selectedAll}
-                  onChange={handleSelectAll}
-                />
-                Show all Annotation layers
-              </label>
-            </li>
-          }
-          {annotationLayers.map((annotationLayer, index) => (
-            <li key={`annotaion-layer-${index}`} className="annotations-dropdown-item">
-              <label>
-                <input
-                  type="checkbox"
-                  checked={isSelected(annotationLayer)}
-                  onChange={() => handleSelect(annotationLayer)}
-                />
-                {annotationLayer.label}
-              </label>
-            </li>
-          ))}
-        </ul>
-      )}
-      <div className="ramp--annotations__scroll" data-testid="annotations-scroll">
-        <input
-          type="checkbox"
-          id="scroll-check"
-          name="scrollcheck"
-          aria-checked={autoScrollEnabled}
-          title='Auto-scroll with media'
-          checked={autoScrollEnabled}
-          onChange={() => { setAutoScrollEnabled(!autoScrollEnabled); }}
-        />
-        <label htmlFor="scroll-check" title='Auto-scroll with media'>
-          Auto-scroll with media
-        </label>
-      </div>
-    </div>
-  );
+    );
+  } else {
+    return null;
+  }
 };
 
 AnnotationLayerSelect.propTypes = {

--- a/src/components/MarkersDisplay/Annotations/AnnotationLayerSelect.test.js
+++ b/src/components/MarkersDisplay/Annotations/AnnotationLayerSelect.test.js
@@ -1,0 +1,434 @@
+import React from 'react';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import AnnotationLayerSelect from './AnnotationLayerSelect';
+import * as annotationParser from '@Services/annotations-parser';
+
+const annotationLayers = [
+  {
+    label: 'Unknown',
+    format: 'application/json',
+    url: 'http://example.com/manifestannotation-page/unknown.json',
+  },
+  {
+    label: 'Songs',
+    format: 'application/json',
+    url: 'http://example.com/manifestannotation-page/songs.json',
+    items: [],
+  },
+  {
+    label: 'Texts',
+    format: 'application/json',
+    url: 'http://example.com/manifestannotation-page/texts.json',
+    items: [],
+  }
+];
+
+const linkedAnnotationLayers = [
+  {
+    canvasId: 'http://example.com/manifestcanvas/1',
+    format: 'text/vtt',
+    id: 'http://example.com/manifestcanvas/1/annotation-page/1/annotation/1',
+    label: 'Captions in English.vtt',
+    linkedResource: true,
+    motivation: ['supplementing'],
+    url: 'http://example.com/manifestfiles/captions-in-english.vtt',
+    items: [],
+  },
+  {
+    canvasId: 'http://example.com/manifestcanvas/1',
+    format: 'text/srt',
+    id: 'http://example.com/manifestcanvas/1/annotation-page/1/annotation/2',
+    label: 'Subtitle in English.srt',
+    linkedResource: true,
+    motivation: ['supplementing'],
+    url: 'http://example.com/manifestfiles/subtitles-in-english.srt',
+  },
+];
+
+const annotationPageResponse = {
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  "id": "http://example.com/manifestannotations/unknown.json",
+  "type": "AnnotationPage", "label": "Unknown",
+  "items": [
+    {
+      "@context": "http://www.w3.org/ns/anno.jsonld",
+      "id": "unknown-annotation-1.json",
+      "type": "Annotation",
+      "motivation": ["supplementing", "commenting"],
+      "body": [
+        { "type": "TextualBody", "value": "Savannah, GA", "format": "text/plain", "purpose": "commenting" },
+        { "type": "TextualBody", "value": "Unknown", "format": "text/plain", "purpose": "tagging" }
+      ],
+      "target": {
+        "source": {
+          "id": "http://example.com/manifest/canvas-1/canvas",
+          "type": "Canvas",
+        },
+        "selector": { "type": "PointSelector", "t": "2766.438533" }
+      }
+    },
+    {
+      "@context": "http://www.w3.org/ns/anno.jsonld",
+      "id": "unknown-annotation-2.json",
+      "type": "Annotation",
+      "motivation": ["supplementing", "commenting"],
+      "body": [
+        { "type": "TextualBody", "value": "A play that we used to play when we were children in Savannah.", "format": "text/plain", "purpose": "commenting" },
+        { "type": "TextualBody", "value": "Unknown", "format": "text/plain", "purpose": "tagging" }
+      ],
+      "target": {
+        "source": {
+          "id": "http://example.com/manifest/canvas-1/canvas",
+          "type": "Canvas",
+        },
+        "selector": {
+          "type": "FragmentSelector",
+          "conformsTo": "http://www.w3.org/TR/media-frags/",
+          "value": "t=2771.900826,2775.619835"
+        }
+      }
+    },
+    {
+      "@context": "http://www.w3.org/ns/anno.jsonld",
+      "id": "unknown-annotation-3.json",
+      "type": "Annotation",
+      "motivation": ["supplementing", "commenting"],
+      "body": [
+        { "type": "TextualBody", "value": "A ring play, just a ring play, a children's ring play", "format": "text/plain", "purpose": "commenting" },
+        { "type": "TextualBody", "value": "Unknown", "format": "text/plain", "purpose": "tagging" }
+      ],
+      "target": {
+        "source": {
+          "id": "http://example.com/manifest/canvas-1/canvas",
+          "type": "Canvas",
+        },
+        "selector": {
+          "type": "FragmentSelector",
+          "conformsTo": "http://www.w3.org/TR/media-frags/",
+          "value": "t=2779.493802,2782.438017"
+        }
+      }
+    }
+  ]
+};
+
+describe('AnnotationLayerSelect component', () => {
+  const setAutoScrollEnabledMock = jest.fn();
+  const setDisplayedAnnotationLayersMock = jest.fn();
+
+  test('displays nothing when there are no annotation layers', () => {
+    render(<AnnotationLayerSelect
+      annotationLayers={[]}
+      duration={0}
+      setDisplayedAnnotationLayers={setDisplayedAnnotationLayersMock}
+      setAutoScrollEnabled={setAutoScrollEnabledMock}
+      autoScrollEnabled={true}
+    />);
+
+    expect(screen.queryByTestId('annotation-multi-select')).not.toBeInTheDocument();
+  });
+
+  describe('displays', () => {
+    beforeEach(() => {
+      render(<AnnotationLayerSelect
+        annotationLayers={annotationLayers}
+        duration={572.34}
+        setDisplayedAnnotationLayers={setDisplayedAnnotationLayersMock}
+        setAutoScrollEnabled={setAutoScrollEnabledMock}
+        autoScrollEnabled={true}
+      />);
+    });
+
+    test('a multi-select box and a checkbox for auto-scroll on initial load', () => {
+      expect(screen.queryByTestId('annotation-multi-select')).toBeInTheDocument();
+      const multiSelect = screen.getByTestId('annotation-multi-select');
+      // Displays only multi select box and auto-scroll checkbox on initial load
+      expect(multiSelect.childNodes[0]).toHaveClass('ramp--annotations__multi-select-header');
+      expect(multiSelect.childNodes[0]).toHaveTextContent('1 of 3 layers selected▼');
+      expect(multiSelect.childNodes[1]).toHaveClass('ramp--annotations__scroll');
+      expect(multiSelect.childNodes[1]).toHaveTextContent('Auto-scroll with media');
+    });
+
+    test('a list of annotation layers on click', () => {
+      expect(screen.queryByTestId('annotation-multi-select')).toBeInTheDocument();
+      const multiSelect = screen.getByTestId('annotation-multi-select');
+      const multiSelectHeader = multiSelect.childNodes[0];
+      expect(multiSelectHeader).toHaveTextContent('1 of 3 layers selected▼');
+
+      fireEvent.click(multiSelectHeader);
+
+      expect(multiSelect.childNodes[1].tagName).toEqual('UL');
+      expect(multiSelect.childNodes[1].childNodes.length).toEqual(4);
+    });
+
+    test('\'Show all Annotation layers\' option on top', () => {
+      expect(screen.queryByTestId('annotation-multi-select')).toBeInTheDocument();
+      const multiSelect = screen.getByTestId('annotation-multi-select');
+      const multiSelectHeader = multiSelect.childNodes[0];
+      expect(multiSelectHeader).toHaveTextContent('1 of 3 layers selected▼');
+
+      fireEvent.click(multiSelectHeader);
+
+      expect(multiSelect.childNodes[1].childNodes.length).toEqual(4);
+      expect(multiSelect.childNodes[1].childNodes[0]).toHaveTextContent('Show all Annotation layers');
+    });
+
+    test('list of annotation layers in alphabetical order', () => {
+      expect(screen.queryByTestId('annotation-multi-select')).toBeInTheDocument();
+      const multiSelect = screen.getByTestId('annotation-multi-select');
+      const multiSelectHeader = multiSelect.childNodes[0];
+      expect(multiSelectHeader).toHaveTextContent('1 of 3 layers selected▼');
+
+      fireEvent.click(multiSelectHeader);
+
+      const annotationList = multiSelect.childNodes[1];
+      expect(annotationList.childNodes.length).toEqual(4);
+      expect(annotationList.childNodes[1]).toHaveTextContent('Songs');
+      expect(annotationList.childNodes[2]).toHaveTextContent('Texts');
+    });
+
+    test('the first annotation layer as selected by default', () => {
+      expect(screen.queryByTestId('annotation-multi-select')).toBeInTheDocument();
+      const multiSelect = screen.getByTestId('annotation-multi-select');
+      const multiSelectHeader = multiSelect.childNodes[0];
+      expect(multiSelectHeader).toHaveTextContent('1 of 3 layers selected▼');
+
+      fireEvent.click(multiSelectHeader);
+
+      const annotationList = multiSelect.childNodes[1];
+      expect(annotationList.childNodes.length).toEqual(4);
+      expect(annotationList.childNodes[1]).toHaveTextContent('Songs');
+      expect(within(annotationList.childNodes[1]).getByRole('checkbox')).toBeChecked();
+
+      expect(annotationList.childNodes[2]).toHaveTextContent('Texts');
+      expect(within(annotationList.childNodes[2]).getByRole('checkbox')).not.toBeChecked();
+    });
+  });
+
+  test('displays annotations options for linked resources', () => {
+    render(<AnnotationLayerSelect
+      annotationLayers={linkedAnnotationLayers}
+      duration={572.34}
+      setDisplayedAnnotationLayers={setDisplayedAnnotationLayersMock}
+      setAutoScrollEnabled={setAutoScrollEnabledMock}
+      autoScrollEnabled={true}
+    />);
+
+    expect(screen.queryByTestId('annotation-multi-select')).toBeInTheDocument();
+    const multiSelect = screen.getByTestId('annotation-multi-select');
+    const multiSelectHeader = multiSelect.childNodes[0];
+    expect(multiSelectHeader).toHaveTextContent('1 of 2 layers selected▼');
+
+    fireEvent.click(multiSelectHeader);
+
+    expect(multiSelect.childNodes[1].tagName).toEqual('UL');
+    expect(multiSelect.childNodes[1].childNodes.length).toEqual(3);
+  });
+
+  describe('\'Show all Annotation layers\' option', () => {
+    test('is displayed when more than 1 annotation layer is present', () => {
+      render(<AnnotationLayerSelect
+        annotationLayers={annotationLayers}
+        duration={572.34}
+        setDisplayedAnnotationLayers={setDisplayedAnnotationLayersMock}
+        setAutoScrollEnabled={setAutoScrollEnabledMock}
+        autoScrollEnabled={true}
+      />);
+      expect(screen.queryByTestId('annotation-multi-select')).toBeInTheDocument();
+      const multiSelect = screen.getByTestId('annotation-multi-select');
+      const multiSelectHeader = multiSelect.childNodes[0];
+      expect(multiSelectHeader).toHaveTextContent('1 of 3 layers selected▼');
+
+      fireEvent.click(multiSelectHeader);
+
+      expect(multiSelect.childNodes[1].tagName).toEqual('UL');
+      expect(multiSelect.childNodes[1].childNodes.length).toEqual(4);
+      expect(screen.getByText('Show all Annotation layers')).toBeInTheDocument();
+      expect(screen.getByText('Songs')).toBeInTheDocument();
+    });
+
+    test('is not displayed when there is one annotation layer', () => {
+      render(<AnnotationLayerSelect
+        annotationLayers={[{
+          label: 'Unknown',
+          format: 'application/json',
+          url: 'http://example.com/manifestannotation-page/unknown.json',
+          items: [],
+        }]}
+        duration={572.34}
+        setDisplayedAnnotationLayers={setDisplayedAnnotationLayersMock}
+        setAutoScrollEnabled={setAutoScrollEnabledMock}
+        autoScrollEnabled={true}
+      />);
+      expect(screen.queryByTestId('annotation-multi-select')).toBeInTheDocument();
+      const multiSelect = screen.getByTestId('annotation-multi-select');
+      const multiSelectHeader = multiSelect.childNodes[0];
+      expect(multiSelectHeader).toHaveTextContent('1 of 1 layers selected▼');
+
+      fireEvent.click(multiSelectHeader);
+
+      expect(multiSelect.childNodes[1].tagName).toEqual('UL');
+      expect(multiSelect.childNodes[1].childNodes.length).toEqual(1);
+      expect(screen.queryByText('Show all Annotation layers')).not.toBeInTheDocument();
+      expect(screen.getByText('Unknown')).toBeInTheDocument();
+    });
+  });
+
+  describe('updates the annotation selection when', () => {
+    test('an annotation layer representing an external AnnotationPage is selected', async () => {
+      const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+        status: 201,
+        ok: true,
+        json: jest.fn(() => { return annotationPageResponse; })
+      });
+
+      render(<AnnotationLayerSelect
+        annotationLayers={annotationLayers}
+        duration={572.34}
+        setDisplayedAnnotationLayers={setDisplayedAnnotationLayersMock}
+        setAutoScrollEnabled={setAutoScrollEnabledMock}
+        autoScrollEnabled={true}
+      />);
+
+      expect(screen.queryByTestId('annotation-multi-select')).toBeInTheDocument();
+      const multiSelect = screen.getByTestId('annotation-multi-select');
+      const multiSelectHeader = multiSelect.childNodes[0];
+
+      // Open the annotation layers list dropdown
+      fireEvent.click(multiSelectHeader);
+
+      const annotationLlist = multiSelect.childNodes[1];
+      // Check the annotation layer with label 'Texts' is not selected
+      expect(multiSelectHeader).toHaveTextContent('1 of 3 layers selected▼');
+      expect(annotationLlist.childNodes[3]).toHaveTextContent('Unknown');
+      expect(within(annotationLlist.childNodes[3]).getByRole('checkbox')).not.toBeChecked();
+
+      const checkBox = screen.queryAllByRole('checkbox')[3];
+
+      // Wrap in act() to ensure all state updates are processed before assertions are run.
+      // Select the 'Unknown' annotation layer from list
+      await act(() => {
+        fireEvent.click(checkBox);
+      });
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(multiSelectHeader).toHaveTextContent('2 of 3 layers selected▼');
+    });
+
+    test('an annotation layer representing a linked WebVTT resource is selected', async () => {
+      const mockResponse =
+        'WEBVTT\r\n\r\n1\r\n00:00:01.200 --> 00:00:21.000\n[music]\n\r\n2\r\n00:00:22.200 --> 00:00:26.600\nJust before lunch one day, a puppet show \nwas put on at school.\n\r\n3\r\n00:00:26.700 --> 00:00:31.500\nIt was called "Mister Bungle Goes to Lunch".\n\r\n4\r\n00:00:31.600 --> 00:00:34.500\nIt was fun to watch.\n\r\n5\r\n00:00:36.100 --> 00:00:41.300\nIn the puppet show, Mr. Bungle came to the \nboys\' room on his way to lunch.\n';
+      const fetchWebVTT = jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+        status: 200,
+        ok: true,
+        headers: { get: jest.fn(() => 'text/vtt') },
+        text: jest.fn(() => mockResponse),
+      });
+      const parseExternalAnnotationResourceMock = jest
+        .spyOn(annotationParser, 'parseExternalAnnotationResource');
+
+      render(<AnnotationLayerSelect
+        annotationLayers={linkedAnnotationLayers}
+        duration={572.34}
+        setDisplayedAnnotationLayers={setDisplayedAnnotationLayersMock}
+        setAutoScrollEnabled={setAutoScrollEnabledMock}
+        autoScrollEnabled={true}
+      />);
+
+      expect(screen.queryByTestId('annotation-multi-select')).toBeInTheDocument();
+      const multiSelect = screen.getByTestId('annotation-multi-select');
+      const multiSelectHeader = multiSelect.childNodes[0];
+
+      // Open the annotation layers list dropdown
+      fireEvent.click(multiSelectHeader);
+
+      const annotationLlist = multiSelect.childNodes[1];
+
+      // Check the annotation layer with label 'Subtitle in English.srt' is not selected
+      expect(multiSelectHeader).toHaveTextContent('1 of 2 layers selected▼');
+      expect(annotationLlist.childNodes[2]).toHaveTextContent('Subtitle in English.srt');
+      expect(within(annotationLlist.childNodes[2]).getByRole('checkbox')).not.toBeChecked();
+
+      const checkBox = screen.queryAllByRole('checkbox')[2];
+
+      // Wrap in act() to ensure all state updates are processed before assertions are run.
+      // Select the 'Subtitle in English.srt' annotation layer from list
+      await act(() => {
+        fireEvent.click(checkBox);
+      });
+
+      expect(parseExternalAnnotationResourceMock).toHaveBeenCalledTimes(1);
+      expect(fetchWebVTT).toHaveBeenCalledTimes(1);
+      expect(multiSelectHeader).toHaveTextContent('2 of 2 layers selected▼');
+    });
+
+    test('\'Show all Annotation layers\' option is selected', async () => {
+      render(<AnnotationLayerSelect
+        annotationLayers={annotationLayers}
+        duration={572.34}
+        setDisplayedAnnotationLayers={setDisplayedAnnotationLayersMock}
+        setAutoScrollEnabled={setAutoScrollEnabledMock}
+        autoScrollEnabled={true}
+      />);
+
+      expect(screen.queryByTestId('annotation-multi-select')).toBeInTheDocument();
+      const multiSelect = screen.getByTestId('annotation-multi-select');
+      const multiSelectHeader = multiSelect.childNodes[0];
+
+      // Open the annotation layers list dropdown
+      fireEvent.click(multiSelectHeader);
+
+      const annotationLlist = multiSelect.childNodes[1];
+      // Check 'Show all Annotation layers' option is not selected
+      expect(multiSelectHeader).toHaveTextContent('1 of 3 layers selected▼');
+      expect(annotationLlist.childNodes[0]).toHaveTextContent('Show all Annotation layers');
+      expect(within(annotationLlist.childNodes[0]).getByRole('checkbox')).not.toBeChecked();
+
+      const checkBox = screen.queryAllByRole('checkbox')[0];
+
+      // Wrap in act() to ensure all state updates are processed before assertions are run.
+      // Select the 'Show all Annotation layers' annotation layer from list
+      await act(() => {
+        fireEvent.click(checkBox);
+      });
+
+      // Dropdown list for annotation layers collapses
+      expect(screen.queryByText('Show all Annotation layers')).not.toBeInTheDocument();
+      expect(screen.queryByText('Songs')).not.toBeInTheDocument();
+
+      // Text in the select box shows all layers are selected
+      expect(multiSelectHeader).toHaveTextContent('3 of 3 layers selected▼');
+    });
+  });
+
+  describe('\'Auto-scroll with media\' checkbox', () => {
+    beforeEach(() => {
+      render(<AnnotationLayerSelect
+        annotationLayers={annotationLayers}
+        duration={572.34}
+        setDisplayedAnnotationLayers={setDisplayedAnnotationLayersMock}
+        setAutoScrollEnabled={setAutoScrollEnabledMock}
+        autoScrollEnabled={true}
+      />);
+    });
+
+    test('is displayed checked on initial load', () => {
+      expect(screen.queryByTestId('annotation-multi-select')).toBeInTheDocument();
+
+      const checkBox = screen.getByTestId('annotation-multi-select').childNodes[1];
+      expect(checkBox).toHaveClass('ramp--annotations__scroll');
+      expect(checkBox).toHaveTextContent('Auto-scroll with media');
+      expect(within(checkBox).getByRole('checkbox')).toBeChecked();
+    });
+
+    test('calls \'setAutoScrollEnabled\' when clicked', () => {
+      const checkBox = screen.getByTestId('annotation-multi-select').childNodes[1];
+      expect(checkBox).toHaveClass('ramp--annotations__scroll');
+      expect(checkBox).toHaveTextContent('Auto-scroll with media');
+
+      fireEvent.click(within(checkBox).getByRole('checkbox'));
+
+      expect(setAutoScrollEnabledMock).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/components/MarkersDisplay/Annotations/AnnotationLayerSelect.test.js
+++ b/src/components/MarkersDisplay/Annotations/AnnotationLayerSelect.test.js
@@ -11,9 +11,30 @@ const annotationLayers = [
   },
   {
     label: 'Songs',
-    format: 'application/json',
-    url: 'http://example.com/manifestannotation-page/songs.json',
-    items: [],
+    items: [{
+      id: 'songs-annotation-0',
+      canvasId: 'http://example.com/manifest/canvas/1',
+      motivation: ['supplementing', 'tagging'],
+      time: { start: 7, end: undefined },
+      value: [{ format: 'text/plain', purpose: ['supplementing'], value: 'Men singing' },
+      { format: 'text/plain', purpose: ['tagging'], value: 'Songs' }]
+    },
+    {
+      id: 'songs-annotation-1',
+      canvasId: 'http://example.com/manifest/canvas/1',
+      motivation: ['supplementing', 'tagging'],
+      time: { start: 25.32, end: 27.65 },
+      value: [{ format: 'text/plain', purpose: ['supplementing'], value: 'The Yale Glee Club singing "Mother of Men"' },
+      { format: 'text/plain', purpose: ['tagging'], value: 'Songs' }]
+    },
+    {
+      id: 'songs-annotation-2',
+      canvasId: 'http://example.com/manifest/canvas/1',
+      motivation: ['supplementing', 'tagging'],
+      time: { start: 29.54, end: 45.32 },
+      value: [{ format: 'text/plain', purpose: ['supplementing'], value: '<strong>Subjects</strong>: Singing' },
+      { format: 'text/plain', purpose: ['tagging'], value: 'Songs' }]
+    }],
   },
   {
     label: 'Texts',
@@ -32,7 +53,29 @@ const linkedAnnotationLayers = [
     linkedResource: true,
     motivation: ['supplementing'],
     url: 'http://example.com/manifestfiles/captions-in-english.vtt',
-    items: [],
+    items: [
+      {
+        id: 'http://example.com/manifest/canvas/1/annotation-page/1/annotation/1',
+        canvasId: 'http://example.com/manifest/canvas/1',
+        motivation: ['supplementing'],
+        time: { start: 7, end: undefined },
+        value: [{ format: 'text/plain', purpose: ['supplementing'], value: 'Men singing' }]
+      },
+      {
+        id: 'http://example.com/manifest/canvas/1/annotation-page/1/annotation/1',
+        canvasId: 'http://example.com/manifest/canvas/1',
+        motivation: ['supplementing'],
+        time: { start: 25.32, end: 27.65 },
+        value: [{ format: 'text/plain', purpose: ['supplementing'], value: 'The Yale Glee Club singing "Mother of Men"' }]
+      },
+      {
+        id: 'http://example.com/manifest/canvas/1/annotation-page/1/annotation/1',
+        canvasId: 'http://example.com/manifest/canvas/1',
+        motivation: ['supplementing'],
+        time: { start: 29.54, end: 45.32 },
+        value: [{ format: 'text/plain', purpose: ['supplementing'], value: '<strong>Subjects</strong>: Singing' }]
+      }
+    ],
   },
   {
     canvasId: 'http://example.com/manifestcanvas/1',
@@ -118,7 +161,7 @@ describe('AnnotationLayerSelect component', () => {
 
   test('displays nothing when there are no annotation layers', () => {
     render(<AnnotationLayerSelect
-      annotationLayers={[]}
+      canvasAnnotationLayers={[]}
       duration={0}
       setDisplayedAnnotationLayers={setDisplayedAnnotationLayersMock}
       setAutoScrollEnabled={setAutoScrollEnabledMock}
@@ -131,7 +174,7 @@ describe('AnnotationLayerSelect component', () => {
   describe('displays', () => {
     beforeEach(() => {
       render(<AnnotationLayerSelect
-        annotationLayers={annotationLayers}
+        canvasAnnotationLayers={annotationLayers}
         duration={572.34}
         setDisplayedAnnotationLayers={setDisplayedAnnotationLayersMock}
         setAutoScrollEnabled={setAutoScrollEnabledMock}
@@ -207,7 +250,7 @@ describe('AnnotationLayerSelect component', () => {
 
   test('displays annotations options for linked resources', () => {
     render(<AnnotationLayerSelect
-      annotationLayers={linkedAnnotationLayers}
+      canvasAnnotationLayers={linkedAnnotationLayers}
       duration={572.34}
       setDisplayedAnnotationLayers={setDisplayedAnnotationLayersMock}
       setAutoScrollEnabled={setAutoScrollEnabledMock}
@@ -228,7 +271,7 @@ describe('AnnotationLayerSelect component', () => {
   describe('\'Show all Annotation layers\' option', () => {
     test('is displayed when more than 1 annotation layer is present', () => {
       render(<AnnotationLayerSelect
-        annotationLayers={annotationLayers}
+        canvasAnnotationLayers={annotationLayers}
         duration={572.34}
         setDisplayedAnnotationLayers={setDisplayedAnnotationLayersMock}
         setAutoScrollEnabled={setAutoScrollEnabledMock}
@@ -249,12 +292,17 @@ describe('AnnotationLayerSelect component', () => {
 
     test('is not displayed when there is one annotation layer', () => {
       render(<AnnotationLayerSelect
-        annotationLayers={[{
-          label: 'Unknown',
-          format: 'application/json',
-          url: 'http://example.com/manifestannotation-page/unknown.json',
-          items: [],
-        }]}
+        canvasAnnotationLayers={[{
+          label: 'Songs',
+          items: [{
+            id: 'songs-annotation-0',
+            canvasId: 'http://example.com/manifest/canvas/1',
+            motivation: ['supplementing', 'tagging'],
+            time: { start: 7, end: undefined },
+            value: [{ format: 'text/plain', purpose: ['supplementing'], value: 'Men singing' },
+            { format: 'text/plain', purpose: ['tagging'], value: 'Songs' }]
+          }],
+        },]}
         duration={572.34}
         setDisplayedAnnotationLayers={setDisplayedAnnotationLayersMock}
         setAutoScrollEnabled={setAutoScrollEnabledMock}
@@ -270,7 +318,7 @@ describe('AnnotationLayerSelect component', () => {
       expect(multiSelect.childNodes[1].tagName).toEqual('UL');
       expect(multiSelect.childNodes[1].childNodes.length).toEqual(1);
       expect(screen.queryByText('Show all Annotation layers')).not.toBeInTheDocument();
-      expect(screen.getByText('Unknown')).toBeInTheDocument();
+      expect(screen.getByText('Songs')).toBeInTheDocument();
     });
   });
 
@@ -283,7 +331,7 @@ describe('AnnotationLayerSelect component', () => {
       });
 
       render(<AnnotationLayerSelect
-        annotationLayers={annotationLayers}
+        canvasAnnotationLayers={annotationLayers}
         duration={572.34}
         setDisplayedAnnotationLayers={setDisplayedAnnotationLayersMock}
         setAutoScrollEnabled={setAutoScrollEnabledMock}
@@ -328,7 +376,7 @@ describe('AnnotationLayerSelect component', () => {
         .spyOn(annotationParser, 'parseExternalAnnotationResource');
 
       render(<AnnotationLayerSelect
-        annotationLayers={linkedAnnotationLayers}
+        canvasAnnotationLayers={linkedAnnotationLayers}
         duration={572.34}
         setDisplayedAnnotationLayers={setDisplayedAnnotationLayersMock}
         setAutoScrollEnabled={setAutoScrollEnabledMock}
@@ -363,8 +411,11 @@ describe('AnnotationLayerSelect component', () => {
     });
 
     test('\'Show all Annotation layers\' option is selected', async () => {
+      jest.spyOn(annotationParser, 'parseExternalAnnotationPage')
+        .mockResolvedValue([{}]);
+
       render(<AnnotationLayerSelect
-        annotationLayers={annotationLayers}
+        canvasAnnotationLayers={annotationLayers}
         duration={572.34}
         setDisplayedAnnotationLayers={setDisplayedAnnotationLayersMock}
         setAutoScrollEnabled={setAutoScrollEnabledMock}
@@ -395,7 +446,6 @@ describe('AnnotationLayerSelect component', () => {
       // Dropdown list for annotation layers collapses
       expect(screen.queryByText('Show all Annotation layers')).not.toBeInTheDocument();
       expect(screen.queryByText('Songs')).not.toBeInTheDocument();
-
       // Text in the select box shows all layers are selected
       expect(multiSelectHeader).toHaveTextContent('3 of 3 layers selected▼');
     });
@@ -404,7 +454,7 @@ describe('AnnotationLayerSelect component', () => {
   describe('\'Auto-scroll with media\' checkbox', () => {
     beforeEach(() => {
       render(<AnnotationLayerSelect
-        annotationLayers={annotationLayers}
+        canvasAnnotationLayers={annotationLayers}
         duration={572.34}
         setDisplayedAnnotationLayers={setDisplayedAnnotationLayersMock}
         setAutoScrollEnabled={setAutoScrollEnabledMock}

--- a/src/components/MarkersDisplay/Annotations/AnnotationRow.js
+++ b/src/components/MarkersDisplay/Annotations/AnnotationRow.js
@@ -1,15 +1,20 @@
 
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
-import { timeToHHmmss } from '@Services/utility-helpers';
+import cx from 'classnames';
+import { autoScroll, timeToHHmmss } from '@Services/utility-helpers';
 import { useAnnotations, useMediaPlayer } from '@Services/ramp-hooks';
+import { SUPPORTED_MOTIVATIONS } from '@Services/annotations-parser';
 
-const AnnotationRow = ({ annotation, displayMotivations }) => {
+const AnnotationRow = ({ annotation, displayMotivations, autoScrollEnabled, containerRef }) => {
   const { id, canvasId, motivation, time, value } = annotation;
-  const { start, end } = time;
 
-  const { player } = useMediaPlayer();
+  const [isActive, setIsActive] = useState(false);
+
+  const { player, currentTime } = useMediaPlayer();
   const { checkCanvas } = useAnnotations({ canvasId });
+
+  const annotationRef = useRef(null);
 
   /**
    * Display only the annotations with at least one of the specified motivations
@@ -24,25 +29,44 @@ const AnnotationRow = ({ annotation, displayMotivations }) => {
   }, [annotation]);
 
   /**
-   * Seek the player to;
+   * When there multiple annotations in the same time range, auto-scroll to
+   * the annotation with the start time that is closest to the current time
+   * of the player.
+   * This allows a better user experience when auto-scroll is enabled during playback, 
+   * and there are multiple annotations that falls within the same time range.
+   */
+  useEffect(() => {
+    if (Math.floor(time?.start) === Math.floor(currentTime)) {
+      setIsActive(true);
+      autoScrollEnabled && autoScroll(annotationRef.current, containerRef, true);
+    } else {
+      setIsActive(false);
+    }
+  }, [currentTime]);
+
+  /**
+   * Click event handler for annotations displayed.
+   * An annotation can have links embedded in the text; and the click event's
+   * target is a link, then open the link in the same page.
+   * If the click event's target is the text or the timestamp of the
+   * annotation, then seek the player to;
    * - start time of an Annotation with a time range
-   * - timestamp of an Annotation with a single time-point
-   * on click event on each Annotation
+   * - timestamp of an Annotation with a single time-point.
    */
   const handleOnClick = useCallback((e) => {
     e.preventDefault();
     checkCanvas();
-    const currentTime = start;
+    const currTime = time?.start;
     if (player) {
       const { start, end } = player.targets[0];
       switch (true) {
-        case currentTime >= start && currentTime <= end:
-          player.currentTime(currentTime);
+        case currTime >= start && currTime <= end:
+          player.currentTime(currTime);
           break;
-        case currentTime < start:
+        case currTime < start:
           player.currentTime(start);
           break;
-        case currentTime > end:
+        case currTime > end:
           player.currentTime(end);
           break;
       }
@@ -51,35 +75,37 @@ const AnnotationRow = ({ annotation, displayMotivations }) => {
 
   // Annotations with purpose tagging are displayed as tags next to time
   const tags = value.filter((v) => v.purpose.includes('tagging'));
-  // Annotations with purpose commenting/supplementing are displayed as text
+  // Annotations with purpose commenting/supplementing/transcribing are displayed as text
   const texts = value.filter(
-    (v) => v.purpose.includes('commenting') || v.purpose.includes('supplementing')
+    (v) => SUPPORTED_MOTIVATIONS.some(m => v.purpose.includes(m))
   );
 
   if (canDisplay) {
     return (
       <li
         key={`li_${id}`}
+        ref={annotationRef}
         onClick={handleOnClick}
         data-testid="annotation-row"
-        className="ramp--annotations__annotation-row"
+        className={cx(
+          "ramp--annotations__annotation-row",
+          isActive && 'active'
+        )}
       >
         <div key={`row_${id}`} className="ramp--annotations__annotation-row-time-tags">
           <div key={`times_${id}`} className="ramp--annotations__annotation-times">
-            {start != undefined && (
+            {time?.start != undefined && (
               <span
                 className="ramp--annotations__annotation-start-time"
-                data-testid="annotation-start-time"
-              >
-                {timeToHHmmss(start, true)}
+                data-testid="annotation-start-time">
+                {timeToHHmmss(time?.start, true, true)}
               </span>
             )}
-            {end != undefined && (
+            {time?.end != undefined && (
               <span
                 className="ramp--annotations__annotation-end-time"
-                data-testid="annotation-end-time"
-              >
-                {` - ${timeToHHmmss(end, true)}`}
+                data-testid="annotation-end-time">
+                {` - ${timeToHHmmss(time?.end, true, true)}`}
               </span>
             )}
           </div>
@@ -115,6 +141,8 @@ const AnnotationRow = ({ annotation, displayMotivations }) => {
 AnnotationRow.propTypes = {
   annotation: PropTypes.object.isRequired,
   displayMotivations: PropTypes.array.isRequired,
+  autoScrollEnabled: PropTypes.bool.isRequired,
+  containerRef: PropTypes.object.isRequired,
 };
 
 export default AnnotationRow;

--- a/src/components/MarkersDisplay/Annotations/AnnotationRow.js
+++ b/src/components/MarkersDisplay/Annotations/AnnotationRow.js
@@ -115,6 +115,7 @@ const AnnotationRow = ({ annotation, displayMotivations, autoScrollEnabled, cont
                 <p
                   key={`tag_${index}`}
                   className="ramp--annotations__annotation-tag"
+                  data-testid={`annotation-tag-${index}`}
                   style={{ backgroundColor: tag.tagColor }}>
                   {tag.value}
                 </p>
@@ -127,6 +128,7 @@ const AnnotationRow = ({ annotation, displayMotivations, autoScrollEnabled, cont
             <p
               key={`text_${index}`}
               className="ramp--annotations__annotation-text"
+              data-testid={`annotation-text-${index}`}
               dangerouslySetInnerHTML={{ __html: text.value }}>
             </p>
           );

--- a/src/components/MarkersDisplay/Annotations/AnnotationRow.test.js
+++ b/src/components/MarkersDisplay/Annotations/AnnotationRow.test.js
@@ -1,0 +1,218 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import AnnotationRow from './AnnotationRow';
+import * as hooks from '@Services/ramp-hooks';
+
+describe('AnnotationRow component', () => {
+  const checkCanvasMock = jest.fn();
+  const playerCurrentTimeMock = jest.fn((time) => { return time; });
+  // Mock custom hook output
+  jest.spyOn(hooks, 'useMediaPlayer').mockImplementation(() => ({
+    currentTime: 0,
+    player: { currentTime: playerCurrentTimeMock, targets: [{ start: 10.23, end: 100.34 }] }
+  }));
+  jest.spyOn(hooks, 'useAnnotations').mockImplementation(() => ({
+    checkCanvas: checkCanvasMock
+  }));
+  const containerRef = { current: document.createElement('div') };
+  const props = { displayMotivations: [], autoScrollEnabled: true, containerRef };
+
+  describe('with displayMotivations=[] (default)', () => {
+    test('displays annotation with \'supplementing\' motivation', () => {
+      const annotation = {
+        id: 'http://example.com/manifest/canvas/1/annotation-page/1/annotation/1',
+        canvasId: 'http://example.com/manifest/canvas/1',
+        motivation: ['supplementing'],
+        time: { start: 0, end: 10 },
+        value: [{ format: 'text/plain', purpose: ['supplementing'], value: 'Men singing' }]
+      };
+      render(<AnnotationRow {...props} annotation={annotation} />);
+
+      expect(screen.getByTestId('annotation-row')).toBeInTheDocument();
+      expect(screen.getByText('Men singing')).toBeInTheDocument();
+      expect(screen.queryAllByTestId(/annotation-tag-*/).length).toBe(0);
+      expect(screen.getByTestId('annotation-start-time')).toHaveTextContent('00:00:00.000');
+      expect(screen.getByTestId('annotation-end-time')).toHaveTextContent('00:00:10.000');
+    });
+
+    test('displays annotation with \'commenting\' motivation', () => {
+      const annotation = {
+        id: 'http://example.com/manifest/canvas/1/annotation-page/1/annotation/1',
+        canvasId: 'http://example.com/manifest/canvas/1',
+        motivation: ['commenting'],
+        time: { start: 10, end: undefined },
+        value: [{ format: 'text/plain', purpose: ['commenting'], value: 'Men singing' }]
+      };
+      render(<AnnotationRow {...props} annotation={annotation} />);
+
+      expect(screen.getByTestId('annotation-row')).toBeInTheDocument();
+      expect(screen.getByText('Men singing')).toBeInTheDocument();
+      expect(screen.queryAllByTestId(/annotation-tag-*/).length).toBe(0);
+      expect(screen.getByTestId('annotation-start-time')).toHaveTextContent('00:00:10.000');
+      expect(screen.queryByTestId('annotation-end-time')).not.toBeInTheDocument();
+    });
+
+    describe('displays annotation tags for annotation with \'tagging\'', () => {
+      test('and \'supplementing\' motivations', () => {
+        const annotation = {
+          id: 'http://example.com/manifest/canvas/1/annotation-page/1/annotation/1',
+          canvasId: 'http://example.com/manifest/canvas/1',
+          motivation: ['supplementing', 'tagging'],
+          time: { start: 0, end: 10 },
+          value: [{ format: 'text/plain', purpose: ['supplementing'], value: 'Men singing' },
+          { format: 'text/plain', purpose: ['tagging'], value: 'Music' }]
+        };
+        render(<AnnotationRow {...props} annotation={annotation} />);
+
+        expect(screen.getByTestId('annotation-row')).toBeInTheDocument();
+        expect(screen.getByText('Men singing')).toBeInTheDocument();
+        expect(screen.queryAllByTestId(/annotation-tag-*/).length).toBe(1);
+        expect(screen.getByTestId('annotation-tag-0')).toHaveTextContent('Music');
+        expect(screen.getByTestId('annotation-start-time')).toHaveTextContent('00:00:00.000');
+        expect(screen.getByTestId('annotation-end-time')).toHaveTextContent('00:00:10.000');
+      });
+
+      test('and \'commenting\' motivations', () => {
+        const annotation = {
+          id: 'http://example.com/manifest/canvas/1/annotation-page/1/annotation/1',
+          canvasId: 'http://example.com/manifest/canvas/1',
+          motivation: ['commenting', 'tagging'],
+          time: { start: 10, end: undefined },
+          value: [{ format: 'text/plain', purpose: ['commenting'], value: 'Men singing' },
+          { format: 'text/plain', purpose: ['tagging'], value: 'Music' }]
+        };
+        render(<AnnotationRow {...props} annotation={annotation} />);
+
+        expect(screen.getByTestId('annotation-row')).toBeInTheDocument();
+        expect(screen.getByText('Men singing')).toBeInTheDocument();
+        expect(screen.queryAllByTestId(/annotation-tag-*/).length).toBe(1);
+        expect(screen.getByTestId('annotation-tag-0')).toHaveTextContent('Music');
+        expect(screen.getByTestId('annotation-start-time')).toHaveTextContent('00:00:10.000');
+        expect(screen.queryByTestId('annotation-end-time')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  test('displays HTML tags in the annotation textual body', () => {
+    const annotation = {
+      id: 'http://example.com/manifest/canvas/1/annotation-page/1/annotation/1',
+      canvasId: 'http://example.com/manifest/canvas/1',
+      motivation: ['commenting', 'tagging'],
+      time: { start: 10, end: undefined },
+      value: [{ format: 'text/plain', purpose: ['commenting'], value: '<strong>Men</strong> singing' },
+      { format: 'text/plain', purpose: ['tagging'], value: 'Music' }]
+    };
+    render(<AnnotationRow {...props} annotation={annotation} />);
+
+    expect(screen.getByTestId('annotation-row')).toBeInTheDocument();
+    // Do not display only plain text
+    expect(screen.queryByText('Men singing')).not.toBeInTheDocument();
+    // Displays text with inline HTML
+    expect(screen.queryByTestId('annotation-text-0')).toBeInTheDocument();
+    expect(screen.getByTestId('annotation-text-0').childNodes[0].tagName).toBe('STRONG');
+    expect(screen.getByTestId('annotation-text-0')).toHaveTextContent('Men singing');
+  });
+
+  describe('with displayMotivations=[\'supplementing\']', () => {
+    test('displays annotation with \'supplementing\' motivation', () => {
+      const annotation = {
+        id: 'http://example.com/manifest/canvas/1/annotation-page/1/annotation/1',
+        canvasId: 'http://example.com/manifest/canvas/1',
+        motivation: ['supplementing', 'tagging'],
+        time: { start: 0, end: 10 },
+        value: [{ format: 'text/plain', purpose: ['supplementing'], value: 'Men singing' },
+        { format: 'text/plain', purpose: ['tagging'], value: 'Music' }]
+      };
+      render(<AnnotationRow {...props}
+        annotation={annotation}
+        displayMotivations={['supplementing']}
+      />);
+
+      expect(screen.getByTestId('annotation-row')).toBeInTheDocument();
+      expect(screen.getByText('Men singing')).toBeInTheDocument();
+      expect(screen.queryAllByTestId(/annotation-tag-*/).length).toBe(1);
+      expect(screen.getByTestId('annotation-tag-0')).toHaveTextContent('Music');
+      expect(screen.getByTestId('annotation-start-time')).toHaveTextContent('00:00:00.000');
+      expect(screen.getByTestId('annotation-end-time')).toHaveTextContent('00:00:10.000');
+    });
+
+    test('does not display annotation with \'commenting\' motivation', () => {
+      const annotation = {
+        id: 'http://example.com/manifest/canvas/1/annotation-page/1/annotation/1',
+        canvasId: 'http://example.com/manifest/canvas/1',
+        motivation: ['commenting'],
+        time: { start: 10, end: undefined },
+        value: [{ format: 'text/plain', purpose: ['commenting'], value: 'Men singing' }]
+      };
+      render(<AnnotationRow
+        {...props}
+        annotation={annotation} displayMotivations={['supplementing']}
+      />);
+      expect(screen.queryByTestId('annotation-row')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('clicking an annotation row', () => {
+    const annotation = {
+      id: 'http://example.com/manifest/canvas/1/annotation-page/1/annotation/1',
+      canvasId: 'http://example.com/manifest/canvas/1',
+      motivation: ['supplementing', 'tagging'],
+      time: { start: 25.32, end: 45.65 },
+      value: [{ format: 'text/plain', purpose: ['supplementing'], value: 'Men singing' },
+      { format: 'text/plain', purpose: ['tagging'], value: 'Music' }]
+    };
+    test('sets player\'s currentTime when time is within the duration of the media', () => {
+      render(<AnnotationRow
+        {...props}
+        annotation={{ ...annotation, time: { start: 25.32, end: 45.65 } }}
+      />);
+
+      expect(screen.getByTestId('annotation-row')).toBeInTheDocument();
+      expect(screen.getByTestId('annotation-text-0')).toHaveTextContent('Men singing');
+      expect(screen.getByTestId('annotation-tag-0')).toHaveTextContent('Music');
+      expect(screen.getByTestId('annotation-start-time')).toHaveTextContent('00:00:25.32');
+      expect(screen.getByTestId('annotation-end-time')).toHaveTextContent('00:00:45.65');
+
+      fireEvent.click(screen.getByTestId('annotation-row'));
+
+      expect(playerCurrentTimeMock).toHaveBeenCalledTimes(1);
+      expect(playerCurrentTimeMock).toHaveBeenCalledWith(25.32);
+    });
+
+    test('sets player to start of the media when annotation start time < media start time', () => {
+      render(<AnnotationRow
+        {...props}
+        annotation={{ ...annotation, time: { start: 0, end: 10 } }}
+      />);
+
+      expect(screen.getByTestId('annotation-row')).toBeInTheDocument();
+      expect(screen.getByTestId('annotation-text-0')).toHaveTextContent('Men singing');
+      expect(screen.getByTestId('annotation-tag-0')).toHaveTextContent('Music');
+      expect(screen.getByTestId('annotation-start-time')).toHaveTextContent('00:00:00.000');
+      expect(screen.getByTestId('annotation-end-time')).toHaveTextContent('00:00:10.000');
+
+      fireEvent.click(screen.getByTestId('annotation-row'));
+
+      expect(playerCurrentTimeMock).toHaveBeenCalledTimes(1);
+      expect(playerCurrentTimeMock).toHaveBeenCalledWith(10.23);
+    });
+
+    test('sets player to end of the media when annotation start time > media duration', () => {
+      render(<AnnotationRow
+        {...props}
+        annotation={{ ...annotation, time: { start: 101.32, end: 110.56 } }}
+      />);
+
+      expect(screen.getByTestId('annotation-row')).toBeInTheDocument();
+      expect(screen.getByTestId('annotation-text-0')).toHaveTextContent('Men singing');
+      expect(screen.getByTestId('annotation-tag-0')).toHaveTextContent('Music');
+      expect(screen.getByTestId('annotation-start-time')).toHaveTextContent('00:01:41.32');
+      expect(screen.getByTestId('annotation-end-time')).toHaveTextContent('00:01:50.56');
+
+      fireEvent.click(screen.getByTestId('annotation-row'));
+
+      expect(playerCurrentTimeMock).toHaveBeenCalledTimes(1);
+      expect(playerCurrentTimeMock).toHaveBeenCalledWith(100.34);
+    });
+  });
+});

--- a/src/components/MarkersDisplay/Annotations/AnnotationsDisplay.js
+++ b/src/components/MarkersDisplay/Annotations/AnnotationsDisplay.js
@@ -116,7 +116,7 @@ const AnnotationsDisplay = ({ annotations, canvasIndex, duration, displayMotivat
       setAutoScrollEnabled={setAutoScrollEnabled}
       autoScrollEnabled={autoScrollEnabled}
     />);
-  }, [canvasAnnotationLayers]);
+  }, [autoScrollEnabled, canvasAnnotationLayers]);
 
   const annotationRows = useMemo(() => {
     if (isLoading) {
@@ -149,7 +149,7 @@ const AnnotationsDisplay = ({ annotations, canvasIndex, duration, displayMotivat
         );
       }
     }
-  }, [hasDisplayAnnotations, displayedAnnotations, isLoading]);
+  }, [hasDisplayAnnotations, displayedAnnotations, isLoading, autoScrollEnabled]);
 
   if (canvasAnnotationLayers?.length > 0) {
     return (

--- a/src/components/MarkersDisplay/Annotations/AnnotationsDisplay.js
+++ b/src/components/MarkersDisplay/Annotations/AnnotationsDisplay.js
@@ -4,11 +4,13 @@ import AnnotationLayerSelect from './AnnotationLayerSelect';
 import '../MarkersDisplay.scss';
 import AnnotationRow from './AnnotationRow';
 import { sortAnnotations } from '@Services/utility-helpers';
+import Spinner from '@Components/Spinner';
 
 const AnnotationsDisplay = ({ annotations, canvasIndex, duration, displayMotivations }) => {
   const [canvasAnnotationLayers, setCanvasAnnotationLayers] = useState([]);
   const [displayedAnnotationLayers, setDisplayedAnnotationLayers] = useState([]);
   const [autoScrollEnabled, setAutoScrollEnabled] = useState(true);
+  const [isLoading, setIsLoading] = useState(true);
 
   const annotationDisplayRef = useRef(null);
 
@@ -16,6 +18,9 @@ const AnnotationsDisplay = ({ annotations, canvasIndex, duration, displayMotivat
    * Update annotation sets for the current Canvas
    */
   useEffect(() => {
+    // Re-set isLoading on Canvas change
+    setIsLoading(true);
+
     if (annotations?.length > 0) {
       const { _, annotationSets } = annotations
         .filter((a) => a.canvasIndex === canvasIndex)[0];
@@ -35,25 +40,77 @@ const AnnotationsDisplay = ({ annotations, canvasIndex, duration, displayMotivat
   }, [displayedAnnotationLayers]);
 
   /**
+   * Identify any of the displayed annotation layers have linked resource(s).
+   * This value is used to initiate a delayed state update to the 'isLoading'
+   * variable, to stop displaying a no annotations message while fetch requests
+   * are in progress.
+   */
+  const hasExternalAnnotations = useMemo(() => {
+    return displayedAnnotationLayers?.length > 0
+      ? displayedAnnotationLayers.map((a) => a.linkedResource).reduce((acc, curr) => {
+        return acc || curr;
+      }, false)
+      : false;
+  }, [displayedAnnotationLayers]);
+
+  /**
+   * Set timeout function with an AbortController
+   * @param {Function} callback 
+   * @param {Number} delay milliseconds number to wait
+   * @param {Object} signal abort signal from AbortController
+   */
+  const setTimeoutWithAbort = (callback, delay, signal) => {
+    if (signal?.aborted) { return; }
+    const timeOutId = setTimeout(() => {
+      if (!signal?.aborted) { callback(); }
+    }, delay);
+    // Listener to abort signal to clear existing timeout
+    signal?.addEventListener('abort', () => {
+      clearTimeout(timeOutId);
+    });
+  };
+
+  /**
    * Check if the annotations related to the Canvas have motivation(s) specified
    * by the user when the component is initialized.
    * If none of the annotations in the Canvas has at least one the specified
    * motivation(s), then a message is displayed to the user.
    */
   const hasDisplayAnnotations = useMemo(() => {
+    // AbortController for timeout function to toggle 'isLoading'
+    let abortController;
     if (displayedAnnotations?.length > 0 && displayedAnnotations[0] != undefined) {
+      // If annotations are read before executing the timeout in the else condition,
+      // abort the timeout
+      abortController?.abort();
+      // Once annotations are present remove the Spinner
+      setIsLoading(false);
       const motivations = displayedAnnotations.map((a) => a.motivation);
       return displayMotivations?.length > 0
         ? displayMotivations.some(m => motivations.flat().includes(m))
         : true;
     } else {
+      // Abort existing abortControll before creating a new one
+      abortController?.abort();
+      /**
+       * Initiate a delayed call to toggle 'isLoading' with an abortController.
+       * This allows the UI to wait for annotations from any linked resources before 
+       * displaying a no annotations message while the fetch requests are in progress.
+       */
+      abortController = new AbortController();
+      if (hasExternalAnnotations) {
+        setTimeoutWithAbort(() => {
+          setIsLoading(false);
+        }, 500, abortController.signal);
+      }
       return false;
     }
   }, [displayedAnnotations]);
 
   const annotationLayerSelect = useMemo(() => {
     return (<AnnotationLayerSelect
-      annotationLayers={canvasAnnotationLayers}
+      key={canvasIndex}
+      canvasAnnotationLayers={canvasAnnotationLayers}
       duration={duration}
       setDisplayedAnnotationLayers={setDisplayedAnnotationLayers}
       setAutoScrollEnabled={setAutoScrollEnabled}
@@ -62,22 +119,37 @@ const AnnotationsDisplay = ({ annotations, canvasIndex, duration, displayMotivat
   }, [canvasAnnotationLayers]);
 
   const annotationRows = useMemo(() => {
-    if (displayedAnnotations?.length > 0) {
-      return (<ul>
-        {displayedAnnotations.map((annotation, index) => {
-          return (<AnnotationRow
-            key={index}
-            annotation={annotation}
-            displayMotivations={displayMotivations}
-            autoScrollEnabled={autoScrollEnabled}
-            containerRef={annotationDisplayRef}
-          />);
-        })}
-      </ul>);
+    if (isLoading) {
+      return <Spinner />;
     } else {
-      return null;
+      if (hasDisplayAnnotations && displayedAnnotations?.length > 0) {
+        return (
+          <ul>
+            {displayedAnnotations.map((annotation, index) => {
+              return (
+                <AnnotationRow
+                  key={index}
+                  annotation={annotation}
+                  displayMotivations={displayMotivations}
+                  autoScrollEnabled={autoScrollEnabled}
+                  containerRef={annotationDisplayRef}
+                  displayedAnnotations={displayedAnnotations}
+                />
+              );
+            })}
+          </ul>
+        );
+      } else {
+        return (
+          <p data-testid="no-annotations-message">
+            {displayMotivations?.length > 0
+              ? `No Annotations were found with ${displayMotivations.join('/')} motivation.`
+              : 'No Annotations were found for the selected layer(s).'}
+          </p>
+        );
+      }
     }
-  }, [hasDisplayAnnotations, displayedAnnotations]);
+  }, [hasDisplayAnnotations, displayedAnnotations, isLoading]);
 
   if (canvasAnnotationLayers?.length > 0) {
     return (
@@ -89,19 +161,16 @@ const AnnotationsDisplay = ({ annotations, canvasIndex, duration, displayMotivat
         </div>
         <div className="ramp--annotations__content"
           data-testid="annotations-content" tabIndex={0} ref={annotationDisplayRef}>
-          {hasDisplayAnnotations && displayedAnnotations != undefined && annotationRows}
-          {!hasDisplayAnnotations && displayedAnnotations?.length === 0 && (
-            <p data-testid="no-annotations-message">
-              {displayMotivations?.length > 0
-                ? `No Annotations were found with ${displayMotivations.join('/')} motivation.`
-                : 'No Annotations were found in the selected layer(s).'}
-            </p>
-          )}
+          {annotationRows}
         </div>
       </div>
     );
   } else {
-    return null;
+    return (
+      <p data-testid="no-annotation-layers-message">
+        No Annotations layers were found for the Canvas.
+      </p>
+    );
   }
 };
 

--- a/src/components/MarkersDisplay/Annotations/AnnotationsDisplay.js
+++ b/src/components/MarkersDisplay/Annotations/AnnotationsDisplay.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import AnnotationLayerSelect from './AnnotationLayerSelect';
 import '../MarkersDisplay.scss';
@@ -8,6 +8,9 @@ import { sortAnnotations } from '@Services/utility-helpers';
 const AnnotationsDisplay = ({ annotations, canvasIndex, duration, displayMotivations }) => {
   const [canvasAnnotationLayers, setCanvasAnnotationLayers] = useState([]);
   const [displayedAnnotationLayers, setDisplayedAnnotationLayers] = useState([]);
+  const [autoScrollEnabled, setAutoScrollEnabled] = useState(true);
+
+  const annotationDisplayRef = useRef(null);
 
   /**
    * Filter and merge annotations parsed from either an AnnotationPage or a linked
@@ -56,22 +59,27 @@ const AnnotationsDisplay = ({ annotations, canvasIndex, duration, displayMotivat
             annotationLayers={canvasAnnotationLayers}
             duration={duration}
             setDisplayedAnnotationLayers={setDisplayedAnnotationLayers}
+            setAutoScrollEnabled={setAutoScrollEnabled}
+            autoScrollEnabled={autoScrollEnabled}
           />
         </div>
-        <div className="ramp--annotations__content" tabIndex={0}>
-          {hasDisplayAnnotations && displayedAnnotations != undefined && displayedAnnotations?.length > 0 && (
-            <ul>
-              {displayedAnnotations.map((annotation, index) => {
-                return (
-                  <AnnotationRow
-                    key={index}
-                    annotation={annotation}
-                    displayMotivations={displayMotivations}
-                  />
-                );
-              })}
-            </ul>
-          )
+        <div className="ramp--annotations__content" tabIndex={0} ref={annotationDisplayRef}>
+          {hasDisplayAnnotations && displayedAnnotations != undefined
+            && displayedAnnotations?.length > 0 && (
+              <ul>
+                {displayedAnnotations.map((annotation, index) => {
+                  return (
+                    <AnnotationRow
+                      key={index}
+                      annotation={annotation}
+                      displayMotivations={displayMotivations}
+                      autoScrollEnabled={autoScrollEnabled}
+                      containerRef={annotationDisplayRef}
+                    />
+                  );
+                })}
+              </ul>
+            )
           }
           {!hasDisplayAnnotations && displayMotivations?.length != 0 && (
             <p>{`No Annotations with ${displayMotivations.join('/')} motivation.`}</p>

--- a/src/components/MarkersDisplay/Annotations/AnnotationsDisplay.test.js
+++ b/src/components/MarkersDisplay/Annotations/AnnotationsDisplay.test.js
@@ -1,0 +1,298 @@
+import React from 'react';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import AnnotationsDisplay from './AnnotationsDisplay';
+import * as hooks from '@Services/ramp-hooks';
+
+const linkedAnnotationLayers = [
+  {
+    canvasIndex: 0,
+    annotationSets: [
+      {
+        canvasId: 'http://example.com/manifestcanvas/1',
+        format: 'text/vtt',
+        id: 'http://example.com/manifestcanvas/1/annotation-page/1/annotation/1',
+        label: 'Captions in English.vtt',
+        linkedResource: true,
+        motivation: ['supplementing'],
+        url: 'http://example.com/manifestfiles/captions-in-english.vtt',
+        items: [],
+      },
+      {
+        canvasId: 'http://example.com/manifestcanvas/1',
+        format: 'text/srt',
+        id: 'http://example.com/manifestcanvas/1/annotation-page/1/annotation/2',
+        label: 'Subtitle in English.srt',
+        linkedResource: true,
+        motivation: ['supplementing'],
+        url: 'http://example.com/manifestfiles/subtitles-in-english.srt',
+      },
+    ]
+  },
+  {
+    canvasIndex: 1,
+    annotationSets: []
+  }
+];
+
+const annotationLayers = [
+  {
+    canvasIndex: 0,
+    annotationSets: [
+      {
+        label: 'Unknown',
+        format: 'application/json',
+        url: 'http://example.com/manifestannotation-page/unknown.json',
+      },
+      {
+        label: 'Songs',
+        format: 'application/json',
+        url: 'http://example.com/manifestannotation-page/songs.json',
+        items: [],
+      },
+      {
+        label: 'Texts',
+        format: 'application/json',
+        url: 'http://example.com/manifestannotation-page/texts.json',
+        items: [],
+      }
+    ]
+  }
+];
+
+const annotationPageResponse = {
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  "id": "http://example.com/manifestannotations/unknown.json",
+  "type": "AnnotationPage", "label": "Unknown",
+  "items": [
+    {
+      "@context": "http://www.w3.org/ns/anno.jsonld",
+      "id": "unknown-annotation-1.json",
+      "type": "Annotation",
+      "motivation": ["commenting"],
+      "body": [
+        { "type": "TextualBody", "value": "Savannah, GA", "format": "text/plain", "purpose": "commenting" },
+        { "type": "TextualBody", "value": "Unknown", "format": "text/plain", "purpose": "tagging" }
+      ],
+      "target": {
+        "source": {
+          "id": "http://example.com/manifest/canvas-1/canvas",
+          "type": "Canvas",
+        },
+        "selector": { "type": "PointSelector", "t": "2766.438533" }
+      }
+    },
+    {
+      "@context": "http://www.w3.org/ns/anno.jsonld",
+      "id": "unknown-annotation-2.json",
+      "type": "Annotation",
+      "motivation": ["supplementing", "commenting"],
+      "body": [
+        { "type": "TextualBody", "value": "A play that we used to play when we were children in Savannah.", "format": "text/plain", "purpose": "commenting" },
+        { "type": "TextualBody", "value": "Unknown", "format": "text/plain", "purpose": "tagging" }
+      ],
+      "target": {
+        "source": {
+          "id": "http://example.com/manifest/canvas-1/canvas",
+          "type": "Canvas",
+        },
+        "selector": {
+          "type": "FragmentSelector",
+          "conformsTo": "http://www.w3.org/TR/media-frags/",
+          "value": "t=2771.900826,2775.619835"
+        }
+      }
+    },
+    {
+      "@context": "http://www.w3.org/ns/anno.jsonld",
+      "id": "unknown-annotation-3.json",
+      "type": "Annotation",
+      "motivation": ["supplementing", "commenting"],
+      "body": [
+        { "type": "TextualBody", "value": "A ring play, just a ring play, a children's ring play", "format": "text/plain", "purpose": "commenting" },
+        { "type": "TextualBody", "value": "Unknown", "format": "text/plain", "purpose": "tagging" }
+      ],
+      "target": {
+        "source": {
+          "id": "http://example.com/manifest/canvas-1/canvas",
+          "type": "Canvas",
+        },
+        "selector": {
+          "type": "FragmentSelector",
+          "conformsTo": "http://www.w3.org/TR/media-frags/",
+          "value": "t=2779.493802,2782.438017"
+        }
+      }
+    }
+  ]
+};
+
+describe('AnnotationsDisplay component', () => {
+  const checkCanvasMock = jest.fn();
+  const playerCurrentTimeMock = jest.fn((time) => { return time; });
+  // Mock custom hook output
+  jest.spyOn(hooks, 'useMediaPlayer').mockImplementation(() => ({
+    currentTime: 0,
+    player: { currentTime: playerCurrentTimeMock, targets: [{ start: 10.23, end: 100.34 }] }
+  }));
+  jest.spyOn(hooks, 'useAnnotations').mockImplementation(() => ({
+    checkCanvas: checkCanvasMock
+  }));
+
+  test('displays nothing when annotations list is empty', () => {
+    render(<AnnotationsDisplay
+      annotations={[]}
+      canvasIndex={0}
+      duration={0}
+      displayMotivations={[]}
+    />);
+
+    expect(screen.queryByTestId('annotations-display')).not.toBeInTheDocument();
+  });
+
+  test('displays nothing when there are no annotation layers for the current Canvas', () => {
+    render(<AnnotationsDisplay
+      annotations={linkedAnnotationLayers}
+      canvasIndex={1}
+      duration={0}
+      displayMotivations={[]}
+    />);
+
+    expect(screen.queryByTestId('annotations-display')).not.toBeInTheDocument();
+  });
+
+  test('displays annotation selection when there are annotation layers for the current Canvas', () => {
+    render(<AnnotationsDisplay
+      annotations={linkedAnnotationLayers}
+      canvasIndex={0}
+      duration={572.34}
+      displayMotivations={[]}
+    />);
+
+    expect(screen.queryByTestId('annotations-display')).toBeInTheDocument();
+    expect(screen.queryByText('Annotation layers:')).toBeInTheDocument();
+    expect(screen.queryByTestId('annotation-multi-select')).toBeInTheDocument();
+    expect(screen.getByTestId('annotation-multi-select').childNodes[0])
+      .toHaveTextContent('1 of 2 layers selected▼');
+    expect(screen.queryByTestId('annotations-content')).toBeInTheDocument();
+  });
+
+  describe('for a selected annotation layer', () => {
+    test('displays annotations with same motivation as \'displayMotivations\'', async () => {
+      const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+        status: 201,
+        ok: true,
+        json: jest.fn(() => { return annotationPageResponse; })
+      });
+
+      render(<AnnotationsDisplay
+        annotations={annotationLayers}
+        canvasIndex={0}
+        duration={572.34}
+        displayMotivations={['supplementing']}
+      />);
+
+      const multiSelect = screen.queryByTestId('annotation-multi-select');
+      const multiSelectHeader = multiSelect.childNodes[0];
+
+      // Only one annotation layer is selected initially
+      expect(multiSelectHeader).toHaveTextContent('1 of 3 layers selected▼');
+
+      // Open the annotation layers list dropdown
+      fireEvent.click(multiSelectHeader);
+
+      const annotationLlist = multiSelect.childNodes[1];
+
+      // Check the second annotation layer is not selected
+      expect(annotationLlist.childNodes[3]).toHaveTextContent('Unknown');
+      expect(within(annotationLlist.childNodes[3]).getByRole('checkbox')).not.toBeChecked();
+
+      // Select the 'Unknown' annotation layer
+      const checkBox = screen.queryAllByRole('checkbox')[3];
+      // Wrap in act() to ensure all state updates are processed before assertions are run.
+      await act(() => {
+        fireEvent.click(checkBox);
+      });
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(multiSelectHeader).toHaveTextContent('2 of 3 layers selected▼');
+      expect(screen.queryAllByTestId('annotation-row').length).toEqual(2);
+    });
+
+    test('displays all annotations when \'displayMotivations\' is empty', async () => {
+      const mockResponse =
+        'WEBVTT\r\n\r\n1\r\n00:00:01.200 --> 00:00:21.000\n[music]\n\r\n2\r\n00:00:22.200 --> 00:00:26.600\nJust before lunch one day, a puppet show \nwas put on at school.\n\r\n3\r\n00:00:26.700 --> 00:00:31.500\nIt was called "Mister Bungle Goes to Lunch".\n\r\n4\r\n00:00:31.600 --> 00:00:34.500\nIt was fun to watch.\n\r\n5\r\n00:00:36.100 --> 00:00:41.300\nIn the puppet show, Mr. Bungle came to the \nboys\' room on his way to lunch.\n';
+      const fetchWebVTT = jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+        status: 200,
+        ok: true,
+        headers: { get: jest.fn(() => 'text/vtt') },
+        text: jest.fn(() => mockResponse),
+      });
+      render(<AnnotationsDisplay
+        annotations={linkedAnnotationLayers}
+        canvasIndex={0}
+        duration={572.34}
+        displayMotivations={[]}
+      />);
+
+      const multiSelect = screen.queryByTestId('annotation-multi-select');
+      const multiSelectHeader = multiSelect.childNodes[0];
+
+      // Only one annotation layer is selected initially
+      expect(multiSelectHeader).toHaveTextContent('1 of 2 layers selected▼');
+
+      // Open the annotation layers list dropdown
+      fireEvent.click(multiSelectHeader);
+
+      const annotationLlist = multiSelect.childNodes[1];
+
+      // Check the second annotation layer is not selected
+      expect(annotationLlist.childNodes[2]).toHaveTextContent('Subtitle in English.srt');
+      expect(within(annotationLlist.childNodes[2]).getByRole('checkbox')).not.toBeChecked();
+
+      // Select the 'Subtitle in English.srt' annotation layer
+      const checkBox = screen.queryAllByRole('checkbox')[2];
+      // Wrap in act() to ensure all state updates are processed before assertions are run.
+      await act(() => {
+        fireEvent.click(checkBox);
+      });
+
+      expect(fetchWebVTT).toHaveBeenCalledTimes(1);
+      expect(multiSelectHeader).toHaveTextContent('2 of 2 layers selected▼');
+      expect(screen.queryAllByTestId('annotation-row').length).toEqual(5);
+    });
+  });
+
+  describe('displays a message when there are no annotations', () => {
+    test('for filtered motivations', () => {
+      render(<AnnotationsDisplay
+        annotations={linkedAnnotationLayers}
+        canvasIndex={0}
+        duration={572.34}
+        displayMotivations={['commenting']}
+      />);
+
+      expect(screen.queryByTestId('annotations-display')).toBeInTheDocument();
+      expect(screen.queryByText('Annotation layers:')).toBeInTheDocument();
+      expect(screen.queryByTestId('annotation-multi-select')).toBeInTheDocument();
+      expect(screen.queryByTestId('annotations-content')).toBeInTheDocument();
+      expect(screen.queryByTestId('no-annotations-message')).toBeInTheDocument();
+      expect(screen.queryByText('No Annotations were found with commenting motivation.'));
+    });
+
+    test('for empty list of displayMotivations', () => {
+      render(<AnnotationsDisplay
+        annotations={annotationLayers}
+        canvasIndex={0}
+        duration={572.34}
+        displayMotivations={[]}
+      />);
+
+      expect(screen.queryByTestId('annotations-display')).toBeInTheDocument();
+      expect(screen.queryByText('Annotation layers:')).toBeInTheDocument();
+      expect(screen.queryByTestId('annotation-multi-select')).toBeInTheDocument();
+      expect(screen.queryByTestId('annotations-content')).toBeInTheDocument();
+      expect(screen.queryByTestId('no-annotations-message')).toBeInTheDocument();
+      expect(screen.queryByText('No Annotations were found for the selected layer(s).'));
+    });
+  });
+});

--- a/src/components/MarkersDisplay/MarkersDisplay.scss
+++ b/src/components/MarkersDisplay/MarkersDisplay.scss
@@ -246,9 +246,31 @@
       }
     }
 
-    p.ramp--annotations__annotation-text {
-      margin: 0;
+    .ramp--annotations__annotation-texts {
+      display: flex;
+      flex-direction: column;
       margin-top: 0.5em;
+
+      :last-child {
+        margin-left: auto;
+      }
+
+      p.ramp--annotations__annotation-text {
+        margin: 0;
+        margin-top: 0.5em;
+
+        &.hidden {
+          display: none;
+        }
+      }
+
+      .ramp--annotations__show-more-less {
+        font-size: small;
+        cursor: pointer;
+        background: none;
+        border: 1px solid $primaryDarker;
+        border-radius: 3px;
+      }
     }
   }
 }

--- a/src/components/MarkersDisplay/MarkersDisplay.scss
+++ b/src/components/MarkersDisplay/MarkersDisplay.scss
@@ -144,7 +144,7 @@
     flex-direction: column;
     background-color: $primaryLightest;
 
-    .ramp--annotatations__multi-select {
+    .ramp--annotations__multi-select {
       position: relative;
       font-family: Arial, sans-serif;
     }
@@ -179,7 +179,7 @@
       padding: 0;
       list-style-type: none;
       position: absolute;
-      top: 100%;
+      top: auto;
       left: 0;
       width: 100%;
       border: 1px solid #ccc;
@@ -219,15 +219,12 @@
     cursor: pointer;
     padding: 10px;
 
-    &:hover,
-    &:focus {
-      background-color: $primaryGreenLight;
+    &.active {
+      background-color: $primaryLight;
     }
 
-    &.focused,
-    &.focused:hover,
-    &.focused:focus {
-      background-color: $primaryGreenSemiLight;
+    &:hover {
+      background-color: $primaryGreenLight;
     }
 
     .ramp--annotations__annotation-row-time-tags {

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -250,8 +250,11 @@ function VideoJSPlayer({
        * of the browser, or network latency.
        * This code helps to store the seeked time in these scenarios and re-seek the player to the initial
        * seeked time-point on player.load() call.
+       * Additional check for player.readyState() != 4 is to avoid this code block from executing when using
+       * seek action to navigate to a timepoint in Annotations.
        */
-      if (player.currentTime() == 0 && player.currentTime() != currentTimeRef.current) {
+      if (player.readyState() != 4 && player.currentTime() == 0
+        && player.currentTime() != currentTimeRef.current) {
         player.currentTime(currentTimeRef.current);
       }
       // Update global state with the current time from 'seek' action

--- a/src/services/annotation-parser.test.js
+++ b/src/services/annotation-parser.test.js
@@ -437,7 +437,6 @@ const linkedExternalAnnotations = {
   ]
 };
 
-
 // Manifest with inline TextualBody annotations with 
 // label/value and multiple annotations with same timestamps
 const aviaryTextualBodyAnnotations = {

--- a/src/services/annotations-parser.js
+++ b/src/services/annotations-parser.js
@@ -14,6 +14,10 @@ let TAG_COLORS = [];
  */
 const TIME_SYNCED_FORMATS = ['text/vtt', 'text/srt', 'application/json'];
 
+// Supported motivations for annotations
+// Remove 'transcribing' once testing for Aviary manifests are completed.
+export const SUPPORTED_MOTIVATIONS = ['commenting', 'supplementing', 'transcribing'];
+
 /**
  * Parse annotation sets relevant to the current Canvas in a
  * given Manifest.
@@ -245,14 +249,12 @@ function parseSelector(selector, duration) {
 function parseTextualBody(textualBody, motivations) {
   let annotationBody = {};
   let tagColor;
-  // List of motivations that is displayed as text in the UI
-  const textualMotivations = ['commenting', 'supplementing'];
   if (textualBody) {
     const { format, label, motivation, purpose, value } = textualBody;
     let annotationPurpose = purpose != undefined ? purpose : motivation;
-    if (annotationPurpose == undefined && textualMotivations.some(m => motivations.includes(m))) {
+    if (annotationPurpose == undefined && SUPPORTED_MOTIVATIONS.some(m => motivations.includes(m))) {
       // Filter only the motivations that are displayed as texts
-      annotationPurpose = motivations.filter((m) => textualMotivations.includes(m));
+      annotationPurpose = motivations.filter((m) => SUPPORTED_MOTIVATIONS.includes(m));
     }
 
     // If a label is given; combine label/value pairs to display

--- a/src/services/annotations-parser.js
+++ b/src/services/annotations-parser.js
@@ -312,7 +312,7 @@ function parseAnnotationBody(annotationBody, motivations) {
         break;
       case 'Text':
         const { format, id, label } = body;
-        // Only use linked annotations with 'transcripts' type in Avalon manifests
+        // Skip linked annotations that are captions in Avalon manifests
         let sType = identifySupplementingAnnotation(id);
         if (sType !== 2) {
           values.push({

--- a/src/services/ramp-hooks.js
+++ b/src/services/ramp-hooks.js
@@ -1142,27 +1142,42 @@ export const useAnnotations = ({ canvasId, startTime, endTime, currentTime, disp
    */
   const inPlayerRange = useMemo(() => {
     // Index of the current annotation
-    const activeAnnotationIndex = displayedAnnotations
+    const currentAnnotationIndex = displayedAnnotations
       .findIndex((a) => a.time?.start === startTime);
-    // Retrieve the next annotation in the list
-    const nexAnnotation = activeAnnotationIndex < displayedAnnotations?.length
-      ? displayedAnnotations[activeAnnotationIndex + 1]
+    // Retrieve the next annotation in the list if it exists
+    const nextAnnotation = currentAnnotationIndex < displayedAnnotations?.length && currentAnnotationIndex > -1
+      ? displayedAnnotations[currentAnnotationIndex + 1]
       : undefined;
     // If there's a next annotation, retrieve its start time
-    const nextAnnotationStartTime = nexAnnotation != undefined
-      ? nexAnnotation.time?.start : undefined;
+    const nextAnnotationStartTime = nextAnnotation != undefined
+      ? nextAnnotation.time?.start : undefined;
+
+    // Filter annotations that has a start time less than or equal to the currentTime
+    const activeAnnotations = displayedAnnotations.filter((a) => a.time?.start <= currentTime);
 
     /**
-     * Check if the currentTime is within the range of the current annotation's startTime 
-     * OR if the currentTime is before the startTime of the next annotation and within the 
-     * range of the current annotation's start and end times.
+     * If there are annotations with a start time less than or equal to the currentTime, get
+     * the last annotation on that list. 
+     * 
+     * If the last annotation is the current annotation, derived by comparing start times 
+     * because start time is unique to each annotation and currentTime is in the current
+     * annotation's time range, mark the current annotation as active.
+     * OR 
+     * if the currentTime is within the range of the current annotation's startTime and endTime
+     * without exceeding the next annotation's start time, mark the current annotation as active.
+     * 
+     * Here current annotation is referring to the AnnotationRow instance calling this function.
      */
-    if (Math.floor(startTime) === Math.floor(currentTime)
-      || (nextAnnotationStartTime != undefined && currentTime < nextAnnotationStartTime
-        && startTime <= currentTime && currentTime <= endTime)) {
-      return true;
-    } else {
-      return false;
+    if (activeAnnotations?.length > 0) {
+      const lastAnnotation = activeAnnotations[activeAnnotations.length - 1];
+      if (lastAnnotation.time?.start === startTime && currentTime <= endTime
+        || (nextAnnotationStartTime != undefined && currentTime < nextAnnotationStartTime
+          && startTime <= currentTime && currentTime <= endTime)
+      ) {
+        return true;
+      } else {
+        return false;
+      }
     }
   }, [currentTime, displayedAnnotations]);
 

--- a/src/services/utility-helpers.js
+++ b/src/services/utility-helpers.js
@@ -555,25 +555,27 @@ export function autoScroll(currentItem, containerRef, toTop = false) {
     element and its container(parent) element to the top padding edge of
     their offsetParent element(body)
   */
-  let scrollHeight = currentItem.offsetTop - containerRef.current.offsetTop;
-  /*
-    Scroll the current active item to into view within the parent container.
-    For transcript active cues => toTop is set to `true`
-    For structure active items => toTop has the default `false` value
-  */
-  if (toTop) {
-    containerRef.current.scrollTop = scrollHeight;
-  } else {
-    // Height of the content in view within the parent container
-    let inViewHeight = containerRef.current.clientHeight - currentItem.clientHeight;
-    // Only scroll current item when it is further down from the 
-    // mid-height point of the container
-    if (scrollHeight > inViewHeight) {
-      containerRef.current.scrollTop = scrollHeight - containerRef.current.clientHeight / 2;
-    } else if (inViewHeight / 2 > scrollHeight) {
-      containerRef.current.scrollTop = 0;
+  if (currentItem) {
+    let scrollHeight = currentItem.offsetTop - containerRef.current.offsetTop;
+    /*
+      Scroll the current active item to into view within the parent container.
+      For transcript active cues => toTop is set to `true`
+      For structure active items => toTop has the default `false` value
+    */
+    if (toTop) {
+      containerRef.current.scrollTop = scrollHeight;
     } else {
-      containerRef.current.scrollTop = scrollHeight / 2;
+      // Height of the content in view within the parent container
+      let inViewHeight = containerRef.current.clientHeight - currentItem.clientHeight;
+      // Only scroll current item when it is further down from the 
+      // mid-height point of the container
+      if (scrollHeight > inViewHeight) {
+        containerRef.current.scrollTop = scrollHeight - containerRef.current.clientHeight / 2;
+      } else if (inViewHeight / 2 > scrollHeight) {
+        containerRef.current.scrollTop = 0;
+      } else {
+        containerRef.current.scrollTop = scrollHeight / 2;
+      }
     }
   }
 };


### PR DESCRIPTION
Related issue: #649 

This PR includes the following;
- Checkbox in the annotations component to allow auto-scrolling of annotations with playback
  - this is turned on by default (similar to transcripts)
  - when auto-scrolling is turned on the annotation with the closest start time to the current time of the player is scrolled to the top of the annotations component and highlighted until the current time of the player reaches the next annotation in the list

https://github.com/user-attachments/assets/fb9146ad-4bb7-4fd3-acff-f9f6fd79f509

- `Show more`/`Show less` button to expand the full text of the annotation when the annotation has more than 6 lines


https://github.com/user-attachments/assets/7ae359da-a980-4079-9bd9-c544d0aa7de3


- Unit tests for all the new user interfaces
- Filter `supplementing` annotations in Avalon manifests to include only transcripts in the Annotations component (using `transcripts` in the Annotation body 'id')
