### PR TITLE
Add back missing autoScroll import

### DIFF
--- a/src/components/MarkersDisplay/Annotations/AnnotationRow.js
+++ b/src/components/MarkersDisplay/Annotations/AnnotationRow.js
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { timeToHHmmss } from '@Services/utility-helpers';
+import { autoScroll, timeToHHmmss } from '@Services/utility-helpers';
 import { useAnnotationRow, useMediaPlayer, useShowMoreOrLess } from '@Services/ramp-hooks';
 import { SUPPORTED_MOTIVATIONS } from '@Services/annotations-parser';
 


### PR DESCRIPTION
The `autoScroll` import was removed in #800 because it wasn't used but #803 was cut from main before #800 was merged and made use of `autoScroll`.  #800 was merged and #803 didn't have any git merge conflicts but the needed import was lost in the process.