### PR TITLE
Show time rail highlight for current timespan when nested

### DIFF
--- a/src/components/StructuredNavigation/NavUtils/List.test.js
+++ b/src/components/StructuredNavigation/NavUtils/List.test.js
@@ -21,6 +21,7 @@ describe('List component', () => {
       isEmpty: false,
       canvasDuration: 0,
       label: 'Lunchroom Manners',
+      times: { start: 0, end: 0 },
       items: [
         {
           id: undefined,
@@ -34,6 +35,7 @@ describe('List component', () => {
           isEmpty: false,
           canvasDuration: 0,
           label: 'Introduction',
+          times: { start: 0, end: 0 },
           items: [
             {
               id: 'https://example.com/manifest/lunchroome_manners/canvas/1#t=0.0,45.321',
@@ -48,6 +50,7 @@ describe('List component', () => {
               label: 'Part I',
               items: [],
               canvasDuration: 572.034,
+              times: { start: 0, end: 45.321 },
             },
             {
               id: 'https://example.com/manifest/lunchroome_manners/canvas/1#t=60,120.321',
@@ -62,6 +65,7 @@ describe('List component', () => {
               label: 'Part II',
               items: [],
               canvasDuration: 572.034,
+              times: { start: 60, end: 120.321 },
             },
           ],
         }
@@ -119,6 +123,7 @@ describe('List component', () => {
       isEmpty: false,
       label: 'Lunchroom Manners',
       canvasDuration: 572.034,
+      times: { start: 0, end: 572 },
       items: [
         {
           id: undefined,
@@ -132,7 +137,8 @@ describe('List component', () => {
           isEmpty: false,
           label: 'Introduction',
           items: [],
-          canvasDuration: 0
+          canvasDuration: 0,
+          times: { start: 0, end: 0 },
         }
       ],
     };
@@ -174,7 +180,8 @@ describe('List component', () => {
       items: [],
       canvasDuration: 572.034,
       label: "Beginning Responsibility: Lunchroom Manners",
-      rangeId: "https://example.com/playlists/1/manifest/range/1"
+      rangeId: "https://example.com/playlists/1/manifest/range/1",
+      times: { start: 0, end: 0 },
     };
     const props = {
       items: [playlistItem],

--- a/src/components/StructuredNavigation/NavUtils/ListItem.js
+++ b/src/components/StructuredNavigation/NavUtils/ListItem.js
@@ -45,7 +45,8 @@ const ListItem = ({
   itemIndex,
   rangeId,
   sectionRef,
-  structureContainerRef
+  structureContainerRef,
+  times,
 }) => {
   const liRef = useRef(null);
 
@@ -54,6 +55,7 @@ const ListItem = ({
     isCanvas,
     isEmpty,
     canvasDuration,
+    times,
   });
 
   // Identify item as a SectionHeading for canvases in non-playlist contexts
@@ -110,7 +112,8 @@ const ListItem = ({
             isRoot={isRoot}
             structureContainerRef={structureContainerRef}
             hasChildren={items?.length > 0}
-            items={items} />
+            items={items}
+            times={times} />
           : <>
             {isTitle
               ?
@@ -187,7 +190,8 @@ ListItem.propTypes = {
   itemIndex: PropTypes.number,
   rangeId: PropTypes.string.isRequired,
   sectionRef: PropTypes.object.isRequired,
-  structureContainerRef: PropTypes.object.isRequired
+  structureContainerRef: PropTypes.object.isRequired,
+  times: PropTypes.object.isRequired,
 };
 
 export default ListItem;

--- a/src/components/StructuredNavigation/NavUtils/ListItem.test.js
+++ b/src/components/StructuredNavigation/NavUtils/ListItem.test.js
@@ -31,6 +31,7 @@ describe('ListItem component', () => {
     canvasDuration: 0,
     sectionRef: sectionRef,
     structureContainerRef,
+    times: { start: 0, end: 0 },
   };
   const canvasItem =
   {
@@ -61,6 +62,7 @@ describe('ListItem component', () => {
         canvasDuration: 572.034,
         sectionRef: sectionRef,
         structureContainerRef,
+        times: { start: 0, end: 45.321 },
       },
       {
         id: 'https://example.com/manifest/lunchroome_manners/canvas/1#t=60,120.321',
@@ -77,10 +79,12 @@ describe('ListItem component', () => {
         items: [],
         sectionRef: sectionRef,
         structureContainerRef,
+        times: { start: 60, end: 120.321 },
       },
     ],
     sectionRef: sectionRef,
     structureContainerRef,
+    times: { start: 0, end: 0 },
   };
 
   describe('with single item', () => {
@@ -100,6 +104,7 @@ describe('ListItem component', () => {
         canvasDuration: 572.034,
         sectionRef: sectionRef,
         structureContainerRef,
+        times: { start: 0, end: 374 },
       };
       const ListItemWithPlayer = withPlayerProvider(ListItem, {
         ...props,
@@ -146,6 +151,7 @@ describe('ListItem component', () => {
           canvasDuration: 572.034,
           sectionRef: sectionRef,
           structureContainerRef,
+          times: { start: 157, end: 160 },
         },
         {
           id: 'https://example.com/manifest/lunchroom_manners/canvas/1#t=165,170',
@@ -162,6 +168,7 @@ describe('ListItem component', () => {
           canvasDuration: 572.034,
           sectionRef: sectionRef,
           structureContainerRef,
+          times: { start: 165, end: 170 },
         },
         {
           id: undefined,
@@ -191,6 +198,7 @@ describe('ListItem component', () => {
               canvasDuration: 572.034,
               sectionRef: sectionRef,
               structureContainerRef,
+              times: { start: 170, end: 180 },
             },
             {
               id: 'https://example.com/manifest/lunchroom_manners/canvas/1#t=180,190',
@@ -207,14 +215,17 @@ describe('ListItem component', () => {
               canvasDuration: 572.034,
               sectionRef: sectionRef,
               structureContainerRef,
+              times: { start: 180, end: 190 },
             }
           ],
           sectionRef: sectionRef,
           structureContainerRef,
+          times: { start: 0, end: 0 },
         }
       ],
       sectionRef: sectionRef,
       structureContainerRef,
+      times: { start: 0, end: 0 },
     };
 
     beforeEach(() => {

--- a/src/components/StructuredNavigation/NavUtils/SectionHeading.js
+++ b/src/components/StructuredNavigation/NavUtils/SectionHeading.js
@@ -29,6 +29,7 @@ const SectionHeading = ({
   label,
   sectionRef,
   structureContainerRef,
+  times,
 }) => {
   const { isCollapsed, updateSectionStatus } = useCollapseExpandAll();
   // Root structure items are always expanded
@@ -54,7 +55,8 @@ const SectionHeading = ({
     isCanvas: true,
     isEmpty: false,
     canvasDuration: duration,
-    setSectionIsCollapsed
+    setSectionIsCollapsed,
+    times,
   });
 
   // Collapse/Expand section when all sections are collapsed/expanded respectively
@@ -152,6 +154,7 @@ SectionHeading.propTypes = {
   structureContainerRef: PropTypes.object.isRequired,
   hasChildren: PropTypes.bool,
   items: PropTypes.array,
+  times: PropTypes.object.isRequired,
 };
 
 export default SectionHeading;

--- a/src/components/StructuredNavigation/NavUtils/SectionHeading.test.js
+++ b/src/components/StructuredNavigation/NavUtils/SectionHeading.test.js
@@ -25,6 +25,7 @@ describe('SectionHeading component', () => {
         structureContainerRef={structureContainerRef}
         hasChildren={true}
         items={[]}
+        times={{ start: 0, end: 572.32 }}
       />
     );
     expect(screen.queryAllByTestId('listitem-section-span')).toHaveLength(1);
@@ -44,6 +45,7 @@ describe('SectionHeading component', () => {
         sectionRef={sectionRef}
         handleClick={handleClickMock}
         structureContainerRef={structureContainerRef}
+        times={{ start: 0, end: 572.32 }}
       />
     );
     expect(screen.queryAllByTestId('listitem-section-span')).toHaveLength(1);
@@ -64,6 +66,7 @@ describe('SectionHeading component', () => {
         itemId='https://example.com/manifest/canvas#t=0.0,572'
         handleClick={handleClickMock}
         structureContainerRef={structureContainerRef}
+        times={{ start: 0, end: 572.32 }}
       />
     );
     expect(screen.queryAllByTestId('listitem-section-span')).toHaveLength(0);
@@ -88,6 +91,7 @@ describe('SectionHeading component', () => {
         itemId={undefined}
         handleClick={handleClickMock}
         structureContainerRef={structureContainerRef}
+        times={{ start: 0, end: 572.32 }}
       />
     );
     expect(screen.queryAllByTestId('listitem-section-span')).toHaveLength(1);
@@ -115,6 +119,7 @@ describe('SectionHeading component', () => {
         itemId={undefined}
         handleClick={handleClickMock}
         structureContainerRef={structureContainerRef}
+        times={{ start: 0, end: 572.32 }}
       />
     );
     expect(screen.queryAllByTestId('listitem-section')).toHaveLength(1);
@@ -141,6 +146,7 @@ describe('SectionHeading component', () => {
         structureContainerRef={structureContainerRef}
         hasChildren={true}
         items={[]}
+        times={{ start: 0, end: 572.32 }}
       />
     );
     expect(screen.queryAllByTestId('listitem-section-span')).toHaveLength(1);
@@ -182,9 +188,11 @@ describe('SectionHeading component', () => {
               items: [],
               label: "Title",
               rangeId: "https://example.com/manifest/range/1",
-              summary: undefined
+              summary: undefined,
+              times: { start: 5.069, end: 65.069 },
             }
           ]}
+          times={{ start: 0, end: 572.32 }}
         />
       );
     });

--- a/src/components/StructuredNavigation/StructuredNavigation.js
+++ b/src/components/StructuredNavigation/StructuredNavigation.js
@@ -63,6 +63,15 @@ const StructuredNavigation = ({ showAllSectionsButton = false, sectionsHeading =
         if (structures?.length > 0 && structures[0].isRoot) {
           canvasStructRef.current = structures[0].items;
         }
+        // Sort timespans; helps with activeSegment calculation in VideoJSPlayer
+        timespans.sort((a, b) => {
+          // If end times are equal, sort them by descending order of start time
+          if (a.times.end === b.times.end) {
+            return b.times.start - a.times.start;
+          }
+          // Else, sort ascending order by end times
+          return a.times.end - b.times.end;
+        });
         manifestDispatch({ structures: canvasStructRef.current, type: 'setStructures' });
         manifestDispatch({ timespans, type: 'setCanvasSegments' });
         structureContainerRef.current.isScrolling = false;
@@ -256,6 +265,7 @@ const StructuredNavigation = ({ showAllSectionsButton = false, sectionsHeading =
                   structureContainerRef={structureContainerRef}
                   hasChildren={item.items?.length > 0}
                   items={item.items}
+                  times={item.times}
                 />
                 : <List
                   items={[item]}

--- a/src/components/StructuredNavigation/StructuredNavigation.scss
+++ b/src/components/StructuredNavigation/StructuredNavigation.scss
@@ -183,6 +183,7 @@ ul.ramp--structured-nav__list {
   li {
     display: block;
     padding: 0 0 0.5rem 1em;
+    font-weight: normal;
 
     .structure-item-locked {
       vertical-align: middle;
@@ -217,7 +218,7 @@ ul.ramp--structured-nav__list {
   li.active {
     font-weight: bold !important;
 
-    .tracker {
+    >.tracker {
       width: 0;
       height: 0;
       border-top: 3px solid transparent;

--- a/src/context/player-context.js
+++ b/src/context/player-context.js
@@ -33,6 +33,9 @@ function PlayerReducer(state = defaultState, action) {
     case 'resetClick': {
       return { ...state, isClicked: false };
     }
+    case 'clearClickedUrl': {
+      return { ...state, clickedUrl: '' };
+    }
     case 'setTimeFragment': {
       return {
         ...state,

--- a/src/services/iiif-parser.js
+++ b/src/services/iiif-parser.js
@@ -548,9 +548,9 @@ export function getStructureRanges(manifest, canvasesInfo, isPlaylist = false) {
   let hasRoot = false;
   let cIndex = 0;
   let hasCollapsibleStructure = false;
-
   // Initialize the subIndex for tracking indices for timespans in structure
   let subIndex = 0;
+
   let parseItem = (range, rootNode) => {
     let behavior = range.getBehavior();
     if (!NO_DISPLAY_STRUCTURE_BEHAVIORS.includes(behavior)) {
@@ -600,25 +600,31 @@ export function getStructureRanges(manifest, canvasesInfo, isPlaylist = false) {
         }
       }
 
+      // Increment index for children timespans within a Canvas
+      if (!isCanvas && canvases.length > 0) subIndex++;
+
+      let id = canvases.length > 0
+        ? isCanvas ? `${canvases[0].split(',')[0]},` : canvases[0] : undefined;
+
+      // Parse start and end times from media-fragment URI
+      // For Canvas-level timespans returns { start: 0, end: 0 }: to avoid full time-rail highligting
+      let times = id ? getMediaFragment(id, canvasDuration) : { start: 0, end: 0 };
+
       let item = {
-        label, summary, isRoot, homepage, canvasDuration,
+        label, summary, isRoot, homepage, canvasDuration, id, times,
         isTitle: canvases.length === 0 ? true : false,
         rangeId: range.id,
-        id: canvases.length > 0
-          ? isCanvas ? `${canvases[0].split(',')[0]},` : canvases[0] : undefined,
         isEmpty: isEmpty,
         isCanvas: isCanvas,
-        itemIndex: isCanvas ? cIndex : undefined,
+        itemIndex: isCanvas ? cIndex : subIndex,
         canvasIndex: cIndex,
         items: range.getRanges()?.length > 0 ? range.getRanges().map(r => parseItem(r, rootNode)) : [],
         duration: timeToHHmmss(duration),
         isClickable: isClickable,
         homepage: homepage
       };
+      // Collect timespans in a separate array
       if (canvases.length > 0) {
-        // Increment the index for each timespan
-        subIndex++;
-        if (!isCanvas) { item.itemIndex = subIndex; }
         timespans.push(item);
       }
       return item;

--- a/src/services/iiif-parser.js
+++ b/src/services/iiif-parser.js
@@ -563,6 +563,7 @@ export function getStructureRanges(manifest, canvasesInfo, isPlaylist = false) {
       let isCanvas;
       let isClickable = false; let isEmpty = false;
       let summary = undefined; let homepage = undefined;
+      let id = undefined;
 
       if (hasRoot) {
         // When parsing the root Range in structures, treat it as a Canvas
@@ -603,8 +604,14 @@ export function getStructureRanges(manifest, canvasesInfo, isPlaylist = false) {
       // Increment index for children timespans within a Canvas
       if (!isCanvas && canvases.length > 0) subIndex++;
 
-      let id = canvases.length > 0
-        ? isCanvas ? `${canvases[0].split(',')[0]},` : canvases[0] : undefined;
+      // Set 'id' in the form of a mediafragment
+      if (canvases.length > 0) {
+        if (isCanvas) {
+          id = `${canvases[0].split(',')[0]},`;
+        } else {
+          id = canvases[0];
+        }
+      }
 
       // Parse start and end times from media-fragment URI
       // For Canvas-level timespans returns { start: 0, end: 0 }: to avoid full time-rail highligting

--- a/src/services/iiif-parser.test.js
+++ b/src/services/iiif-parser.test.js
@@ -600,6 +600,7 @@ describe('iiif-parser', () => {
       expect(firstStructCanvas.isClickable).toBeFalsy();
       expect(firstStructCanvas.duration).toEqual('09:32');
       expect(firstStructCanvas.canvasDuration).toEqual(572.034);
+      expect(firstStructCanvas.times).toEqual({ start: 0, end: 0 });
 
       const firstTimespan = timespans[0];
       expect(firstTimespan.label).toEqual('Track 1. I. Kraftig');
@@ -612,6 +613,7 @@ describe('iiif-parser', () => {
       expect(firstTimespan.isClickable).toBeTruthy();
       expect(firstTimespan.duration).toEqual('06:14');
       expect(firstTimespan.canvasDuration).toEqual(572.034);
+      expect(firstTimespan.times).toEqual({ start: 0, end: 374 });
     });
 
     it('returns empty structures and timespans when behavior is set to no-nav', () => {
@@ -644,6 +646,7 @@ describe('iiif-parser', () => {
       expect(firstStructCanvas.isClickable).toBeTruthy();
       expect(firstStructCanvas.duration).toEqual('01:06:11');
       expect(firstStructCanvas.canvasDuration).toEqual(3971.24);
+      expect(firstStructCanvas.times).toEqual({ start: 0, end: 0 });
 
       const firstTimespan = timespans[0];
       expect(firstTimespan).toEqual(firstStructCanvas);
@@ -669,6 +672,7 @@ describe('iiif-parser', () => {
       expect(firstStructCanvas.isClickable).toBeTruthy();
       expect(firstStructCanvas.duration).toEqual('11:00');
       expect(firstStructCanvas.canvasDuration).toEqual(660);
+      expect(firstStructCanvas.times).toEqual({ start: 0, end: 0 });
     });
 
     it('returns structure with root for a single canvas manifest', () => {
@@ -690,6 +694,7 @@ describe('iiif-parser', () => {
       expect(firstStructCanvas.id).toBeUndefined();
       expect(firstStructCanvas.isClickable).toBeFalsy();
       expect(firstStructCanvas.canvasDuration).toEqual(7278.422);
+      expect(firstStructCanvas.times).toEqual({ start: 0, end: 0 });
     });
 
     it('returns [] when structure is not present', () => {
@@ -722,6 +727,7 @@ describe('iiif-parser', () => {
       expect(firstStructCanvas.isClickable).toBeTruthy();
       expect(firstStructCanvas.duration).toEqual('00:32');
       expect(firstStructCanvas.canvasDuration).toEqual(32);
+      expect(firstStructCanvas.times).toEqual({ start: 0, end: 0 });
     });
 
     it('return empty structures and timespans when behavior is set to thumbnail-nav', () => {

--- a/src/services/ramp-hooks.js
+++ b/src/services/ramp-hooks.js
@@ -14,9 +14,8 @@ import {
   TRANSCRIPT_TYPES
 } from './transcript-parser';
 import {
-  CANVAS_MESSAGE_TIMEOUT, checkSrcRange, getMediaFragment,
-  HOTKEY_ACTION_OUTPUT, playerHotKeys, screenReaderFriendlyTime,
-  identifyMachineGen
+  CANVAS_MESSAGE_TIMEOUT, checkSrcRange, HOTKEY_ACTION_OUTPUT, playerHotKeys,
+  screenReaderFriendlyTime, identifyMachineGen
 } from '@Services/utility-helpers';
 import { getMediaInfo } from '@Services/iiif-parser';
 import videojs from 'video.js';
@@ -678,6 +677,7 @@ export const useShowInaccessibleMessage = ({ lastCanvasIndex }) => {
  * @param {Boolean} obj.isEmpty is a restricted item
  * @param {Number} obj.canvasDuration
  * @param {Function} obj.setSectionIsCollapsed
+ * @param {Object} obj.times start and end times of the structure timespan
  * @returns { 
  * canvasIndex,
  * currentNavItem,
@@ -700,6 +700,7 @@ export const useActiveStructure = ({
   isEmpty,
   canvasDuration,
   setSectionIsCollapsed,
+  times,
 }) => {
   const playerDispatch = useContext(PlayerDispatchContext);
   const manifestState = useContext(ManifestStateContext);
@@ -729,7 +730,6 @@ export const useActiveStructure = ({
 
   // Convert timestamp to a text read as a human
   const screenReaderTime = useMemo(() => {
-    const times = getMediaFragment(itemId, canvasDuration);
     if (times != undefined) {
       return screenReaderFriendlyTime(times.start);
     } else {
@@ -741,7 +741,7 @@ export const useActiveStructure = ({
     e.preventDefault();
     e.stopPropagation();
 
-    const { start, end } = getMediaFragment(itemId, canvasDuration);
+    const { start, end } = times;
     const inRange = checkSrcRange({ start, end }, { end: canvasDuration });
     /* 
       Only continue the click action if not both start and end times of 

--- a/src/services/ramp-hooks.test.js
+++ b/src/services/ramp-hooks.test.js
@@ -303,7 +303,8 @@ describe('useActiveStructure', () => {
         liRef,
         isCanvas: false,
         canvasDuration: 660,
-        sectionRef
+        sectionRef,
+        times: { start: 0, end: 60 }
       });
     });
     test('returns isActiveLi = false when currentNavItem = null', () => {
@@ -351,6 +352,7 @@ describe('useActiveStructure', () => {
       canvasDuration: 660,
       liRef: sectionRef,
       setSectionIsCollapsed: setSectionIsCollapsedMock,
+      times: { start: 0, end: 0 }
     };
 
     test('returns isActiveSection = true when Canvas is selected', () => {


### PR DESCRIPTION
Related issue: #779 

To test nested timespans in Ramp demo site use the example Manifest at: https://gist.githubusercontent.com/Dananji/6575bff0213ca42af36009650fa986de/raw/857c759675c84acabe900f35838295613e369bb8/nested-timespans.json

| Before  | After fix |
| ------------- | ------------- |
| <img width="901" alt="Image" src="https://github.com/user-attachments/assets/ceeac1d2-2f53-46f0-9aa8-ce431782f669" /> | <img width="901" alt="Image" src="https://github.com/user-attachments/assets/26ed2313-f153-4af3-a763-a2873fee10e1" /> |
