### PR TITLE
Use a lighter color for active cues and annotation rows to fix contrast

### DIFF
--- a/src/components/MarkersDisplay/MarkersDisplay.scss
+++ b/src/components/MarkersDisplay/MarkersDisplay.scss
@@ -220,7 +220,7 @@
     padding: 10px;
 
     &.active {
-      background-color: $primaryLight;
+      background-color: $primaryLighter;
     }
 
     &:hover {

--- a/src/components/Transcript/Transcript.scss
+++ b/src/components/Transcript/Transcript.scss
@@ -45,7 +45,7 @@ span.ramp--transcript_item {
   transition: background-color 0.2s ease-in;
 
   &.active {
-    background-color: $primaryLight;
+    background-color: $primaryLighter;
   }
 
   &:hover,

--- a/src/styles/_vars.scss
+++ b/src/styles/_vars.scss
@@ -1,6 +1,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;700&display=swap');
 
 $primaryLightest: #f2f2f2;
+$primaryLighter: #ebebeb;
 $primaryLight: #d3d3d3;
 $primary: #bbbbbb;
 $primaryDark: #7e7e7e;


### PR DESCRIPTION
Related issue: #764 and https://github.com/samvera-labs/ramp/issues/764#issuecomment-2749402131