### PR TITLE
Fix possible role relation a11y issues in transcript display

### DIFF
--- a/src/components/Transcript/Transcript.scss
+++ b/src/components/Transcript/Transcript.scss
@@ -40,17 +40,22 @@ p.ramp--transcript_untimed_item {
 span.ramp--transcript_item {
   display: flex;
   margin: 10px 10px 10px 10px;
-  cursor: pointer;
   text-decoration: none;
   transition: background-color 0.2s ease-in;
+  align-items: center;
+
+  &.untimed {
+    // Enable pointer events for untimed items to allow scrolling on click
+    cursor: pointer;
+    // Highlight entire cue on hover
+    &:focus,
+    &:hover {
+      background-color: $primaryGreenLight;
+    }
+  }
 
   &.active {
     background-color: $primaryLighter;
-  }
-
-  &:hover,
-  &:focus {
-    background-color: $primaryGreenLight;
   }
 
   &.disabled {
@@ -71,8 +76,13 @@ span.ramp--transcript_item {
   }
 
   .ramp--transcript_time {
-    margin-right: 15px;
+    cursor: pointer;
+    margin-right: 1em;
     color: $primaryGreenDark;
+
+    &:hover {
+      text-decoration: underline;
+    }
   }
 
   .ramp--transcript_text {

--- a/src/components/Transcript/Transcript.test.js
+++ b/src/components/Transcript/Transcript.test.js
@@ -110,11 +110,24 @@ describe('Transcript component', () => {
         });
       });
 
-      test('highlights transcript item on click', async () => {
+      test('highlights cue when clicking on cue\'s timestamp', async () => {
         await waitFor(() => {
           const transcriptItem = screen.queryAllByTestId('transcript_item')[0];
-          fireEvent.click(transcriptItem);
+          expect(transcriptItem.children).toHaveLength(2);
+          expect(transcriptItem.children[0].textContent).toEqual('[00:00:01]');
+          expect(transcriptItem.children[1].textContent).toEqual('[music]');
+          expect(transcriptItem.classList.contains('active')).toBeFalsy();
+          // Click on the cue's timestamp
+          fireEvent.click(transcriptItem.children[0]);
           expect(transcriptItem.classList.contains('active')).toBeTruthy();
+        });
+      });
+
+      test('does nothing when clicking on the cue\'s text', async () => {
+        await waitFor(() => {
+          const transcriptItem = screen.queryAllByTestId('transcript_item')[0];
+          fireEvent.click(transcriptItem.children[1]);
+          expect(transcriptItem.classList.contains('active')).toBeFalsy();
         });
       });
     });
@@ -190,11 +203,39 @@ describe('Transcript component', () => {
         });
       });
 
-      test('renders the rest of the cue with timestamp', async () => {
+      test('renders the rest of the cues with timestamps', async () => {
+        await waitFor(() => {
+          const transcriptItem0 = screen.queryAllByTestId('transcript_item')[0];
+          expect(transcriptItem0.children).toHaveLength(2);
+          expect(transcriptItem0.children[0].textContent).toEqual('[00:00:01]');
+          expect(transcriptItem0.children[1].textContent).toEqual('[music]');
+          expect(transcriptItem0.classList.contains('active')).toBeFalsy();
+
+          const transcriptItem1 = screen.queryAllByTestId('transcript_item')[1];
+          expect(transcriptItem1.children).toHaveLength(2);
+          expect(transcriptItem1.children[0].textContent).toEqual('[00:00:22]');
+          expect(transcriptItem1.children[1].textContent).toEqual('transcript text 1');
+          expect(transcriptItem1.classList.contains('active')).toBeFalsy();
+        });
+      });
+
+      test('highlights cue when clicking on the cue\'s timestamp', async () => {
         await waitFor(() => {
           const transcriptItem = screen.queryAllByTestId('transcript_item')[1];
-          fireEvent.click(transcriptItem);
+          expect(transcriptItem.children).toHaveLength(2);
+          expect(transcriptItem.children[0].textContent).toEqual('[00:00:22]');
+          expect(transcriptItem.children[1].textContent).toEqual('transcript text 1');
+          // Click on the cue's timestamp
+          fireEvent.click(transcriptItem.children[0]);
           expect(transcriptItem.classList.contains('active')).toBeTruthy();
+        });
+      });
+
+      test('does nothing when clicking on the cue\'s text', async () => {
+        await waitFor(() => {
+          const transcriptItem = screen.queryAllByTestId('transcript_item')[1];
+          fireEvent.click(transcriptItem.children[1]);
+          expect(transcriptItem.classList.contains('active')).toBeFalsy();
         });
       });
     });

