### PR TITLE
Auto scroll time-point annotations by comparing start time avoiding end times

### DIFF
--- a/src/services/ramp-hooks.test.js
+++ b/src/services/ramp-hooks.test.js
@@ -416,58 +416,154 @@ describe('useAnnotationRow', () => {
     return UIComponent;
   };
 
-  let props = {
-    canvasId: 'https://example.com/manifest/lunchroom_manners/canvas/1',
-    displayedAnnotations: [
-      {
-        id: 'https://example.com/manifest/lunchroom_manners/canvas/1/annotation-page/1/annotation/1',
-        canvasId: 'https://example.com/manifest/lunchroom_manners/canvas/1',
-        motivation: ['supplementing'],
-        time: { start: 7, end: 44 },
-        value: [{ format: 'text/plain', purpose: ['supplementing'], value: 'Men singing' }]
-      },
-      {
-        id: 'https://example.com/manifest/lunchroom_manners/canvas/1/annotation-page/1/annotation/2',
-        canvasId: 'https://example.com/manifest/lunchroom_manners/canvas/1',
-        motivation: ['supplementing'],
-        time: { start: 24.32, end: 25.33 },
-        value: [{ format: 'text/plain', purpose: ['supplementing'], value: '<strong>Subjects</strong>: Singing' }]
-      },
-      {
-        id: 'https://example.com/manifest/lunchroom_manners/canvas/1/annotation-page/1/annotation/3',
-        canvasId: 'https://example.com/manifest/lunchroom_manners/canvas/1',
-        motivation: ['supplementing'],
-        time: { start: 28.43, end: 29.35 },
-        value: [{ format: 'text/plain', purpose: ['supplementing'], value: 'The Yale Glee Club singing "Mother of Men"' }]
-      },
-    ]
-  };
+  describe('with time range annotations, when player\'s currentTime is', () => {
+    let props = {
+      canvasId: 'https://example.com/manifest/lunchroom_manners/canvas/1',
+      displayedAnnotations: [
+        {
+          id: 'https://example.com/manifest/lunchroom_manners/canvas/1/annotation-page/1/annotation/1',
+          canvasId: 'https://example.com/manifest/lunchroom_manners/canvas/1',
+          motivation: ['supplementing'],
+          time: { start: 7, end: 44 },
+          value: [{ format: 'text/plain', purpose: ['supplementing'], value: 'Men singing' }]
+        },
+        {
+          id: 'https://example.com/manifest/lunchroom_manners/canvas/1/annotation-page/1/annotation/2',
+          canvasId: 'https://example.com/manifest/lunchroom_manners/canvas/1',
+          motivation: ['supplementing'],
+          time: { start: 24.32, end: 25.33 },
+          value: [{ format: 'text/plain', purpose: ['supplementing'], value: '<strong>Subjects</strong>: Singing' }]
+        },
+        {
+          id: 'https://example.com/manifest/lunchroom_manners/canvas/1/annotation-page/1/annotation/3',
+          canvasId: 'https://example.com/manifest/lunchroom_manners/canvas/1',
+          motivation: ['supplementing'],
+          time: { start: 28.43, end: 29.35 },
+          value: [{ format: 'text/plain', purpose: ['supplementing'], value: 'The Yale Glee Club singing "Mother of Men"' }]
+        },
+      ]
+    };
 
-  test('when player\'s currentTime is not within annotation\'s start and end times returns inPlayerRange=false ', () => {
-    const UIComponent = renderHook({
-      ...props,
-      startTime: 7,
-      endTime: 44,
-      currentTime: 5,
-    });
-    const CustomComponent = withManifestAndPlayerProvider(UIComponent, {
-      initialManifestState: {
-        ...manifestState(lunchroomManners)
-      },
-      initialPlayerState: {},
-    });
-    render(<CustomComponent />);
-
-    expect(resultRef.current.inPlayerRange).toBeFalsy();
-  });
-
-  describe('when player\'s currentTime is within annotation\'s start and end times', () => {
-    test('without overlapping annotations returns inPlayerRange = true', () => {
+    test('not within annotation\'s start and end times returns inPlayerRange=false ', () => {
       const UIComponent = renderHook({
         ...props,
         startTime: 7,
         endTime: 44,
-        currentTime: 10,
+        currentTime: 5,
+      });
+      const CustomComponent = withManifestAndPlayerProvider(UIComponent, {
+        initialManifestState: {
+          ...manifestState(lunchroomManners)
+        },
+        initialPlayerState: {},
+      });
+      render(<CustomComponent />);
+
+      expect(resultRef.current.inPlayerRange).toBeFalsy();
+    });
+
+    describe('within annotation\'s start and end times', () => {
+      test('without overlapping annotations returns inPlayerRange = true', () => {
+        const UIComponent = renderHook({
+          ...props,
+          startTime: 7,
+          endTime: 44,
+          currentTime: 10,
+        });
+        const CustomComponent = withManifestAndPlayerProvider(UIComponent, {
+          initialManifestState: {
+            ...manifestState(lunchroomManners)
+          },
+          initialPlayerState: {},
+        });
+        render(<CustomComponent />);
+
+        expect(resultRef.current.inPlayerRange).toBeTruthy();
+      });
+
+      test('with overlapping annotations returns inPlayerRange = false', () => {
+        const UIComponent = renderHook({
+          ...props,
+          startTime: 7,
+          endTime: 44,
+          currentTime: 24.35,
+        });
+        const CustomComponent = withManifestAndPlayerProvider(UIComponent, {
+          initialManifestState: {
+            ...manifestState(lunchroomManners)
+          },
+          initialPlayerState: {},
+        });
+        render(<CustomComponent />);
+
+        expect(resultRef.current.inPlayerRange).toBeFalsy();
+      });
+    });
+
+    test('within annotation\'s start and end times returns inPlayerRange=true', () => {
+      const UIComponent = renderHook({
+        ...props,
+        startTime: 28.43,
+        endTime: 29.35,
+        currentTime: 28.45,
+      });
+      const CustomComponent = withManifestAndPlayerProvider(UIComponent, {
+        initialManifestState: {
+          ...manifestState(lunchroomManners)
+        },
+        initialPlayerState: {},
+      });
+      render(<CustomComponent />);
+
+      expect(resultRef.current.inPlayerRange).toBeTruthy();
+    });
+  });
+
+  describe('with time-point annotations, when player\'s currentTime is', () => {
+    let props = {
+      canvasId: 'https://example.com/manifest/lunchroom_manners/canvas/1',
+      displayedAnnotations: [
+        {
+          id: 'https://example.com/manifest/lunchroom_manners/canvas/1/annotation-page/1/annotation/1',
+          canvasId: 'https://example.com/manifest/lunchroom_manners/canvas/1',
+          motivation: ['supplementing'],
+          time: { start: 7, end: undefined },
+          value: [{ format: 'text/plain', purpose: ['supplementing'], value: 'Men singing' }]
+        },
+        {
+          id: 'https://example.com/manifest/lunchroom_manners/canvas/1/annotation-page/1/annotation/2',
+          canvasId: 'https://example.com/manifest/lunchroom_manners/canvas/1',
+          motivation: ['supplementing'],
+          time: { start: 24.32, end: undefined },
+          value: [{ format: 'text/plain', purpose: ['supplementing'], value: '<strong>Subjects</strong>: Singing' }]
+        },
+      ]
+    };
+
+    test('before first annotation, returns inPlayerRange=false ', () => {
+      const UIComponent = renderHook({
+        ...props,
+        startTime: 7,
+        endTime: undefined,
+        currentTime: 5,
+      });
+      const CustomComponent = withManifestAndPlayerProvider(UIComponent, {
+        initialManifestState: {
+          ...manifestState(lunchroomManners)
+        },
+        initialPlayerState: {},
+      });
+      render(<CustomComponent />);
+
+      expect(resultRef.current.inPlayerRange).toBeFalsy();
+    });
+
+    test('between first and second annotation, returns inPlayerRange=true for first annotation ', () => {
+      const UIComponent = renderHook({
+        ...props,
+        startTime: 7,
+        endTime: undefined,
+        currentTime: 10.34,
       });
       const CustomComponent = withManifestAndPlayerProvider(UIComponent, {
         initialManifestState: {
@@ -480,12 +576,12 @@ describe('useAnnotationRow', () => {
       expect(resultRef.current.inPlayerRange).toBeTruthy();
     });
 
-    test('with overlapping annotations returns inPlayerRange = false', () => {
+    test('between first and second annotation, returns inPlayerRange=false for second annotation ', () => {
       const UIComponent = renderHook({
         ...props,
-        startTime: 7,
-        endTime: 44,
-        currentTime: 24.35,
+        startTime: 24.32,
+        endTime: undefined,
+        currentTime: 10.34,
       });
       const CustomComponent = withManifestAndPlayerProvider(UIComponent, {
         initialManifestState: {
@@ -497,23 +593,5 @@ describe('useAnnotationRow', () => {
 
       expect(resultRef.current.inPlayerRange).toBeFalsy();
     });
-  });
-
-  test('when player\'s currentTime is within annotation\'s start and end times returns inPlayerRange=true', () => {
-    const UIComponent = renderHook({
-      ...props,
-      startTime: 28.43,
-      endTime: 29.35,
-      currentTime: 28.45,
-    });
-    const CustomComponent = withManifestAndPlayerProvider(UIComponent, {
-      initialManifestState: {
-        ...manifestState(lunchroomManners)
-      },
-      initialPlayerState: {},
-    });
-    render(<CustomComponent />);
-
-    expect(resultRef.current.inPlayerRange).toBeTruthy();
   });
 });


### PR DESCRIPTION
Related issue: #789 

Assumption: for time point annotations consider an implicit time range spanning from its given start time to the start time of the next annotation in the list. Therefore marking a time point annotation as active until the current time of the player reaches the start time of the next annotation's start time.