### PR TITLE
Fix role relationship error and VoiceOver instruction issue for annotation row

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^16.0.1",
+    "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^26.0.12",
     "@types/react": "18.3.5",
     "babel-jest": "^26.3.0",

--- a/src/components/MarkersDisplay/Annotations/AnnotationRow.js
+++ b/src/components/MarkersDisplay/Annotations/AnnotationRow.js
@@ -178,12 +178,29 @@ const AnnotationRow = ({
     }
   };
 
+  /**
+   * Seek the player to the start time of the activated annotation, and mark it as active
+   * when using Enter/Space keys to select the focused annotation
+   * @param {Event} e keyboard event
+   * @returns 
+   */
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      handleOnClick(e);
+    } else {
+      return;
+    }
+  };
+
   if (canDisplay) {
     return (
       <li
         key={`li_${index}`}
+        role='option'
+        tabIndex={index === 0 ? 0 : -1}
         ref={annotationRef}
         onClick={handleOnClick}
+        onKeyDown={handleKeyDown}
         data-testid="annotation-row"
         className={cx(
           "ramp--annotations__annotation-row",

--- a/src/components/MarkersDisplay/Annotations/AnnotationRow.js
+++ b/src/components/MarkersDisplay/Annotations/AnnotationRow.js
@@ -204,11 +204,6 @@ const AnnotationRow = ({
   const handleKeyDown = (e) => {
     // Get links/buttons inside the annotation row
     const linksAndButtons = annotationRef.current.querySelectorAll('button, a');
-    if (linksAndButtons?.length > 0) {
-      for (let i = 0; i < linksAndButtons.length; i++) {
-        linksAndButtons[i].tabIndex = -1;
-      }
-    }
     const handleTab = (e) => {
       let nextIndex = focusedIndex.current;
       // Allow tabbing through links/buttons if they exist, and do nothing if not
@@ -234,10 +229,6 @@ const AnnotationRow = ({
           linksAndButtons[nextIndex].focus();
           setFocusedIndex(nextIndex);
         }
-      } else {
-        // Stop default behavior when there are no links/buttons in the annotation
-        e.preventDefault();
-        return;
       }
     };
 
@@ -316,6 +307,7 @@ const AnnotationRow = ({
                 onClick={handleShowMoreTagsClicks}
                 onKeyDown={handleShowMoreTagsKeyDown}
                 ref={moreTagsButtonRef}
+                tabIndex={-1}
               >
                 <i className={`arrow ${showMoreTags ? 'right' : 'left'}`}></i>
               </button>
@@ -345,6 +337,7 @@ const AnnotationRow = ({
               data-testid={`annotation-show-more-${index}`}
               onClick={handleShowMoreLessClick}
               onKeyDown={handleShowMoreLessKeydown}
+              tabIndex={-1}
             >
               {isShowMoreRef.current ? 'Show more' : 'Show less'}
             </button>)

--- a/src/components/MarkersDisplay/Annotations/AnnotationSetSelect.js
+++ b/src/components/MarkersDisplay/Annotations/AnnotationSetSelect.js
@@ -107,9 +107,11 @@ const AnnotationSetSelect = ({
    * @param {Array} items list of timed annotations
    */
   const makeSelection = (annotationSet, items) => {
-    annotationSet.items = items;
-    setSelectedAnnotationSets((prev) => [...prev, annotationSet.label]);
-    setDisplayedAnnotationSets((prev) => [...prev, annotationSet]);
+    if (items != undefined) {
+      annotationSet.items = items;
+      setSelectedAnnotationSets((prev) => [...prev, annotationSet.label]);
+      setDisplayedAnnotationSets((prev) => [...prev, annotationSet]);
+    }
   };
 
   /**

--- a/src/components/MarkersDisplay/Annotations/AnnotationSetSelect.js
+++ b/src/components/MarkersDisplay/Annotations/AnnotationSetSelect.js
@@ -17,6 +17,8 @@ const AnnotationSetSelect = ({
   const [timedAnnotationSets, setTimedAnnotationSets] = useState([]);
 
   const multiSelectRef = useRef(null);
+  const selectButtonRef = useRef(null);
+  const dropDownRef = useRef(null);
 
   // Need to keep this as a state variable for re-rendering UI
   const [isOpen, _setIsOpen] = useState(false);
@@ -27,6 +29,10 @@ const AnnotationSetSelect = ({
     _setIsOpen(value);
   };
   const toggleDropdown = () => setIsOpen(!isOpenRef.current);
+
+  // Index of the focused option in the list
+  const currentIndex = useRef(0);
+  const setCurrentIndex = (i) => currentIndex.current = i;
 
   useEffect(() => {
     // Reset state when Canvas changes
@@ -54,27 +60,9 @@ const AnnotationSetSelect = ({
     };
   }, [canvasAnnotationSets]);
 
-  // Close the dropdown when clicked outside of it
-  const handleClickOutside = (e) => {
-    if (!multiSelectRef?.current?.contains(e.target) && isOpenRef.current) {
-      setIsOpen(false);
-    }
-  };
-
   const isSelected = useCallback((set) => {
     return selectedAnnotationSets.includes(set.label);
   }, [selectedAnnotationSets]);
-
-  /**
-   * Event handler for the check-box for each annotation set in the dropdown
-   * @param {Object} annotationSet checked/unchecked set
-   */
-  const handleSelect = async (annotationSet) => {
-    findOrFetchandParseLinkedAnnotations(annotationSet);
-
-    // Uncheck and clear annotation set in state
-    if (isSelected(annotationSet)) clearSelection(annotationSet);
-  };
 
   /**
    * Fetch linked annotations and parse its content only on first time selection
@@ -103,6 +91,28 @@ const AnnotationSetSelect = ({
   };
 
   /**
+ * Remove unchecked annotation and its label from state. This function updates
+ * as a wrapper for updating both state variables in one place to avoid inconsistencies
+ * @param {Object} annotationSet selected annotation set
+ */
+  const clearSelection = (annotationSet) => {
+    setSelectedAnnotationSets((prev) => prev.filter((item) => item !== annotationSet.label));
+    setDisplayedAnnotationSets((prev) => prev.filter((a) => a.label != annotationSet.label));
+  };
+
+  /**
+   * Add checked annotation and its label to state. This function updates
+   * as a wrapper for updating both state variables in one place to avoid inconsistencies
+   * @param {Object} annotationSet selected annotation set
+   * @param {Array} items list of timed annotations
+   */
+  const makeSelection = (annotationSet, items) => {
+    annotationSet.items = items;
+    setSelectedAnnotationSets((prev) => [...prev, annotationSet.label]);
+    setDisplayedAnnotationSets((prev) => [...prev, annotationSet]);
+  };
+
+  /**
    * Event handler for the checkbox for 'Show all Annotation sets' option
    * Check/uncheck all Annotation sets as slected/not-selected
    */
@@ -126,65 +136,179 @@ const AnnotationSetSelect = ({
   };
 
   /**
-   * Remove unchecked annotation and its label from state. This function updates
-   * as a wrapper for updating both state variables in one place to avoid inconsistencies
-   * @param {Object} annotationSet selected annotation set
+   * Event handler for the check-box for each annotation set in the dropdown
+   * @param {Object} annotationSet checked/unchecked set
    */
-  const clearSelection = (annotationSet) => {
-    setSelectedAnnotationSets((prev) => prev.filter((item) => item !== annotationSet.label));
-    setDisplayedAnnotationSets((prev) => prev.filter((a) => a.label != annotationSet.label));
+  const handleSelect = async (annotationSet) => {
+    findOrFetchandParseLinkedAnnotations(annotationSet);
+
+    // Uncheck and clear annotation set in state
+    if (isSelected(annotationSet)) clearSelection(annotationSet);
+  };
+
+  // Close the dropdown when clicked outside of it
+  const handleClickOutside = (e) => {
+    if (!multiSelectRef?.current?.contains(e.target) && isOpenRef.current) {
+      setIsOpen(false);
+    }
   };
 
   /**
-   * Add checked annotation and its label to state. This function updates
-   * as a wrapper for updating both state variables in one place to avoid inconsistencies
-   * @param {Object} annotationSet selected annotation set
-   * @param {Array} items list of timed annotations
+   * Open/close the dropdown and move focus to the first option in the drowdown
+   * menu as needed based on the keys pressed when dropdown is in focus
+   * @param {Event} e keydown event from dropdown button
    */
-  const makeSelection = (annotationSet, items) => {
-    annotationSet.items = items;
-    setSelectedAnnotationSets((prev) => [...prev, annotationSet.label]);
-    setDisplayedAnnotationSets((prev) => [...prev, annotationSet]);
+  const handleDropdownKeyPress = (e) => {
+    // Close the dropdown on 'Escape' keypress if it is open
+    if (e.keyCode === 27) {
+      e.preventDefault();
+      if (isOpenRef.current) toggleDropdown();
+    }
+
+    // Toggle dropdown on Enter/Space keypresses
+    if (e.keyCode === 13 || e.keyCode === 32) {
+      e.preventDefault();
+      toggleDropdown();
+    }
+    // Open the dropdown and move focus to first option on ArrowDown/ArrowUp keypresses
+    if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+      if (!isOpenRef.current) {
+        setIsOpen(true);
+        // Keep the container scrolled to top. Without this the first option 
+        // gets out of view when dropdown is programatically opened
+        setTimeout(() => dropDownRef.current.scrollTop = 0, 0);
+      }
+
+      // Move focus to the first option in the list
+      const firstOption = document.querySelector(".annotations-dropdown-item");
+      if (firstOption) {
+        firstOption.focus();
+        setCurrentIndex(0);
+      }
+    }
+  };
+
+  /**
+   * Handle keyboard events for each annotation set option.
+   * @param {Event} e keyboard event
+   */
+  const handleAnnotationSetKeyPress = (e) => {
+    const allOptions = dropDownRef.current.children;
+    let nextIndex = currentIndex.current;
+    switch (e.key) {
+      case 'Enter':
+      case ' ':
+        // On Enter/Space select the focused annotation set
+        e.preventDefault();
+        const option = timedAnnotationSets.filter((a) => e.target.id == a.label)[0];
+        if (option != undefined) {
+          handleSelect(option);
+        } else {
+          handleSelectAll();
+        }
+        break;
+      case 'ArrowDown':
+        e.preventDefault();
+        // Move to next option on ArrowDown keypress and wraps to first option when end is reached
+        nextIndex = (currentIndex.current + 1) % allOptions.length;
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        // Move to previous option on ArrowUp keypress and wraps to last option when top is reached
+        nextIndex = (currentIndex.current - 1 + allOptions.length) % allOptions.length;
+        break;
+      case 'Escape':
+        e.preventDefault();
+        // Close the dropdown and move focus to dropdown button
+        toggleDropdown();
+        selectButtonRef.current.focus();
+        break;
+      case 'Tab':
+        // Close dropdown and move focus out to the next element in the DOM
+        toggleDropdown();
+        break;
+    }
+
+    // Update focus on the selected option using ArrowDown/ArrowUp keys
+    if (nextIndex !== currentIndex.current) {
+      allOptions[nextIndex].focus();
+      setCurrentIndex(nextIndex);
+    }
   };
 
   if (timedAnnotationSets?.length > 0) {
     return (
-      <div className="ramp--annotations__select">
+      <div className='ramp--annotations__select'>
         <label>Annotation sets: </label>
         <div
-          className="ramp--annotations__multi-select"
-          data-testid="annotation-multi-select"
+          className='ramp--annotations__multi-select'
+          data-testid='annotation-multi-select'
           ref={multiSelectRef}
         >
-          <div className="ramp--annotations__multi-select-header" onClick={toggleDropdown}>
+          <span
+            className='ramp--annotations__multi-select-header'
+            onClick={toggleDropdown}
+            onKeyDown={handleDropdownKeyPress}
+            aria-haspopup='listbox'
+            aria-expanded={isOpen}
+            aria-controls='annotations-dropdown-menu'
+            id='dropdown-button'
+            role='button'
+            tabIndex={0}
+            ref={selectButtonRef}
+          >
             {selectedAnnotationSets.length > 0
               ? `${selectedAnnotationSets.length} of ${timedAnnotationSets.length} sets selected`
-              : "Select Annotation set(s)"}
-            <span className={`annotations-dropdown-arrow ${isOpen ? "open" : ""}`}>▼</span>
-          </div>
+              : 'Select Annotation set(s)'}
+            <span className={`annotations-dropdown-arrow ${isOpen ? 'open' : ''}`}>▼</span>
+          </span>
           {isOpen && (
-            <ul className="annotations-dropdown-menu">
+            <ul
+              className='annotations-dropdown-menu'
+              role='listbox'
+              aria-labelledby='dropdown-button'
+              aria-multiselectable={true}
+              tabIndex={-1}
+              ref={dropDownRef}>
               {
                 // Only show select all option when there's more than one annotation set
                 timedAnnotationSets?.length > 1 &&
-                <li key="select-all" className="annotations-dropdown-item">
+                <li key='select-all'
+                  className='annotations-dropdown-item'
+                  role='option' tabIndex={0}
+                  aria-selected={selectedAll}
+                  onKeyDown={handleAnnotationSetKeyPress}
+                  id='select-all-annotation-sets'
+                >
                   <label>
                     <input
-                      type="checkbox"
+                      type='checkbox'
+                      aria-checked={selectedAll}
                       checked={selectedAll}
                       onChange={handleSelectAll}
+                      tabIndex={0}
+                      role='checkbox'
                     />
                     Show all Annotation sets
                   </label>
                 </li>
               }
               {timedAnnotationSets.map((annotationSet, index) => (
-                <li key={`annotaion-set-${index}`} className="annotations-dropdown-item">
+                <li key={`annotaion-set-${index}`}
+                  className='annotations-dropdown-item'
+                  role='option' tabIndex={0}
+                  aria-selected={isSelected(annotationSet)}
+                  onKeyDown={handleAnnotationSetKeyPress}
+                  id={annotationSet.label}
+                >
                   <label>
                     <input
-                      type="checkbox"
+                      type='checkbox'
+                      aria-checked={isSelected(annotationSet)}
                       checked={isSelected(annotationSet)}
                       onChange={() => handleSelect(annotationSet)}
+                      tabIndex={0}
+                      role='checkbox'
                     />
                     {annotationSet.label}
                   </label>
@@ -192,17 +316,17 @@ const AnnotationSetSelect = ({
               ))}
             </ul>
           )}
-          <div className="ramp--annotations__scroll" data-testid="annotations-scroll">
+          <div className='ramp--annotations__scroll' data-testid='annotations-scroll'>
             <input
-              type="checkbox"
-              id="scroll-check"
-              name="scrollcheck"
+              type='checkbox'
+              id='scroll-check'
+              name='scrollcheck'
               aria-checked={autoScrollEnabled}
               title='Auto-scroll with media'
               checked={autoScrollEnabled}
               onChange={() => { setAutoScrollEnabled(!autoScrollEnabled); }}
             />
-            <label htmlFor="scroll-check" title='Auto-scroll with media'>
+            <label htmlFor='scroll-check' title='Auto-scroll with media'>
               Auto-scroll with media
             </label>
           </div>

--- a/src/components/MarkersDisplay/Annotations/AnnotationSetSelect.js
+++ b/src/components/MarkersDisplay/Annotations/AnnotationSetSelect.js
@@ -116,7 +116,7 @@ const AnnotationSetSelect = ({
    * Event handler for the checkbox for 'Show all Annotation sets' option
    * Check/uncheck all Annotation sets as slected/not-selected
    */
-  const handleSelectAll = async () => {
+  const handleSelectAll = async (e) => {
     const selectAllUpdated = !selectedAll;
     setSelectedAll(selectAllUpdated);
     if (selectAllUpdated) {
@@ -130,6 +130,9 @@ const AnnotationSetSelect = ({
       setSelectedAnnotationSets([]);
       setDisplayedAnnotationSets([]);
     }
+
+    // Stop propogation of the event to stop bubbling this event upto playerHotKeys
+    e.stopPropagation();
 
     // Close the dropdown
     toggleDropdown();
@@ -160,13 +163,13 @@ const AnnotationSetSelect = ({
    */
   const handleDropdownKeyPress = (e) => {
     // Close the dropdown on 'Escape' keypress if it is open
-    if (e.keyCode === 27) {
+    if (e.key === 'Escape') {
       e.preventDefault();
       if (isOpenRef.current) toggleDropdown();
     }
 
     // Toggle dropdown on Enter/Space keypresses
-    if (e.keyCode === 13 || e.keyCode === 32) {
+    if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
       toggleDropdown();
     }
@@ -176,7 +179,9 @@ const AnnotationSetSelect = ({
         setIsOpen(true);
         // Keep the container scrolled to top. Without this the first option 
         // gets out of view when dropdown is programatically opened
-        setTimeout(() => dropDownRef.current.scrollTop = 0, 0);
+        setTimeout(() => {
+          if (dropDownRef.current) dropDownRef.current.scrollTop = 0;
+        }, 0);
       }
 
       // Move focus to the first option in the list
@@ -204,7 +209,7 @@ const AnnotationSetSelect = ({
         if (option != undefined) {
           handleSelect(option);
         } else {
-          handleSelectAll();
+          handleSelectAll(e);
         }
         break;
       case 'ArrowDown':
@@ -233,6 +238,17 @@ const AnnotationSetSelect = ({
     if (nextIndex !== currentIndex.current) {
       allOptions[nextIndex].focus();
       setCurrentIndex(nextIndex);
+    }
+  };
+
+  /**
+   * Handle keydown event for the checkbox for turning auto-scroll on/off
+   * @param {Event} e keydown event
+   */
+  const handleAutoScrollKeyPress = (e) => {
+    if (e.key == ' ' || e.key == 'Enter') {
+      e.preventDefault();
+      setAutoScrollEnabled((prev) => !prev);
     }
   };
 
@@ -325,6 +341,7 @@ const AnnotationSetSelect = ({
               title='Auto-scroll with media'
               checked={autoScrollEnabled}
               onChange={() => { setAutoScrollEnabled(!autoScrollEnabled); }}
+              onKeyDown={handleAutoScrollKeyPress}
             />
             <label htmlFor='scroll-check' title='Auto-scroll with media'>
               Auto-scroll with media

--- a/src/components/MarkersDisplay/Annotations/AnnotationSetSelect.test.js
+++ b/src/components/MarkersDisplay/Annotations/AnnotationSetSelect.test.js
@@ -511,4 +511,238 @@ describe('AnnotationSetSelect component', () => {
     // Hides the dropdown list
     expect(multiSelect.children).toHaveLength(2);
   });
+
+  describe('dropdown menu with keyboard navigation', () => {
+    beforeEach(() => {
+      render(<AnnotationSetSelect
+        canvasAnnotationSets={annotationSets}
+        duration={572.34}
+        setDisplayedAnnotationSets={setDisplayedAnnotationSetsMock}
+        setAutoScrollEnabled={setAutoScrollEnabledMock}
+        autoScrollEnabled={true}
+      />);
+    });
+
+    test('renders successfully', () => {
+      expect(screen.queryByTestId('annotation-multi-select')).toBeInTheDocument();
+      expect(screen.getByTestId('annotation-multi-select').children).toHaveLength(2);
+      expect(screen.queryByTestId('annotations-scroll')).toBeInTheDocument();
+      expect(screen.getByTestId('annotations-scroll')).toHaveTextContent('Auto-scroll with media');
+    });
+
+    describe('when focused on dropwdown menu', () => {
+      let dropdownMenu, multiSelectHeader;
+      beforeEach(() => {
+        multiSelectHeader = screen.getByTestId('annotation-multi-select');
+        dropdownMenu = multiSelectHeader.children[0];
+        dropdownMenu.focus();
+      });
+
+      test('allows ArrowDown keypress to expand and navigate the dropdown', () => {
+        // Dropdown menu is collapsed initially
+        expect(dropdownMenu).toHaveClass('ramp--annotations__multi-select-header');
+        expect(dropdownMenu.children[0]).not.toHaveClass('open');
+
+        fireEvent.keyDown(dropdownMenu, { key: 'ArrowDown', keyCode: 40 });
+
+        // Opens the dropdown menu
+        expect(dropdownMenu.children[0]).toHaveClass('open');
+        expect(multiSelectHeader.childNodes[1].tagName).toEqual('UL');
+        expect(multiSelectHeader.childNodes[1].childNodes.length).toEqual(4);
+
+        // Press 'ArrowDown' key again
+        fireEvent.keyDown(dropdownMenu, { key: 'ArrowDown', keyCode: 40 });
+
+        // Focus is moved from the dropdown menu to its first option
+        expect(dropdownMenu).not.toHaveFocus();
+        expect(multiSelectHeader.childNodes[1].children[0]).toHaveFocus();
+      });
+
+      test('allows ArrowUp keypress to expand and navigate the dropdown', () => {
+        // Dropdown menu is collapsed initially
+        expect(dropdownMenu).toHaveClass('ramp--annotations__multi-select-header');
+        expect(dropdownMenu.children[0]).not.toHaveClass('open');
+
+        fireEvent.keyDown(dropdownMenu, { key: 'ArrowUp', keyCode: 38 });
+
+        // Opens the dropdown menu
+        expect(dropdownMenu.children[0]).toHaveClass('open');
+        expect(multiSelectHeader.childNodes[1].tagName).toEqual('UL');
+        expect(multiSelectHeader.childNodes[1].childNodes.length).toEqual(4);
+
+        // Press 'ArrowUp' key again
+        fireEvent.keyDown(dropdownMenu, { key: 'ArrowUp', keyCode: 38 });
+
+        // Focus is moved from the dropdown menu to its first option
+        expect(dropdownMenu).not.toHaveFocus();
+        expect(multiSelectHeader.childNodes[1].children[0]).toHaveFocus();
+      });
+
+      test('allows Enter keypress to expand dropdown and ArrowDown to navigate options', () => {
+        // Dropdown menu is collapsed initially
+        expect(dropdownMenu).toHaveClass('ramp--annotations__multi-select-header');
+        expect(dropdownMenu.children[0]).not.toHaveClass('open');
+
+        fireEvent.keyDown(dropdownMenu, { key: 'Enter', keyCode: 13 });
+
+        // Opens the dropdown menu
+        expect(dropdownMenu.children[0]).toHaveClass('open');
+        expect(multiSelectHeader.childNodes[1].tagName).toEqual('UL');
+        expect(multiSelectHeader.childNodes[1].childNodes.length).toEqual(4);
+
+        // Press 'ArrowDown' key
+        fireEvent.keyDown(dropdownMenu, { key: 'ArrowDown', keyCode: 40 });
+
+        // Focus is moved from the dropdown menu to its first option
+        expect(dropdownMenu).not.toHaveFocus();
+        expect(multiSelectHeader.childNodes[1].children[0]).toHaveFocus();
+      });
+
+      test('allows Space keypress to expand dropdown and ArrowDown to navigate options', () => {
+        // Dropdown menu is collapsed initially
+        expect(dropdownMenu).toHaveClass('ramp--annotations__multi-select-header');
+        expect(dropdownMenu.children[0]).not.toHaveClass('open');
+
+        fireEvent.keyDown(dropdownMenu, { key: ' ', keyCode: 32 });
+
+        // Opens the dropdown menu
+        expect(dropdownMenu.children[0]).toHaveClass('open');
+        expect(multiSelectHeader.childNodes[1].tagName).toEqual('UL');
+        expect(multiSelectHeader.childNodes[1].childNodes.length).toEqual(4);
+
+        // Press 'ArrowDown' key
+        fireEvent.keyDown(dropdownMenu, { key: 'ArrowDown', keyCode: 40 });
+
+        // Focus is moved from the dropdown menu to its first option
+        expect(dropdownMenu).not.toHaveFocus();
+        expect(multiSelectHeader.childNodes[1].children[0]).toHaveFocus();
+      });
+
+      test('allows Escape keypress to collapse the dropdown', () => {
+        // Dropdown menu is collapsed initially
+        expect(dropdownMenu).toHaveClass('ramp--annotations__multi-select-header');
+        expect(dropdownMenu.children[0]).not.toHaveClass('open');
+
+        fireEvent.keyDown(dropdownMenu, { key: ' ', keyCode: 32 });
+
+        // Opens the dropdown menu
+        expect(dropdownMenu.children[0]).toHaveClass('open');
+        expect(multiSelectHeader.childNodes[1].tagName).toEqual('UL');
+        expect(multiSelectHeader.childNodes[1].childNodes.length).toEqual(4);
+
+        // Press 'Escape' key
+        fireEvent.keyDown(dropdownMenu, { key: 'Escape', keyCode: 47 });
+
+        // Collapses the dropdown
+        expect(dropdownMenu).toHaveFocus();
+        expect(dropdownMenu.children[0]).not.toHaveClass('open');
+      });
+
+      test('allows Tab keypress to collapse the dropdown', () => {
+        // Dropdown menu is collapsed initially
+        expect(dropdownMenu.children[0]).not.toHaveClass('open');
+
+        fireEvent.keyDown(dropdownMenu, { key: ' ', keyCode: 32 });
+
+        // Opens the dropdown menu
+        expect(dropdownMenu.children[0]).toHaveClass('open');
+        expect(multiSelectHeader.childNodes[1].tagName).toEqual('UL');
+        expect(multiSelectHeader.childNodes[1].childNodes.length).toEqual(4);
+
+        // Press 'ArrowDown' key to move focus to options dropdown
+        fireEvent.keyDown(dropdownMenu, { key: 'ArrowDown', keyCode: 40 });
+
+        // Press 'Tab' key when focused on the first option in the dropdown
+        fireEvent.keyDown(multiSelectHeader.childNodes[1].childNodes[0], { key: 'Tab', keyCode: 9 });
+
+        // Collapses the dropdown
+        expect(dropdownMenu.children[0]).not.toHaveClass('open');
+      });
+    });
+
+    describe('when focused on an annotation set', () => {
+      let dropdownMenu, allOptions, multiSelectHeader;
+      beforeEach(() => {
+        multiSelectHeader = screen.getByTestId('annotation-multi-select');
+        dropdownMenu = multiSelectHeader.children[0];
+        dropdownMenu.focus();
+
+        // Press ArrowDown key twice to move focus to the first option
+        fireEvent.keyDown(dropdownMenu, { key: 'ArrowDown', keyCode: 40 });
+        fireEvent.keyDown(dropdownMenu, { key: 'ArrowDown', keyCode: 40 });
+
+        allOptions = multiSelectHeader.childNodes[1].childNodes;
+      });
+
+      test('allows Enter keypress to select the focused annotation set', async () => {
+        // The first option in the dropdown has focus initially
+        expect(allOptions).toHaveLength(4);
+        expect(allOptions[0]).toHaveFocus();
+        expect(allOptions[0]).toHaveAttribute('aria-selected', 'false');
+
+        await act(() => {
+          fireEvent.keyDown(allOptions[0], { key: 'Enter', keyCode: 13 });
+        });
+
+        // The first option for select all is checked
+        expect(allOptions[0]).toHaveAttribute('aria-selected', 'true');
+      });
+
+      test('allows Space keypress to select the focused annotation set', async () => {
+        // The first option in the dropdown has focus and is unchecked initially
+        expect(allOptions).toHaveLength(4);
+        expect(allOptions[0]).toHaveFocus();
+
+        // Press 'ArrowDown' key to select the next annotation set
+        fireEvent.keyDown(allOptions[0], { key: 'ArrowDown', keyCode: 40 });
+        fireEvent.keyDown(allOptions[0], { key: 'ArrowDown', keyCode: 40 });
+
+        expect(allOptions[0]).not.toHaveFocus();
+        expect(allOptions[2]).toHaveFocus();
+        expect(allOptions[2]).toHaveAttribute('aria-selected', 'false');
+
+        await act(() => {
+          fireEvent.keyDown(allOptions[2], { key: ' ', keyCode: 32 });
+        });
+
+        // Second option in the list is selected
+        expect(allOptions[2]).toHaveAttribute('aria-selected', 'true');
+      });
+
+      test('allows ArrowDown keypress to move focus to next option', () => {
+        // The first option in the dropdown has focus initially
+        expect(allOptions[0]).toHaveFocus();
+
+        fireEvent.keyDown(allOptions[0], { key: 'ArrowDown', keyCode: 40 });
+
+        // The second option in the dropdown has focus
+        expect(allOptions[0]).not.toHaveFocus();
+        expect(allOptions[1]).toHaveFocus();
+      });
+
+      test('allows ArrowUp keypress to move focus to last option', () => {
+        // The first option in the dropdown has focus initially
+        expect(allOptions[0]).toHaveFocus();
+
+        fireEvent.keyDown(allOptions[0], { key: 'ArrowUp', keyCode: 38 });
+
+        // The last option in the dropdown has focus
+        expect(allOptions[0]).not.toHaveFocus();
+        expect(allOptions[3]).toHaveFocus();
+      });
+
+      test('allows Escape keypress to collapse the dropdown', () => {
+        // The first option in the dropdown has focus initially
+        expect(allOptions[0]).toHaveFocus();
+
+        fireEvent.keyDown(allOptions[0], { key: 'Escape', keyCode: 47 });
+
+        // Dropdown UL element with options are not displayed
+        expect(multiSelectHeader.childNodes).toHaveLength(2);
+        expect(multiSelectHeader.childNodes[0]).toHaveClass('ramp--annotations__multi-select-header');
+        expect(multiSelectHeader.childNodes[1]).toHaveClass('ramp--annotations__scroll');
+        expect(dropdownMenu.children[0]).not.toHaveClass('open');
+      });
+    });
+  });
 });

--- a/src/components/MarkersDisplay/Annotations/AnnotationSetSelect.test.js
+++ b/src/components/MarkersDisplay/Annotations/AnnotationSetSelect.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import AnnotationSetSelect from './AnnotationSetSelect';
 import * as annotationParser from '@Services/annotations-parser';
 
@@ -658,6 +658,56 @@ describe('AnnotationSetSelect component', () => {
         // Collapses the dropdown
         expect(dropdownMenu.children[0]).not.toHaveClass('open');
       });
+
+      test('allows a printable character to focus an option starts with it', async () => {
+        // Dropdown menu is collapsed initially
+        expect(dropdownMenu).toHaveClass('ramp--annotations__multi-select-header');
+        expect(dropdownMenu.children[0]).not.toHaveClass('open');
+        expect(dropdownMenu).toHaveFocus();
+
+        fireEvent.keyDown(dropdownMenu, { key: 't', keyCode: 84 });
+
+        await waitFor(() => {
+          expect(dropdownMenu).not.toHaveFocus();
+          expect(dropdownMenu.children[0]).toHaveClass('open');
+          expect(multiSelectHeader.childNodes[1].children).toHaveLength(4);
+          const focusedOption = multiSelectHeader.childNodes[1].children[2];
+          expect(focusedOption).toHaveFocus();
+          expect(focusedOption.textContent.toLowerCase().startsWith('t')).toBeTruthy();
+        });
+      });
+
+      describe('and expanded', () => {
+        beforeEach(() => {
+          // Expand the dropdown list
+          fireEvent.keyDown(dropdownMenu, { key: 'Enter', keyCode: 13 });
+        });
+
+        test('allows Home keypress to focus the first option', () => {
+          // Dropdown menu is expanded initially
+          expect(dropdownMenu.children[0]).toHaveClass('open');
+          expect(dropdownMenu).toHaveFocus();
+
+          fireEvent.keyDown(dropdownMenu, { key: 'Home', keyCode: 36 });
+
+          // Focus is moved from the dropdown menu to its first option
+          expect(dropdownMenu).not.toHaveFocus();
+          expect(multiSelectHeader.childNodes[1].children[0]).toHaveFocus();
+        });
+
+        test('allows End keypress to focus the last option', () => {
+          // Dropdown menu is expanded initially
+          expect(dropdownMenu.children[0]).toHaveClass('open');
+          expect(dropdownMenu).toHaveFocus();
+          expect(multiSelectHeader.childNodes[1].children).toHaveLength(4);
+
+          fireEvent.keyDown(dropdownMenu, { key: 'End', keyCode: 35 });
+
+          // Focus is moved from the dropdown menu to its last option
+          expect(dropdownMenu).not.toHaveFocus();
+          expect(multiSelectHeader.childNodes[1].children[3]).toHaveFocus();
+        });
+      });
     });
 
     describe('when focused on an annotation set', () => {
@@ -742,6 +792,48 @@ describe('AnnotationSetSelect component', () => {
         expect(multiSelectHeader.childNodes[0]).toHaveClass('ramp--annotations__multi-select-header');
         expect(multiSelectHeader.childNodes[1]).toHaveClass('ramp--annotations__scroll');
         expect(dropdownMenu.children[0]).not.toHaveClass('open');
+      });
+
+      test('allows a printable character to focus an option starts with it', async () => {
+        // The first option in the dropdown has focus initially
+        expect(allOptions[0]).toHaveFocus();
+
+        fireEvent.keyDown(dropdownMenu, { key: 't', keyCode: 84 });
+
+        await waitFor(() => {
+          expect(allOptions[0]).not.toHaveFocus();
+          const focusedOption = allOptions[2];
+          expect(focusedOption).toHaveFocus();
+          expect(focusedOption.textContent.toLowerCase().startsWith('t')).toBeTruthy();
+        });
+      });
+
+      test('allows PageUp keypress to focus the first option', () => {
+        // The first option in the dropdown has focus initially
+        expect(allOptions[0]).toHaveFocus();
+
+        // Move focus to next option in the list
+        fireEvent.keyDown(allOptions[0], { key: 'ArrowDown', keyCode: 40 });
+        expect(allOptions[0]).not.toHaveFocus();
+        expect(allOptions[1]).toHaveFocus();
+
+        fireEvent.keyDown(dropdownMenu, { key: 'PageUp', keyCode: 33 });
+
+        // Focus is moved from second option to first option
+        expect(allOptions[0]).toHaveFocus();
+        expect(allOptions[1]).not.toHaveFocus();
+      });
+
+      test('allows PageDown keypress to focus the last option', () => {
+        // The first option in the dropdown has focus initially
+        expect(allOptions[0]).toHaveFocus();
+
+        fireEvent.keyDown(dropdownMenu, { key: 'PageDown', keyCode: 34 });
+
+        // Focus is moved from first option to last option
+        expect(allOptions[0]).not.toHaveFocus();
+        expect(allOptions[3]).toHaveFocus();
+
       });
     });
   });

--- a/src/components/MarkersDisplay/Annotations/AnnotationsDisplay.js
+++ b/src/components/MarkersDisplay/Annotations/AnnotationsDisplay.js
@@ -140,7 +140,8 @@ const AnnotationsDisplay = ({ annotations, canvasIndex, duration, displayMotivat
    * @param {Event} e keydown event
    */
   const handleKeyDown = (e) => {
-    const annotationRows = annotationRowContainerRef.current.children;
+    // Get all annotation rows by the click-able element className
+    const annotationRows = annotationRowContainerRef.current.querySelectorAll('.ramp--annotations__annotation-row-time-tags');
     if (annotationRows?.length > 0) {
       let nextIndex = currentIndex.current;
       if (e.key === 'ArrowDown') {
@@ -174,7 +175,10 @@ const AnnotationsDisplay = ({ annotations, canvasIndex, duration, displayMotivat
     } else {
       if (hasDisplayAnnotations && displayedAnnotations?.length > 0) {
         return (
-          <ul onKeyDown={handleKeyDown} role='listbox' ref={annotationRowContainerRef}>
+          <div onKeyDown={handleKeyDown}
+            ref={annotationRowContainerRef}
+            aria-label='Scrollable time-synced annotations list'
+          >
             {displayedAnnotations.map((annotation, index) => {
               return (
                 <AnnotationRow
@@ -189,7 +193,7 @@ const AnnotationsDisplay = ({ annotations, canvasIndex, duration, displayMotivat
                 />
               );
             })}
-          </ul>
+          </div>
         );
       } else {
         return (

--- a/src/components/MarkersDisplay/Annotations/AnnotationsDisplay.js
+++ b/src/components/MarkersDisplay/Annotations/AnnotationsDisplay.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import AnnotationSetSelect from './AnnotationSetSelect';
 import '../MarkersDisplay.scss';
 import AnnotationRow from './AnnotationRow';
-import { sortAnnotations } from '@Services/utility-helpers';
+import { autoScroll, sortAnnotations } from '@Services/utility-helpers';
 import Spinner from '@Components/Spinner';
 import { SUPPORTED_MOTIVATIONS } from '@Services/annotations-parser';
 
@@ -14,6 +14,11 @@ const AnnotationsDisplay = ({ annotations, canvasIndex, duration, displayMotivat
   const [isLoading, setIsLoading] = useState(true);
 
   const annotationDisplayRef = useRef(null);
+  const annotationRowContainerRef = useRef(null);
+
+  // Index of the focused annotation row in the list
+  const currentIndex = useRef(0);
+  const setCurrentIndex = (i) => currentIndex.current = i;
 
   /**
    * Update annotation sets for the current Canvas
@@ -124,13 +129,50 @@ const AnnotationsDisplay = ({ annotations, canvasIndex, duration, displayMotivat
     />);
   }, [autoScrollEnabled, canvasAnnotationSets]);
 
+  /**
+   * Handle keyboard accessibility within the annotations component using
+   * roving tabindex strategy.
+   * All annotation rows are given 'tabIndex' -1 except for the first annotation row
+   * in the list, which is set to 0.
+   * Then as the user uses 'ArrowDown' and 'ArrowDown' keys move up and down through
+   * the annotation rows the focus is moved enabling activation of each focused cue
+   * in the AnnotationRow component using keyboard.
+   * @param {Event} e keydown event
+   */
+  const handleKeyDown = (e) => {
+    const annotationRows = annotationRowContainerRef.current.children;
+    if (annotationRows?.length > 0) {
+      let nextIndex = currentIndex.current;
+      e.preventDefault();
+      if (e.key === 'ArrowDown') {
+        // Wraps focus back to first cue when the end of annotations list is reached
+        nextIndex = (currentIndex.current + 1) % annotationRows.length;
+      } else if (e.key === 'ArrowUp') {
+        nextIndex = (currentIndex.current - 1 + annotationRows.length) % annotationRows.length;
+      } else if (e.key === 'Tab' && e.shiftKey) {
+        // Returns focus to parent container on (Shift + Tab) key combination press
+        annotationRowContainerRef.current.parentElement.focus();
+        return;
+      }
+
+      if (nextIndex !== currentIndex.current) {
+        annotationRows[currentIndex.current].tabIndex = -1;
+        annotationRows[nextIndex].tabIndex = 0;
+        annotationRows[nextIndex].focus();
+        // Scroll the focused annotation row into view
+        autoScroll(annotationRows[nextIndex], annotationDisplayRef, true);
+        setCurrentIndex(nextIndex);
+      }
+    }
+  };
+
   const annotationRows = useMemo(() => {
     if (isLoading) {
       return <Spinner />;
     } else {
       if (hasDisplayAnnotations && displayedAnnotations?.length > 0) {
         return (
-          <ul>
+          <ul onKeyDown={handleKeyDown} role='listbox' ref={annotationRowContainerRef}>
             {displayedAnnotations.map((annotation, index) => {
               return (
                 <AnnotationRow
@@ -165,7 +207,9 @@ const AnnotationsDisplay = ({ annotations, canvasIndex, duration, displayMotivat
         data-testid="annotations-display">
         {annotationSetSelect}
         <div className="ramp--annotations__content"
-          data-testid="annotations-content" tabIndex={0} ref={annotationDisplayRef}>
+          data-testid="annotations-content" tabIndex={-1}
+          ref={annotationDisplayRef}
+        >
           {annotationRows}
         </div>
       </div>

--- a/src/components/MarkersDisplay/Annotations/AnnotationsDisplay.js
+++ b/src/components/MarkersDisplay/Annotations/AnnotationsDisplay.js
@@ -143,15 +143,17 @@ const AnnotationsDisplay = ({ annotations, canvasIndex, duration, displayMotivat
     const annotationRows = annotationRowContainerRef.current.children;
     if (annotationRows?.length > 0) {
       let nextIndex = currentIndex.current;
-      e.preventDefault();
       if (e.key === 'ArrowDown') {
         // Wraps focus back to first cue when the end of annotations list is reached
         nextIndex = (currentIndex.current + 1) % annotationRows.length;
+        e.preventDefault();
       } else if (e.key === 'ArrowUp') {
         nextIndex = (currentIndex.current - 1 + annotationRows.length) % annotationRows.length;
+        e.preventDefault();
       } else if (e.key === 'Tab' && e.shiftKey) {
         // Returns focus to parent container on (Shift + Tab) key combination press
         annotationRowContainerRef.current.parentElement.focus();
+        e.preventDefault();
         return;
       }
 

--- a/src/components/MarkersDisplay/MarkersDisplay.scss
+++ b/src/components/MarkersDisplay/MarkersDisplay.scss
@@ -147,6 +147,10 @@
     .ramp--annotations__multi-select {
       position: relative;
       font-family: Arial, sans-serif;
+
+      .ramp--annotations__scroll input {
+        accent-color: $primaryGreenDark;
+      }
     }
 
     .ramp--annotations__multi-select-header {
@@ -201,6 +205,12 @@
 
     .annotations-dropdown-item input[type="checkbox"] {
       margin-right: 8px;
+      accent-color: $primaryGreenDark;
+    }
+    .annotations-dropdown-menu li:focus {
+      outline: none !important;
+      background-color: $primaryLighter;
+      border: 2px solid $primaryGreenDark;
     }
   }
 
@@ -223,7 +233,8 @@
       background-color: $primaryLighter;
     }
 
-    &:hover {
+    &:hover,
+    &:focus {
       background-color: $primaryGreenLight;
     }
 

--- a/src/components/MarkersDisplay/MarkersDisplay.scss
+++ b/src/components/MarkersDisplay/MarkersDisplay.scss
@@ -218,30 +218,29 @@
     height: 19em;
     overflow-y: auto;
 
-    ul {
+    >div {
       padding: 0;
       margin-top: 0;
     }
   }
 
   .ramp--annotations__annotation-row {
-    list-style: none;
-    cursor: pointer;
-    padding: 10px;
-
     &.active {
       background-color: $primaryLighter;
     }
 
-    &:hover,
-    &:focus {
-      background-color: $primaryGreenLight;
-    }
-
     .ramp--annotations__annotation-row-time-tags {
+      cursor: pointer;
       display: grid;
       grid-template-columns: repeat(2, 1fr);
       border-bottom: 1px dotted $primaryDarker;
+      padding: 0.5em; // Need to be same in .ramp--annotations__annotation-texts
+      padding-bottom: 0.25em;
+
+      &:hover,
+      &:focus {
+        background-color: $primaryGreenLight;
+      }
 
       .ramp--annotations__annotation-tags {
         display: flex;
@@ -305,8 +304,8 @@
     .ramp--annotations__annotation-texts {
       display: flex;
       flex-direction: column;
-      margin-top: 0.5em;
       line-height: 1.5em;
+      padding: 0.5em; // Need to be same in .ramp--annotations__annotation-row-time-tags
 
       :last-child {
         margin-left: auto;
@@ -314,7 +313,6 @@
 
       p.ramp--annotations__annotation-text {
         margin: 0;
-        margin-top: 0.5em;
 
         &.hidden {
           display: none;

--- a/src/components/Transcript/TranscriptMenu/TranscriptMenu.scss
+++ b/src/components/Transcript/TranscriptMenu/TranscriptMenu.scss
@@ -86,6 +86,10 @@
   justify-content: flex-end;
   line-height: 1.25em;
 
+  & input {
+    accent-color: $primaryGreenDark;
+  }
+
   & label {
     margin-left: 0.25em;
     line-height: 1.25em;

--- a/src/services/annotation-parser.test.js
+++ b/src/services/annotation-parser.test.js
@@ -1098,7 +1098,7 @@ describe('annotation-parser', () => {
     });
   });
 
-  describe('parseExternalAnnotationPage', () => {
+  describe('parseExternalAnnotationPage()', () => {
     describe('parses annotations for valid linked AnnotationPage', () => {
       let fetchSpy, annotations, spy;
       beforeEach(async () => {
@@ -1249,7 +1249,7 @@ describe('annotation-parser', () => {
       expect(items.length).toEqual(5);
       expect(items[0]).toEqual({
         canvasId: 'http://example.com/example-manifest/canvas/1',
-        id: 'http://example.com/example-manifest/canvas/1/page/annotation-1',
+        id: 'http://example.com/example-manifest/canvas/1/page/annotation-1-0',
         motivation: ['supplementing'],
         time: { start: 1.2, end: 21 },
         value: [{ format: 'text/plain', purpose: ['supplementing'], value: '[music]' }]

--- a/src/services/annotations-parser.js
+++ b/src/services/annotations-parser.js
@@ -1,5 +1,5 @@
 import { getCanvasId } from "./iiif-parser";
-import { parseTranscriptData } from "./transcript-parser";
+import { parseTranscriptData, TRANSCRIPT_TYPES } from "./transcript-parser";
 import {
   getLabelValue, getMediaFragment, handleFetchErrors,
   identifySupplementingAnnotation,
@@ -364,17 +364,20 @@ function parseAnnotationBody(annotationBody, motivations) {
  */
 export async function parseExternalAnnotationResource(annotation) {
   const { canvasId, format, id, motivation, url } = annotation;
-  const { tData } = await parseTranscriptData(url, format);
-  return tData.map((data) => {
-    const { begin, end, text } = data;
-    return {
-      canvasId,
-      id,
-      motivation,
-      time: { start: begin, end },
-      value: [{ format: 'text/plain', purpose: motivation, value: text }],
-    };
-  });
+  const { tData, tType } = await parseTranscriptData(url, format);
+  // Only parse the transcript if it is valid
+  if (tData && (tType != TRANSCRIPT_TYPES.invalidTimestamp && tType != TRANSCRIPT_TYPES.invalidVTT)) {
+    return tData.map((data, index) => {
+      const { begin, end, text } = data;
+      return {
+        canvasId,
+        id: `${id}-${index}`, // Add unique ids for each cue based on annotation id
+        motivation,
+        time: { start: begin, end },
+        value: [{ format: 'text/plain', purpose: motivation, value: text }],
+      };
+    });
+  }
 }
 
 /**

--- a/src/services/utility-helpers.js
+++ b/src/services/utility-helpers.js
@@ -885,6 +885,11 @@ const truncateNode = (node, maxLength) => {
     }
   }
 
+  // Set tab-index of each Anchor node to -1 to remove them from tab order of the page
+  if (node.nodeType === Node.ELEMENT_NODE && node.nodeName.toLowerCase() === 'a') {
+    node.tabIndex = -1;
+  }
+
   let currentRemaining = maxLength;
   const childNodes = Array.from(node.childNodes);
 

--- a/src/services/utility-helpers.js
+++ b/src/services/utility-helpers.js
@@ -626,17 +626,19 @@ export function playerHotKeys(event, player, canvasIsEmpty) {
   // Check if ctrl/cmd/alt/shift keys are pressed when using key combinations
   let isCombKeyPress = event.ctrlKey || event.metaKey || event.altKey || event.shiftKey;
 
+  // CSS classes of active buttons to skip
+  let buttonClassesToCheck = ['ramp--transcript_item', 'ramp--structured-nav__section-title',
+    'ramp--structured-nav__item-link', 'ramp--structured-nav__collapse-all-btn',
+    'ramp--annotations__multi-select-header', 'ramp--annotations__show-more-tags',
+    'ramp--annotations__show-more-less'
+  ];
+
   // Determine the focused element and pressed key combination needs to be skipped
-  let skipActionWithButtonFocus = activeElement?.role === 'button'
+  let skipActionWithButtonFocus = (
+    activeElement?.role === 'button'
     && (
       (
-        (
-          activeElement?.classList?.contains('ramp--transcript_item')
-          || activeElement?.classList?.contains('ramp--structured-nav__section-title')
-          || activeElement?.classList?.contains('ramp--structured-nav__item-link')
-          || activeElement?.classList?.contains('ramp--structured-nav__collapse-all-btn')
-          || activeElement?.classList?.contains('ramp--annotations__multi-select-header')
-        )
+        buttonClassesToCheck.some(c => activeElement?.classList?.contains(c))
         && (pressedKey === 38 || pressedKey === 40 || pressedKey === 32)
       )
       || (
@@ -648,7 +650,7 @@ export function playerHotKeys(event, player, canvasIsEmpty) {
         ) // Collapse/expand for ArrowLeft and ArrowRight respectively when focused on a section
       )
     )
-    || (
+  ) || (
       activeElement?.role === 'option'
       && (
         activeElement?.classList?.contains('annotations-dropdown-item')

--- a/src/services/utility-helpers.js
+++ b/src/services/utility-helpers.js
@@ -627,7 +627,7 @@ export function playerHotKeys(event, player, canvasIsEmpty) {
   let isCombKeyPress = event.ctrlKey || event.metaKey || event.altKey || event.shiftKey;
 
   // Determine the focused element and pressed key combination needs to be skipped
-  let skipActionWithButtonFocus = activeElement?.role === "button"
+  let skipActionWithButtonFocus = activeElement?.role === 'button'
     && (
       (
         (
@@ -635,6 +635,7 @@ export function playerHotKeys(event, player, canvasIsEmpty) {
           || activeElement?.classList?.contains('ramp--structured-nav__section-title')
           || activeElement?.classList?.contains('ramp--structured-nav__item-link')
           || activeElement?.classList?.contains('ramp--structured-nav__collapse-all-btn')
+          || activeElement?.classList?.contains('ramp--annotations__multi-select-header')
         )
         && (pressedKey === 38 || pressedKey === 40 || pressedKey === 32)
       )
@@ -646,6 +647,14 @@ export function playerHotKeys(event, player, canvasIsEmpty) {
           && (pressedKey === 37 || pressedKey === 39)
         ) // Collapse/expand for ArrowLeft and ArrowRight respectively when focused on a section
       )
+    )
+    || (
+      activeElement?.role === 'option'
+      && (
+        activeElement?.classList?.contains('annotations-dropdown-item')
+        || activeElement?.classList?.contains('ramp--annotations__annotation-row')
+      )
+      && (pressedKey === 38 || pressedKey === 40 || pressedKey === 32 || pressedKey === 13)
     );
 
   /*

--- a/src/services/utility-helpers.test.js
+++ b/src/services/utility-helpers.test.js
@@ -916,7 +916,7 @@ describe('util helper', () => {
       // Character count for text "Bold and superscript text" is 25
       const html = '<p><strong>Bold</strong> and <sup><a href="http://example.com">superscript</a></sup> text</p>';
       const { isTruncated, truncated } = util.truncateText(html, 15);
-      expect(truncated).toBe('<p><strong>Bold</strong> and <sup><a href="http://example.com">supers...</a></sup></p>');
+      expect(truncated).toBe('<p><strong>Bold</strong> and <sup><a href="http://example.com" tabindex="-1">supers...</a></sup></p>');
       expect(isTruncated).toBe(true);
     });
   });

--- a/src/services/utility-helpers.test.js
+++ b/src/services/utility-helpers.test.js
@@ -916,7 +916,7 @@ describe('util helper', () => {
       // Character count for text "Bold and superscript text" is 25
       const html = '<p><strong>Bold</strong> and <sup><a href="http://example.com">superscript</a></sup> text</p>';
       const { isTruncated, truncated } = util.truncateText(html, 15);
-      expect(truncated).toBe('<p><strong>Bold</strong> and <sup><a href="http://example.com" tabindex="-1">supers...</a></sup></p>');
+      expect(truncated).toBe('<p><strong>Bold</strong> and <sup><a href="http://example.com">supers...</a></sup></p>');
       expect(isTruncated).toBe(true);
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1631,6 +1631,11 @@
   dependencies:
     "@babel/runtime" "^7.12.5"
 
+"@testing-library/user-event@^14.6.1":
+  version "14.6.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.6.1.tgz#13e09a32d7a8b7060fe38304788ebf4197cd2149"
+  integrity sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==
+
 "@tippyjs/react@4.1.0":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@tippyjs/react/-/react-4.1.0.tgz#be4e826ac198d2394a5ffed3508ca9c098c527f1"


### PR DESCRIPTION
Related issues: #815, #817, and #811

Changes in the PR:
- remove `<li />` elements for annotation-row which implicitly adds list based aria-role blocking the use of `role="button"` on annotation row elements. Having `role="button"` let screen-readers to announce instructions for activating the annotation upon focus (#815)
- replace `<ul />` with `<div />` element to remove implicit role relationship associated with the `<ul />` (#811)
- use aria-role 'button' only on the timestamp portion of the annotation row to enable nesting `<a />` and `<button />` tags within annotation texts (#811)
- add `aria-label` to annotation's timestamp, with more user friendly time formats
- some cleanup on the player hotkeys function for changing roles and test everything works

These need to be broken into multiple PRs once the base PR is merged.

Merge after #805 