### PR TITLE
Handle click on a link in annotation: open URL in same tab without seeking player

### DIFF
--- a/src/components/MarkersDisplay/Annotations/AnnotationRow.js
+++ b/src/components/MarkersDisplay/Annotations/AnnotationRow.js
@@ -79,6 +79,12 @@ const AnnotationRow = ({
     checkCanvas();
     // Do nothing when clicked on 'Show more'/'Show less' button
     if (e.target.tagName === 'BUTTON') return;
+
+    // Handle click on a link in the text in the same tab without seeking the player
+    if (e.target.tagName == 'A') {
+      window.open(e.target.href, '_self');
+      return;
+    }
     const currTime = time?.start;
     if (player && player?.targets?.length > 0) {
       const { start, end } = player.targets[0];

--- a/src/components/MarkersDisplay/Annotations/AnnotationRow.js
+++ b/src/components/MarkersDisplay/Annotations/AnnotationRow.js
@@ -82,8 +82,15 @@ const AnnotationRow = ({
 
     // Handle click on a link in the text in the same tab without seeking the player
     if (e.target.tagName == 'A') {
-      window.open(e.target.href, '_self');
-      return;
+      // Check if the href value is a valid URL before navigation
+      const urlRegex = /https?:\/\/[^\s/$.?#].[^\s]*/gi;
+      const href = e.target.getAttribute('href');
+      if (!href?.match(urlRegex)) {
+        e.preventDefault();
+      } else {
+        window.open(e.target.href, '_self');
+        return;
+      }
     }
     const currTime = time?.start;
     if (player && player?.targets?.length > 0) {

--- a/src/components/MarkersDisplay/MarkersDisplay.scss
+++ b/src/components/MarkersDisplay/MarkersDisplay.scss
@@ -259,6 +259,18 @@
       p.ramp--annotations__annotation-text {
         margin: 0;
         margin-top: 0.5em;
+
+        &.hidden {
+          display: none;
+        }
+
+        // Links within annotation texts
+        a {
+          color: $primaryGreenDark;
+          &:hover {
+            color: $primaryDarker;
+          }
+        }
       }
 
       .ramp--annotations__show-more-less {


### PR DESCRIPTION
Related issue: #764 