### PR TITLE
Fix voiceover and role relationship errors for annotations

### DIFF
--- a/src/components/MarkersDisplay/Annotations/AnnotationRow.js
+++ b/src/components/MarkersDisplay/Annotations/AnnotationRow.js
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { autoScroll, timeToHHmmss } from '@Services/utility-helpers';
+import { autoScroll, screenReaderFriendlyText, screenReaderFriendlyTime, timeToHHmmss } from '@Services/utility-helpers';
 import { useAnnotationRow, useMediaPlayer, useShowMoreOrLess } from '@Services/ramp-hooks';
 import { SUPPORTED_MOTIVATIONS } from '@Services/annotations-parser';
 
@@ -242,11 +242,25 @@ const AnnotationRow = ({
     }
   };
 
+  /**
+   * Screen reader friendly label for the annotation row, that includes the start and/or 
+   * end time of the annotation and the text to be read by the screen reader.
+   */
+  const screenReaderLabel = useMemo(() => {
+    const textToRead = screenReaderFriendlyText(textToShow);
+    const startTimeToRead = time?.start != undefined ? screenReaderFriendlyTime(time?.start) : '';
+    if (time?.end != undefined) {
+      return `From ${startTimeToRead} to ${screenReaderFriendlyTime(time.end)}, ${textToRead}`;
+    } else {
+      return `${startTimeToRead}, ${textToRead}`;
+    }
+  }, [time, textToShow]);
+
   if (canDisplay) {
     return (
-      <li
+      <div
         key={`li_${index}`}
-        role='option'
+        role='button'
         tabIndex={index === 0 ? 0 : -1}
         ref={annotationRef}
         onClick={handleOnClick}
@@ -256,6 +270,7 @@ const AnnotationRow = ({
           'ramp--annotations__annotation-row',
           isActive && 'active'
         )}
+        aria-label={screenReaderLabel}
       >
         <div key={`row_${index}`} className='ramp--annotations__annotation-row-time-tags'>
           <div
@@ -343,7 +358,7 @@ const AnnotationRow = ({
             </button>)
           }
         </div>
-      </li >
+      </div>
     );
   } else {
     return null;

--- a/src/components/MarkersDisplay/Annotations/AnnotationSetSelect.js
+++ b/src/components/MarkersDisplay/Annotations/AnnotationSetSelect.js
@@ -107,9 +107,11 @@ const AnnotationSetSelect = ({
    * @param {Array} items list of timed annotations
    */
   const makeSelection = (annotationSet, items) => {
-    annotationSet.items = items;
-    setSelectedAnnotationSets((prev) => [...prev, annotationSet.label]);
-    setDisplayedAnnotationSets((prev) => [...prev, annotationSet]);
+    if (items != undefined) {
+      annotationSet.items = items;
+      setSelectedAnnotationSets((prev) => [...prev, annotationSet.label]);
+      setDisplayedAnnotationSets((prev) => [...prev, annotationSet]);
+    }
   };
 
   /**

--- a/src/components/MarkersDisplay/Annotations/AnnotationsDisplay.js
+++ b/src/components/MarkersDisplay/Annotations/AnnotationsDisplay.js
@@ -174,7 +174,10 @@ const AnnotationsDisplay = ({ annotations, canvasIndex, duration, displayMotivat
     } else {
       if (hasDisplayAnnotations && displayedAnnotations?.length > 0) {
         return (
-          <ul onKeyDown={handleKeyDown} role='listbox' ref={annotationRowContainerRef}>
+          <div onKeyDown={handleKeyDown}
+            ref={annotationRowContainerRef}
+            aria-label='Scrollable time-synced annotations list'
+          >
             {displayedAnnotations.map((annotation, index) => {
               return (
                 <AnnotationRow
@@ -189,7 +192,7 @@ const AnnotationsDisplay = ({ annotations, canvasIndex, duration, displayMotivat
                 />
               );
             })}
-          </ul>
+          </div>
         );
       } else {
         return (

--- a/src/components/MarkersDisplay/MarkersDisplay.scss
+++ b/src/components/MarkersDisplay/MarkersDisplay.scss
@@ -218,7 +218,7 @@
     height: 19em;
     overflow-y: auto;
 
-    ul {
+    >div {
       padding: 0;
       margin-top: 0;
     }

--- a/src/services/annotation-parser.test.js
+++ b/src/services/annotation-parser.test.js
@@ -1098,7 +1098,7 @@ describe('annotation-parser', () => {
     });
   });
 
-  describe('parseExternalAnnotationPage', () => {
+  describe('parseExternalAnnotationPage()', () => {
     describe('parses annotations for valid linked AnnotationPage', () => {
       let fetchSpy, annotations, spy;
       beforeEach(async () => {
@@ -1249,7 +1249,7 @@ describe('annotation-parser', () => {
       expect(items.length).toEqual(5);
       expect(items[0]).toEqual({
         canvasId: 'http://example.com/example-manifest/canvas/1',
-        id: 'http://example.com/example-manifest/canvas/1/page/annotation-1',
+        id: 'http://example.com/example-manifest/canvas/1/page/annotation-1-0',
         motivation: ['supplementing'],
         time: { start: 1.2, end: 21 },
         value: [{ format: 'text/plain', purpose: ['supplementing'], value: '[music]' }]

--- a/src/services/annotations-parser.js
+++ b/src/services/annotations-parser.js
@@ -1,5 +1,5 @@
 import { getCanvasId } from "./iiif-parser";
-import { parseTranscriptData } from "./transcript-parser";
+import { parseTranscriptData, TRANSCRIPT_TYPES } from "./transcript-parser";
 import {
   getLabelValue, getMediaFragment, handleFetchErrors,
   identifySupplementingAnnotation,
@@ -364,13 +364,14 @@ function parseAnnotationBody(annotationBody, motivations) {
  */
 export async function parseExternalAnnotationResource(annotation) {
   const { canvasId, format, id, motivation, url } = annotation;
-  const { tData } = await parseTranscriptData(url, format);
-  if (tData) {
-    return tData.map((data) => {
+  const { tData, tType } = await parseTranscriptData(url, format);
+  // Only parse the transcript if it is valid
+  if (tData && (tType != TRANSCRIPT_TYPES.invalidTimestamp && tType != TRANSCRIPT_TYPES.invalidVTT)) {
+    return tData.map((data, index) => {
       const { begin, end, text } = data;
       return {
         canvasId,
-        id,
+        id: `${id}-${index}`, // Add unique ids for each cue based on annotation id
         motivation,
         time: { start: begin, end },
         value: [{ format: 'text/plain', purpose: motivation, value: text }],

--- a/src/services/utility-helpers.js
+++ b/src/services/utility-helpers.js
@@ -650,24 +650,21 @@ export function playerHotKeys(event, player, canvasIsEmpty) {
     && (
       (
         buttonClassesToCheck.some(c => activeElement?.classList?.contains(c))
-        && (pressedKey === 38 || pressedKey === 40 || pressedKey === 32)
-      )
+        && (pressedKey === 38 || pressedKey === 40 || pressedKey === 32 || pressedKey === 13)
+      ) // Skip hot-keys when focused on transcript item/structure item/annotation row for ArrowUp/ArrowDown/Space/Enter keys
       || (
         ((
           activeElement?.classList?.contains('ramp--structured-nav__section-title')
           || activeElement?.classList?.contains('ramp--structured-nav__collapse-all-btn')
         )
           && (pressedKey === 37 || pressedKey === 39)
-        ) // Collapse/expand for ArrowLeft and ArrowRight respectively when focused on a section
+        ) // Skip hot-keys when focused on a section or close/expand button for ArrowLeft/ArrowRight keys 
       )
     )
   ) || (
-      activeElement?.role === 'option'
-      && (
-        activeElement?.classList?.contains('annotations-dropdown-item')
-        || activeElement?.classList?.contains('ramp--annotations__annotation-row')
-      )
-      && (pressedKey === 38 || pressedKey === 40 || pressedKey === 32 || pressedKey === 13)
+      (activeElement?.role === 'button' && activeElement?.classList?.contains('ramp--annotations__multi-select-header'))
+      || (activeElement?.role === 'option' && activeElement?.classList?.contains('annotations-dropdown-item'))
+      // Skip hot-keys when focused on annotation set dropdown/item, since it allows printable characters for keyboard navigation
     );
 
   /*
@@ -721,7 +718,7 @@ export function playerHotKeys(event, player, canvasIsEmpty) {
       case 70:
         event.preventDefault();
         // Fullscreen should only be available for videos
-        if (!playerInst.isAudio()) {
+        if (!playerInst.audioOnlyMode()) {
           if (!playerInst.isFullscreen()) {
             output = HOTKEY_ACTION_OUTPUT.enterFullscreen;
             playerInst.requestFullscreen();


### PR DESCRIPTION
Related issues: #811 and #815

To fix the role relationship error in annotations component, `<ul />` and `<li />` elements replaced with `<div />` elements when creating the annotations list. Because these list elements are document structure elements, implicit roles were being added to the DOM. And these roles were blocking the use of `role="button"` for annotations and displaying links and buttons within the annotation text.

As a result of this, #815 gets automatically fixed because, removing `<li>` in the annotation row implementation eliminated the list-based role overriding `role="button"` for a clickable annotation row, which automatically enables the instructions to activate the annotation in VoiceOver 

Additionally;
- added `aria-label` to annotation row with more user friendly time formats
- some cleanup on the player hotkeys function
- fix highlights for active annotation with time ranges