--- a/src/services/annotations-parser.js
+++ b/src/services/annotations-parser.js
@@ -365,16 +365,18 @@ function parseAnnotationBody(annotationBody, motivations) {
 export async function parseExternalAnnotationResource(annotation) {
   const { canvasId, format, id, motivation, url } = annotation;
   const { tData } = await parseTranscriptData(url, format);
-  return tData.map((data) => {
-    const { begin, end, text } = data;
-    return {
-      canvasId,
-      id,
-      motivation,
-      time: { start: begin, end },
-      value: [{ format: 'text/plain', purpose: motivation, value: text }],
-    };
-  });
+  if (tData) {
+    return tData.map((data) => {
+      const { begin, end, text } = data;
+      return {
+        canvasId,
+        id,
+        motivation,
+        time: { start: begin, end },
+        value: [{ format: 'text/plain', purpose: motivation, value: text }],
+      };
+    });
+  }
 }
 
 /**

--- a/src/services/utility-helpers.js
+++ b/src/services/utility-helpers.js
@@ -110,6 +110,17 @@ export function screenReaderFriendlyTime(time) {
 };
 
 /**
+ * Convert a given text with HTML tags to a string read as a human
+ * @param {String} html text with HTML tags
+ * @returns {String} text without HTML tags
+ */
+export function screenReaderFriendlyText(html) {
+  const tempElement = document.createElement('div');
+  tempElement.innerHTML = html;
+  return tempElement.textContent || tempElement.innerText || "";
+}
+
+/**
  * Convert time from hh:mm:ss.ms/mm:ss.ms string format to int
  * @function Utils#timeToS
  * @param {String} time convert time from string to int
@@ -631,7 +642,7 @@ export function playerHotKeys(event, player, canvasIsEmpty) {
     && (
       (
         (
-          activeElement?.classList?.contains('ramp--transcript_item')
+          activeElement?.classList?.contains('ramp--transcript_time')
           || activeElement?.classList?.contains('ramp--structured-nav__section-title')
           || activeElement?.classList?.contains('ramp--structured-nav__item-link')
           || activeElement?.classList?.contains('ramp--structured-nav__collapse-all-btn')
@@ -668,6 +679,8 @@ export function playerHotKeys(event, player, canvasIsEmpty) {
         inputs.indexOf(activeElement.tagName.toLowerCase()) !== -1
         || (activeElement.role === 'tab' && (pressedKey === 37 || pressedKey === 39))
         || (activeElement.role === 'switch' && (pressedKey === 13 || pressedKey === 32))
+        || (activeElement?.classList?.contains('transcript_content') && (pressedKey === 38 || pressedKey === 40))
+        || (activeElement?.classList?.contains('ramp--transcript_item')) && (pressedKey === 38 || pressedKey === 40)
         || skipActionWithButtonFocus
       )
       && !focusedWithinPlayer)


### PR DESCRIPTION
Remove `radiogroup/radio` role relationship introduced in #820 for transcript cues as this could introduce role relationship errors similar to annotations component (#811) in the future. E.g. cues with links embedded in them could lead to a break in accessibility as they are presented within a parent container which has the `role="radio"`.

Changes included in the PR:
- make only the timestamp portion of the cue clickable with `role="button"`, therefore only highlighting the timestamp on hover events
- add additional keyboard and click event handling to untimed cues as these are now presented as focus-able plain text elements