### PR TITLE
Truncate only text nodes without counting HTML markup, cleanup useEffects

### DIFF
--- a/src/components/MarkersDisplay/Annotations/AnnotationRow.js
+++ b/src/components/MarkersDisplay/Annotations/AnnotationRow.js
@@ -1,8 +1,8 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { autoScroll, timeToHHmmss } from '@Services/utility-helpers';
-import { useAnnotationRow, useMediaPlayer } from '@Services/ramp-hooks';
+import { timeToHHmmss } from '@Services/utility-helpers';
+import { useAnnotationRow, useMediaPlayer, useShowMoreOrLess } from '@Services/ramp-hooks';
 import { SUPPORTED_MOTIVATIONS } from '@Services/annotations-parser';
 
 const AnnotationRow = ({
@@ -18,15 +18,6 @@ const AnnotationRow = ({
   const { enableShowMore, textLineLimit: MAX_LINES } = showMoreSettings;
 
   const [isActive, setIsActive] = useState(false);
-  // Text displayed for the annotation
-  const [textToShow, setTextToShow] = useState(0);
-  // If annotation has a longer text; truncated text to fit number of MAX_LINES in the display
-  const [truncatedText, setTruncatedText] = useState('');
-  const [hasLongerText, setHasLongerText] = useState(false);
-  // State variables to store information related to overflowing tags in the annotation
-  const [hasLongerTags, setLongerTags] = useState(false);
-  const [showMoreTags, setShowMoreTags] = useState(false);
-
   const { player, currentTime } = useMediaPlayer();
   const { checkCanvas, inPlayerRange } = useAnnotationRow({
     canvasId,
@@ -47,6 +38,26 @@ const AnnotationRow = ({
   const isShowMoreRef = useRef(true);
   const setIsShowMoreRef = (state) => isShowMoreRef.current = state;
 
+  // TextualBodies with purpose tagging to be displayed as tags next to time range
+  const tags = useMemo(() => {
+    return value.filter((v) => v.purpose.includes('tagging'));
+  }, [value]);
+
+  // TextualBodies with supported purpose (motivation) values to be displayed as text
+  const texts = useMemo(() => {
+    const textsToShow = value.filter(
+      (v) => SUPPORTED_MOTIVATIONS.some(m => v.purpose.includes(m))
+    );
+
+    if (textsToShow?.length > 0) {
+      // Join texts with line breaks into a single text block
+      const annotationText = textsToShow.map((t) => t.value).join('<br>');
+      return annotationText;
+    } else {
+      return '';
+    }
+  }, [value]);
+
   /**
    * Display only the annotations with at least one of the specified motivations
    * when the component is initialized.
@@ -57,21 +68,29 @@ const AnnotationRow = ({
     return displayMotivations?.length > 0
       ? displayMotivations.some(m => motivation.includes(m))
       : true;
-  }, [annotation]);
+  }, [annotation, displayMotivations]);
 
-  /**
-   * When there multiple annotations in the same time range, auto-scroll to
-   * the annotation with the start time that is closest to the current time
-   * of the player.
-   * This allows a better user experience when auto-scroll is enabled during playback, 
-   * and there are multiple annotations that falls within the same time range.
-   */
-  useEffect(() => {
-    inPlayerRange ? setIsActive(true) : setIsActive(false);
-    if (autoScrollEnabled && inPlayerRange) {
-      autoScroll(annotationRef.current, containerRef, true);
-    }
-  }, [inPlayerRange]);
+  // Custom hook to handle show more/less functionality for texts and tags
+  const {
+    hasLongerTags,
+    hasLongerText,
+    setShowMoreTags,
+    showMoreTags,
+    setTextToShow,
+    textToShow,
+    toggleTagsView,
+    truncatedText } = useShowMoreOrLess({
+      autoScrollEnabled,
+      enableShowMore,
+      inPlayerRange,
+      MAX_LINES,
+      refs: {
+        annotationRef, annotationTagsRef, annotationTextsRef, annotationTimesRef,
+        containerRef, moreTagsButtonRef
+      },
+      setIsShowMoreRef, setIsActive,
+      tags, texts
+    });
 
   /**
    * Click event handler for annotations displayed.
@@ -118,207 +137,6 @@ const AnnotationRow = ({
     }
   }, [annotation, player]);
 
-  // TextualBodies with purpose tagging to be displayed as tags next to time range
-  const tags = useMemo(() => {
-    return value.filter((v) => v.purpose.includes('tagging'));
-  }, [value]);
-
-  // TextualBodies with supported purpose (motivation) values to be displayed as text
-  const texts = useMemo(() => {
-    const textsToShow = value.filter(
-      (v) => SUPPORTED_MOTIVATIONS.some(m => v.purpose.includes(m))
-    );
-    if (textsToShow?.length > 0) {
-      // Join texts with line breaks into a single text block
-      const annotationText = textsToShow.map((t) => t.value).join('<br>');
-      return annotationText;
-    } else {
-      return '';
-    }
-  }, [value]);
-
-  /**
-   * Truncate annotation text based on the width of the element on the page.
-   * Use a ResizeObserver to re-calculate truncated texts based on Annotations
-   * container re-size events
-   */
-  useEffect(() => {
-    const textBlock = annotationTextsRef.current;
-    let canvas, observer;
-    const calcTruncatedText = () => {
-      if (textBlock && texts?.length > 0) {
-        const textBlockWidth = textBlock.clientWidth;
-        const fontSize = parseFloat(getComputedStyle(textBlock).fontSize);
-        if (!isNaN(fontSize)) {
-          // Create a temporary canvas element to measure average character width
-          canvas = document.createElement('canvas');
-          const context = canvas.getContext('2d');
-          context.font = getComputedStyle(textBlock).font;
-
-          // Calculate average character width based on the specified font in CSS
-          const textWidth = context.measureText(texts).width;
-          const avgCharWidth = textWidth / texts.length;
-
-          // Calculate maximum number of characters that can be shown on avg character width
-          const charsPerLine = textBlockWidth / avgCharWidth;
-
-          /**
-           * To account for spaces at the end of line breaks, calculate max character for
-           * half a line width less than given MAX_LINES count
-           */
-          const maxCharactersToShow = charsPerLine * (MAX_LINES - 1)
-            + Math.floor(charsPerLine / 2);
-
-          let elementText = texts;
-
-          /**
-           * When texts has line breaks with shorter text in each line, pad each shorter line 
-           * until the length of it reaches the calculated charsPerLine number
-           */
-          if (texts.includes('<br>')) {
-            const lines = texts.split('<br>');
-            let paddedText = [];
-            for (let i = 0; i < lines.length; i++) {
-              const line = lines[i];
-              if (line.length < charsPerLine) {
-                // Account for the space for <br> for line breaks
-                const maxLineLength = charsPerLine > 4 ? charsPerLine - 4 : 0;
-                paddedText.push(line.padEnd(maxLineLength));
-              } else {
-                // Do nothing if text length is longer than charsPerLine
-                paddedText.push(line);
-              }
-            }
-            elementText = paddedText.join('<br>');
-          }
-
-          // Truncate text if the annotation text is longer than max character count
-          if (elementText.length > maxCharactersToShow) {
-            const truncated = `${elementText.slice(0, maxCharactersToShow)}...`;
-            setTextToShow(truncated);
-            setTruncatedText(truncated);
-            setIsShowMoreRef(true);
-            setHasLongerText(true);
-          } else {
-            setTextToShow(elementText);
-            setHasLongerText(false);
-          }
-        }
-      }
-    };
-
-    // Only truncate text if `enableShowMore` is turned ON
-    if (enableShowMore) {
-      /* Create a ResizeObserver to truncate the text as the 
-      Annotations container re-sizes */
-      observer = new ResizeObserver(entries => {
-        requestAnimationFrame(() => {
-          for (let entry of entries) {
-            calcTruncatedText();
-          }
-        });
-      });
-      if (containerRef.current) observer.observe(containerRef.current);
-
-      // Truncate text on load
-      calcTruncatedText();
-    } else {
-      setTextToShow(texts);
-    }
-
-    // Cleanup observer and temp canvas element on component un-mount
-    return () => {
-      canvas?.remove();
-      observer?.disconnect();
-    };
-  }, [texts]);
-
-  /**
-   * Hide annotation tags when they overflow the width of the annotation 
-   * container on the page
-   */
-  useEffect(() => {
-    /**
-     * Use ResizeObserver to hide/show tags as the annotations component re-sizes. 
-     * Using it along with 'requestAnimationFrame' optimizes the animation
-     * when container is contunuously being re-sized.
-     */
-    const observer = new ResizeObserver(entries => {
-      requestAnimationFrame(() => {
-        for (let entry of entries) {
-          updateTagView(true);
-        }
-      });
-    });
-    if (containerRef.current) observer.observe(containerRef.current);
-
-    const updateTagView = (s) => {
-      const hasOverflowingTags = toggleTagsView(s);
-      // Update state
-      setLongerTags(hasOverflowingTags);
-      setShowMoreTags(hasOverflowingTags);
-    };
-
-    // Hide/show tags on load
-    updateTagView(true);
-
-    // Cleanup observer on component un-mount
-    return () => {
-      observer?.disconnect();
-    };
-  }, [tags]);
-
-  /**
-   * Hide/show tags in the Annotation when the tags overflow the annotation
-   * component's width.
-   * This function is called in the ResizeObserver, as well as a callback function
-   * within the click event handler of the show more/less tags button to re-render 
-   * tags as needed.
-   * @param {Boolean} hideTags 
-   * @returns {Boolean}
-   */
-  const toggleTagsView = (hideTags) => {
-    let hasOverflowingTags = false;
-    // Tags and times UI elements on the page
-    const tagsBlock = annotationTagsRef.current;
-    const timesBlock = annotationTimesRef.current;
-    if (tagsBlock && timesBlock && tags?.length > 0) {
-      /* Reset the grid-column to its default if it was previously set */
-      tagsBlock.style.gridColumn = '';
-      const timesBlockWidth = timesBlock?.clientWidth || 0;
-      // Available space to render tags for the current annotation
-      const availableTagsWidth = tagsBlock.parentElement.clientWidth - timesBlockWidth;
-      if (tagsBlock.children?.length > 0) {
-        // 20 is an approximate width of the button, since this element gets rendered later
-        const moreTagsButtonWidth = moreTagsButtonRef.current?.clientWidth || 20;
-        // Reserve space for show more tags button
-        let spaceForTags = Math.abs(availableTagsWidth - moreTagsButtonWidth);
-        let hasLongerChild = false;
-        for (let i = 0; i < tagsBlock.children.length; i++) {
-          const child = tagsBlock.children[i];
-          // Reset 'hidden' class in each tag
-          if (child.classList.contains('hidden')) child.classList.remove('hidden');
-          // Check if at least one tag has longer text than the available space
-          if (child.clientWidth > availableTagsWidth) hasLongerChild = true;
-          if (hideTags && child != moreTagsButtonRef.current) {
-            spaceForTags = spaceForTags - child.clientWidth;
-            // If the space left is shorter than the width of more tags button, 
-            // hide the rest of the tags
-            if (spaceForTags < moreTagsButtonWidth) {
-              hasOverflowingTags = true;
-              child.classList.add('hidden');
-            }
-          }
-        }
-        /* Make the tags block span the full width of the time and tags container if 
-        there are tags with longer text */
-        if (hasLongerChild) {
-          tagsBlock.style.gridColumn = '1 / -1';
-        }
-      }
-    }
-    return hasOverflowingTags;
-  };
 
   /**
    * Click event handler for the 'Show more'/'Show less' button for

--- a/src/components/MarkersDisplay/Annotations/AnnotationRow.test.js
+++ b/src/components/MarkersDisplay/Annotations/AnnotationRow.test.js
@@ -709,7 +709,7 @@ describe('AnnotationRow component', () => {
         expect(screen.queryByTestId('annotation-text-0')).toBeInTheDocument();
 
         // maxCharactersToShow += (. characters) x 3
-        expect(screen.getByTestId('annotation-text-0').innerHTML.length).toBe(443);
+        expect(screen.getByTestId('annotation-text-0').innerHTML.length).toBe(439);
         expect(screen.getByTestId('annotation-text-0').textContent.endsWith('...')).toBeTruthy();
 
         expect(screen.queryByText('Show more')).toBeInTheDocument();
@@ -728,7 +728,7 @@ describe('AnnotationRow component', () => {
         fireEvent.click(screen.getByTestId('annotation-show-more-0'));
 
         // maxCharactersToShow += (. characters) x 3
-        expect(screen.getByTestId('annotation-text-0').innerHTML.length).toBe(443);
+        expect(screen.getByTestId('annotation-text-0').innerHTML.length).toBe(439);
         expect(screen.getByTestId('annotation-text-0').textContent.endsWith('...')).toBeTruthy();
 
         // Text on the button is toggled
@@ -796,7 +796,7 @@ describe('AnnotationRow component', () => {
         expect(screen.queryByTestId('annotation-text-0')).toBeInTheDocument();
 
         // maxCharactersToShow += (. characters) x 3
-        expect(screen.getByTestId('annotation-text-0').innerHTML.length).toBe(463);
+        expect(screen.getByTestId('annotation-text-0').innerHTML.length).toBe(462);
         expect(screen.getByTestId('annotation-text-0').textContent.endsWith('...')).toBeTruthy();
 
         expect(screen.queryByText('Show more')).toBeInTheDocument();
@@ -819,7 +819,7 @@ describe('AnnotationRow component', () => {
         fireEvent.click(screen.getByTestId('annotation-show-more-0'));
 
         // maxCharactersToShow += (. characters) x 3
-        expect(screen.getByTestId('annotation-text-0').innerHTML.length).toBe(463);
+        expect(screen.getByTestId('annotation-text-0').innerHTML.length).toBe(462);
         expect(screen.getByTestId('annotation-text-0').textContent.endsWith('...')).toBeTruthy();
 
         // Text on the button is toggled

--- a/src/components/MarkersDisplay/Annotations/AnnotationRow.test.js
+++ b/src/components/MarkersDisplay/Annotations/AnnotationRow.test.js
@@ -796,7 +796,7 @@ describe('AnnotationRow component', () => {
         expect(screen.queryByTestId('annotation-text-0')).toBeInTheDocument();
 
         // maxCharactersToShow += (. characters) x 3
-        expect(screen.getByTestId('annotation-text-0').innerHTML.length).toBe(443);
+        expect(screen.getByTestId('annotation-text-0').innerHTML.length).toBe(463);
         expect(screen.getByTestId('annotation-text-0').textContent.endsWith('...')).toBeTruthy();
 
         expect(screen.queryByText('Show more')).toBeInTheDocument();
@@ -813,12 +813,13 @@ describe('AnnotationRow component', () => {
         // Text on the button is toggled
         expect(screen.queryByText('Show more')).not.toBeInTheDocument();
         expect(screen.queryByText('Show less')).toBeInTheDocument();
+        expect(screen.getByTestId('annotation-text-0').textContent.endsWith('...')).toBeFalsy();
 
         // Click 'Show less' button
         fireEvent.click(screen.getByTestId('annotation-show-more-0'));
 
         // maxCharactersToShow += (. characters) x 3
-        expect(screen.getByTestId('annotation-text-0').innerHTML.length).toBe(443);
+        expect(screen.getByTestId('annotation-text-0').innerHTML.length).toBe(463);
         expect(screen.getByTestId('annotation-text-0').textContent.endsWith('...')).toBeTruthy();
 
         // Text on the button is toggled

--- a/src/services/ramp-hooks.js
+++ b/src/services/ramp-hooks.js
@@ -1453,8 +1453,8 @@ export const useShowMoreOrLess = ({
           }
 
           // Truncate text if the annotation text is longer than max character count
-          const { truncated, hasShowMore } = truncateText(elementText, maxCharactersToShow);
-          if (hasShowMore) {
+          const { truncated, isTruncated } = truncateText(elementText, maxCharactersToShow);
+          if (isTruncated) {
             setTextToShow(truncated);
             setTruncatedText(truncated);
             setIsShowMoreRef(true);

--- a/src/services/ramp-hooks.js
+++ b/src/services/ramp-hooks.js
@@ -15,7 +15,9 @@ import {
 } from './transcript-parser';
 import {
   CANVAS_MESSAGE_TIMEOUT, checkSrcRange, HOTKEY_ACTION_OUTPUT, playerHotKeys,
-  screenReaderFriendlyTime, identifyMachineGen
+  screenReaderFriendlyTime, identifyMachineGen,
+  truncateText,
+  autoScroll
 } from '@Services/utility-helpers';
 import { getMediaInfo } from '@Services/iiif-parser';
 import videojs from 'video.js';
@@ -1342,4 +1344,250 @@ export const useAnnotations = () => {
     }
 
   }, [isPlaylist, canvasIndex, annotations]);
+};
+
+/**
+ * 
+ * @param {Object} obj
+ * @param {Boolean} obj.autoScrollEnabled
+ * @param {Boolean} obj.enableShowMore
+ * @param {Boolean} obj.inPlayerRange
+ * @param {Number} obj.MAX_LINES
+ * @param {Object} obj.refs
+ * @param {Function} obj.setIsShowMoreRef
+ * @param {Function} obj.setIsActive
+ * @param {Array} obj.tags
+ * @param {Array} obj.texts 
+ * @returns {
+ *  hasLongerTags,
+ *  hasLongerText,
+ *  setShowMoreTags,
+ *  showMoreTags,
+ *  setTextToShow,
+ *  textToShow,
+ *  toggleTagsView,
+ *  truncatedText
+ * }
+ */
+export const useShowMoreOrLess = ({
+  autoScrollEnabled, enableShowMore, inPlayerRange,
+  MAX_LINES, refs, setIsShowMoreRef, setIsActive, tags, texts }) => {
+
+  const { annotationRef, annotationTagsRef, annotationTextsRef, annotationTimesRef, containerRef, moreTagsButtonRef } = refs;
+  // Text displayed for the annotation
+  const [textToShow, setTextToShow] = useState(0);
+  // If annotation has a longer text; truncated text to fit number of MAX_LINES in the display
+  const [truncatedText, setTruncatedText] = useState('');
+  const [hasLongerText, setHasLongerText] = useState(false);
+  // State variables to store information related to overflowing tags in the annotation
+  const [hasLongerTags, setLongerTags] = useState(false);
+  const [showMoreTags, setShowMoreTags] = useState(false);
+
+  /**
+   * When there multiple annotations in the same time range, auto-scroll to
+   * the annotation with the start time that is closest to the current time
+   * of the player.
+   * This allows a better user experience when auto-scroll is enabled during playback, 
+   * and there are multiple annotations that falls within the same time range.
+   */
+  useEffect(() => {
+    inPlayerRange ? setIsActive(true) : setIsActive(false);
+    if (autoScrollEnabled && inPlayerRange) {
+      autoScroll(annotationRef.current, containerRef, true);
+    }
+  }, [inPlayerRange]);
+
+  /**
+   * Truncate annotation text based on the width of the element on the page.
+   * Use a ResizeObserver to re-calculate truncated texts based on Annotations
+   * container re-size events
+   */
+  useEffect(() => {
+    const textBlock = annotationTextsRef.current;
+    let canvas, observer;
+    const calcTruncatedText = () => {
+      if (textBlock && texts?.length > 0) {
+        const textBlockWidth = textBlock.clientWidth;
+        const fontSize = parseFloat(getComputedStyle(textBlock).fontSize);
+        if (!isNaN(fontSize)) {
+          // Create a temporary canvas element to measure average character width
+          canvas = document.createElement('canvas');
+          const context = canvas.getContext('2d');
+          context.font = getComputedStyle(textBlock).font;
+
+          // Calculate average character width based on the specified font in CSS
+          const textWidth = context.measureText(texts).width;
+          const avgCharWidth = textWidth / texts.length;
+
+          // Calculate maximum number of characters that can be shown on avg character width
+          const charsPerLine = textBlockWidth / avgCharWidth;
+
+          /**
+           * To account for spaces at the end of line breaks, calculate max character for
+           * half a line width less than given MAX_LINES count
+           */
+          const maxCharactersToShow = charsPerLine * (MAX_LINES - 1)
+            + Math.floor(charsPerLine / 2);
+
+          let elementText = texts;
+
+          /**
+           * When texts has line breaks with shorter text in each line, pad each shorter line 
+           * until the length of it reaches the calculated charsPerLine number
+           */
+          if (texts.includes('<br>')) {
+            const lines = texts.split('<br>');
+            let paddedText = [];
+            for (let i = 0; i < lines.length; i++) {
+              const line = lines[i];
+              if (line.length < charsPerLine) {
+                // Account for the space for <br> for line breaks
+                const maxLineLength = charsPerLine > 4 ? charsPerLine - 4 : 0;
+                paddedText.push(line.padEnd(maxLineLength));
+              } else {
+                // Do nothing if text length is longer than charsPerLine
+                paddedText.push(line);
+              }
+            }
+            elementText = paddedText.join('<br>');
+          }
+
+          // Truncate text if the annotation text is longer than max character count
+          const { truncated, hasShowMore } = truncateText(elementText, maxCharactersToShow);
+          if (hasShowMore) {
+            setTextToShow(truncated);
+            setTruncatedText(truncated);
+            setIsShowMoreRef(true);
+            setHasLongerText(true);
+          } else {
+            setTextToShow(elementText);
+            setHasLongerText(false);
+          }
+        }
+      }
+    };
+
+    // Only truncate text if `enableShowMore` is turned ON
+    if (enableShowMore) {
+      /* Create a ResizeObserver to truncate the text as the 
+      Annotations container re-sizes */
+      observer = new ResizeObserver(entries => {
+        requestAnimationFrame(() => {
+          for (let entry of entries) {
+            calcTruncatedText();
+          }
+        });
+      });
+      if (containerRef.current) observer.observe(containerRef.current);
+
+      // Truncate text on load
+      calcTruncatedText();
+    } else {
+      setTextToShow(texts);
+    }
+
+    // Cleanup observer and temp canvas element on component un-mount
+    return () => {
+      canvas?.remove();
+      observer?.disconnect();
+    };
+  }, [texts]);
+
+  /**
+   * Hide annotation tags when they overflow the width of the annotation 
+   * container on the page
+   */
+  useEffect(() => {
+    /**
+     * Use ResizeObserver to hide/show tags as the annotations component re-sizes. 
+     * Using it along with 'requestAnimationFrame' optimizes the animation
+     * when container is contunuously being re-sized.
+     */
+    const observer = new ResizeObserver(entries => {
+      requestAnimationFrame(() => {
+        for (let entry of entries) {
+          updateTagView(true);
+        }
+      });
+    });
+    if (containerRef.current) observer.observe(containerRef.current);
+
+    const updateTagView = (s) => {
+      const hasOverflowingTags = toggleTagsView(s);
+      // Update state
+      setLongerTags(hasOverflowingTags);
+      setShowMoreTags(hasOverflowingTags);
+    };
+
+    // Hide/show tags on load
+    updateTagView(true);
+
+    // Cleanup observer on component un-mount
+    return () => {
+      observer?.disconnect();
+    };
+  }, [tags]);
+
+  /**
+   * Hide/show tags in the Annotation when the tags overflow the annotation
+   * component's width.
+   * This function is called in the ResizeObserver, as well as a callback function
+   * within the click event handler of the show more/less tags button to re-render 
+   * tags as needed.
+   * @param {Boolean} hideTags 
+   * @returns {Boolean}
+   */
+  const toggleTagsView = (hideTags) => {
+    let hasOverflowingTags = false;
+    // Tags and times UI elements on the page
+    const tagsBlock = annotationTagsRef.current;
+    const timesBlock = annotationTimesRef.current;
+    if (tagsBlock && timesBlock && tags?.length > 0) {
+      /* Reset the grid-column to its default if it was previously set */
+      tagsBlock.style.gridColumn = '';
+      const timesBlockWidth = timesBlock?.clientWidth || 0;
+      // Available space to render tags for the current annotation
+      const availableTagsWidth = tagsBlock.parentElement.clientWidth - timesBlockWidth;
+      if (tagsBlock.children?.length > 0) {
+        // 20 is an approximate width of the button, since this element gets rendered later
+        const moreTagsButtonWidth = moreTagsButtonRef.current?.clientWidth || 20;
+        // Reserve space for show more tags button
+        let spaceForTags = Math.abs(availableTagsWidth - moreTagsButtonWidth);
+        let hasLongerChild = false;
+        for (let i = 0; i < tagsBlock.children.length; i++) {
+          const child = tagsBlock.children[i];
+          // Reset 'hidden' class in each tag
+          if (child.classList.contains('hidden')) child.classList.remove('hidden');
+          // Check if at least one tag has longer text than the available space
+          if (child.clientWidth > availableTagsWidth) hasLongerChild = true;
+          if (hideTags && child != moreTagsButtonRef.current) {
+            spaceForTags = spaceForTags - child.clientWidth;
+            // If the space left is shorter than the width of more tags button, 
+            // hide the rest of the tags
+            if (spaceForTags < moreTagsButtonWidth) {
+              hasOverflowingTags = true;
+              child.classList.add('hidden');
+            }
+          }
+        }
+        /* Make the tags block span the full width of the time and tags container if 
+        there are tags with longer text */
+        if (hasLongerChild) {
+          tagsBlock.style.gridColumn = '1 / -1';
+        }
+      }
+    }
+    return hasOverflowingTags;
+  };
+
+  return {
+    hasLongerTags,
+    hasLongerText,
+    setShowMoreTags,
+    showMoreTags,
+    setTextToShow,
+    textToShow,
+    toggleTagsView,
+    truncatedText
+  };
 };

--- a/src/services/utility-helpers.test.js
+++ b/src/services/utility-helpers.test.js
@@ -873,4 +873,43 @@ describe('util helper', () => {
       expect(util.screenReaderFriendlyTime(NaN)).toEqual('');
     });
   });
+
+  describe('truncateText()', () => {
+    test('returns original text if it is shorter than maxLength', () => {
+      const html = '<p>Short text</p>';
+      const { hasShowMore, truncated } = util.truncateText(html, 20);
+      expect(truncated).toBe(html);
+      expect(hasShowMore).toBe(false);
+    });
+
+    test('returns truncated plain text', () => {
+      const html = 'This is a longer text that needs truncation';
+      const { hasShowMore, truncated } = util.truncateText(html, 10);
+      expect(truncated).toBe('This is a ...');
+      expect(hasShowMore).toBe(true);
+    });
+
+    test('returns truncated text with original HTML tags intact', () => {
+      const html = '<p>This is a <strong>bold statement</strong> with some text.</p>';
+      const { hasShowMore, truncated } = util.truncateText(html, 20);
+      expect(truncated).toBe('<p>This is a <strong>bold state...</strong></p>');
+      expect(hasShowMore).toBe(true);
+    });
+
+    test('returns original text when text without HTML tags is shorter than maxLength', () => {
+      // Character count for text with HTML tags is 58, without HTML tags 41 
+      const html = 'Text that <strong>without the need</strong> for truncation';
+      const { hasShowMore, truncated } = util.truncateText(html, 50);
+      expect(truncated).toBe('Text that <strong>without the need</strong> for truncation');
+      expect(hasShowMore).toBe(false);
+    });
+
+    test('returns truncated text without counting HTML tags towards character limit', () => {
+      // Character count for text "Bold and superscript text" is 25
+      const html = '<p><strong>Bold</strong> and <sup><a href="http://example.com">superscript</a></sup> text</p>';
+      const { hasShowMore, truncated } = util.truncateText(html, 15);
+      expect(truncated).toBe('<p><strong>Bold</strong> and <sup><a href="http://example.com">supers...</a></sup></p>');
+      expect(hasShowMore).toBe(true);
+    });
+  });
 });

--- a/src/services/utility-helpers.test.js
+++ b/src/services/utility-helpers.test.js
@@ -875,41 +875,49 @@ describe('util helper', () => {
   });
 
   describe('truncateText()', () => {
-    test('returns original text if it is shorter than maxLength', () => {
+    test('returns original text with HTML if it is shorter than maxLength', () => {
       const html = '<p>Short text</p>';
-      const { hasShowMore, truncated } = util.truncateText(html, 20);
+      const { isTruncated, truncated } = util.truncateText(html, 20);
       expect(truncated).toBe(html);
-      expect(hasShowMore).toBe(false);
+      expect(isTruncated).toBe(false);
     });
 
     test('returns truncated plain text', () => {
       const html = 'This is a longer text that needs truncation';
-      const { hasShowMore, truncated } = util.truncateText(html, 10);
-      expect(truncated).toBe('This is a ...');
-      expect(hasShowMore).toBe(true);
+      const { isTruncated, truncated } = util.truncateText(html, 10);
+      expect(truncated).toBe('This is a...');
+      expect(isTruncated).toBe(true);
+    });
+
+    test('returns original text without counting length of ellipsis (3 characters)', () => {
+      // Original text length is 23, which is 3 characters longer than maxLength of 20
+      const html = 'No need for truncation.';
+      const { isTruncated, truncated } = util.truncateText(html, 20);
+      expect(truncated).toBe('No need for truncation.');
+      expect(isTruncated).toBe(false);
     });
 
     test('returns truncated text with original HTML tags intact', () => {
       const html = '<p>This is a <strong>bold statement</strong> with some text.</p>';
-      const { hasShowMore, truncated } = util.truncateText(html, 20);
-      expect(truncated).toBe('<p>This is a <strong>bold state...</strong></p>');
-      expect(hasShowMore).toBe(true);
+      const { isTruncated, truncated } = util.truncateText(html, 20);
+      expect(truncated).toBe('<p>This is a <strong>bold...</strong></p>');
+      expect(isTruncated).toBe(true);
     });
 
     test('returns original text when text without HTML tags is shorter than maxLength', () => {
       // Character count for text with HTML tags is 58, without HTML tags 41 
       const html = 'Text that <strong>without the need</strong> for truncation';
-      const { hasShowMore, truncated } = util.truncateText(html, 50);
+      const { isTruncated, truncated } = util.truncateText(html, 50);
       expect(truncated).toBe('Text that <strong>without the need</strong> for truncation');
-      expect(hasShowMore).toBe(false);
+      expect(isTruncated).toBe(false);
     });
 
     test('returns truncated text without counting HTML tags towards character limit', () => {
       // Character count for text "Bold and superscript text" is 25
       const html = '<p><strong>Bold</strong> and <sup><a href="http://example.com">superscript</a></sup> text</p>';
-      const { hasShowMore, truncated } = util.truncateText(html, 15);
+      const { isTruncated, truncated } = util.truncateText(html, 15);
       expect(truncated).toBe('<p><strong>Bold</strong> and <sup><a href="http://example.com">supers...</a></sup></p>');
-      expect(hasShowMore).toBe(true);
+      expect(isTruncated).toBe(true);
     });
   });
 });


### PR DESCRIPTION
Related issue: #790 

In addition to the fix the PR includes cleanup of `useEffect` hooks in `AnnotationRow` component. There's a bunch of `useEffect` code in the component, which were moved into a custom hook as a result.