### PR TITLE
Limit button role for timestamps, to avoid a11y issues with links in annotations

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^16.0.1",
+    "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^26.0.12",
     "@types/react": "18.3.5",
     "babel-jest": "^26.3.0",

--- a/src/components/MarkersDisplay/Annotations/AnnotationRow.js
+++ b/src/components/MarkersDisplay/Annotations/AnnotationRow.js
@@ -38,10 +38,6 @@ const AnnotationRow = ({
   const isShowMoreRef = useRef(true);
   const setIsShowMoreRef = (state) => isShowMoreRef.current = state;
 
-  // Track the index of the focused link/button within the annotation
-  const focusedIndex = useRef(-1);
-  const setFocusedIndex = (i) => focusedIndex.current = i;
-
   // TextualBodies with purpose tagging to be displayed as tags next to time range
   const tags = useMemo(() => {
     return value.filter((v) => v.purpose.includes('tagging'));
@@ -97,11 +93,8 @@ const AnnotationRow = ({
     });
 
   /**
-   * Click event handler for annotations displayed.
-   * An annotation can have links embedded in the text; and the click event's
-   * target is a link, then open the link in the same page.
-   * If the click event's target is the text or the timestamp of the
-   * annotation, then seek the player to;
+   * Click event handler for annotations displayed in the UI.
+   * Seek the player to;
    * - start time of an Annotation with a time range
    * - timestamp of an Annotation with a single time-point.
    */
@@ -109,21 +102,6 @@ const AnnotationRow = ({
     e.preventDefault();
     checkCanvas(annotation);
 
-    // Do nothing when clicked on 'Show more'/'Show less' button
-    if (e.target.tagName === 'BUTTON') return;
-
-    // Handle click on a link in the text in the same tab without seeking the player
-    if (e.target.tagName == 'A') {
-      // Check if the href value is a valid URL before navigation
-      const urlRegex = /https?:\/\/[^\s/$.?#].[^\s]*/gi;
-      const href = e.target.getAttribute('href');
-      if (!href?.match(urlRegex)) {
-        e.preventDefault();
-      } else {
-        window.open(e.target.href, '_self');
-        return;
-      }
-    }
     const currTime = time?.start;
     if (player && player?.targets?.length > 0) {
       const { start, end } = player.targets[0];
@@ -141,6 +119,25 @@ const AnnotationRow = ({
     }
   }, [annotation, player]);
 
+  /**
+   * Validate and handle click events on a link in the annotation text
+   * @param {Event} e 
+   * @returns 
+   */
+  const handleLinkClicks = (e) => {
+    // Handle click on a link in the text in the same tab without seeking the player
+    if (e.target.tagName == 'A') {
+      // Check if the href value is a valid URL before navigation
+      const urlRegex = /https?:\/\/[^\s/$.?#].[^\s]*/gi;
+      const href = e.target.getAttribute('href');
+      if (!href?.match(urlRegex)) {
+        e.preventDefault();
+      } else {
+        window.open(e.target.href, '_self');
+        return;
+      }
+    }
+  };
 
   /**
    * Click event handler for the 'Show more'/'Show less' button for
@@ -196,49 +193,12 @@ const AnnotationRow = ({
   /**
    * Seek the player to the start time of the activated annotation, and mark it as active
    * when using Enter/Space keys to select the focused annotation
-   * Trap focus within the annotation to navigate through any links or buttons in the
-   * annotation row display when Tab key is pressed
    * @param {Event} e keyboard event
    * @returns 
    */
   const handleKeyDown = (e) => {
-    // Get links/buttons inside the annotation row
-    const linksAndButtons = annotationRef.current.querySelectorAll('button, a');
-    const handleTab = (e) => {
-      let nextIndex = focusedIndex.current;
-      // Allow tabbing through links/buttons if they exist, and do nothing if not
-      if (linksAndButtons?.length > 0) {
-        if (e.shiftKey) {
-          // When focused on a link/button that is not the first in annotation trap
-          // focus within the annotation else let the event bubble up to move focus
-          // away from the focused annotation
-          if (focusedIndex.current > 0) {
-            nextIndex = (focusedIndex.current - 1) % linksAndButtons.length;
-            // Stop the event from bubbling up to keydown event handler in parent element in AnnotationDisplay
-            e.stopPropagation();
-          }
-          // Prevent default behavior. Focus shifts to the link/button prior to the one at nextIndex without this
-          e.preventDefault();
-        } else {
-          nextIndex = (focusedIndex.current + 1) % linksAndButtons.length;
-          e.preventDefault();
-        }
-
-        // Focus on link/button if it exists
-        if (linksAndButtons[nextIndex]) {
-          linksAndButtons[nextIndex].focus();
-          setFocusedIndex(nextIndex);
-        }
-      }
-    };
-
     if (e.key === 'Enter' || e.key === ' ') {
       handleOnClick(e);
-    }
-
-    // Allow tab through any existing links/buttons inside the annotation
-    if (e.key === 'Tab') {
-      handleTab(e);
     }
   };
 
@@ -260,11 +220,7 @@ const AnnotationRow = ({
     return (
       <div
         key={`li_${index}`}
-        role='button'
-        tabIndex={index === 0 ? 0 : -1}
         ref={annotationRef}
-        onClick={handleOnClick}
-        onKeyDown={handleKeyDown}
         data-testid='annotation-row'
         className={cx(
           'ramp--annotations__annotation-row',
@@ -272,7 +228,14 @@ const AnnotationRow = ({
         )}
         aria-label={screenReaderLabel}
       >
-        <div key={`row_${index}`} className='ramp--annotations__annotation-row-time-tags'>
+        <div key={`row_${index}`}
+          role='button'
+          tabIndex={index === 0 ? 0 : -1}
+          onClick={handleOnClick}
+          onKeyDown={handleKeyDown}
+          aria-label={screenReaderLabel}
+          data-testid='annotation-row-button'
+          className='ramp--annotations__annotation-row-time-tags'>
           <div
             key={`times_${index}`}
             className='ramp--annotations__annotation-times'
@@ -322,7 +285,6 @@ const AnnotationRow = ({
                 onClick={handleShowMoreTagsClicks}
                 onKeyDown={handleShowMoreTagsKeyDown}
                 ref={moreTagsButtonRef}
-                tabIndex={-1}
               >
                 <i className={`arrow ${showMoreTags ? 'right' : 'left'}`}></i>
               </button>
@@ -339,6 +301,7 @@ const AnnotationRow = ({
               key={`text_${index}`}
               data-testid={`annotation-text-${index}`}
               className='ramp--annotations__annotation-text'
+              onClick={handleLinkClicks}
               dangerouslySetInnerHTML={{ __html: textToShow }}
             ></p>
           )}
@@ -352,7 +315,6 @@ const AnnotationRow = ({
               data-testid={`annotation-show-more-${index}`}
               onClick={handleShowMoreLessClick}
               onKeyDown={handleShowMoreLessKeydown}
-              tabIndex={-1}
             >
               {isShowMoreRef.current ? 'Show more' : 'Show less'}
             </button>)

--- a/src/components/MarkersDisplay/Annotations/AnnotationsDisplay.js
+++ b/src/components/MarkersDisplay/Annotations/AnnotationsDisplay.js
@@ -140,7 +140,8 @@ const AnnotationsDisplay = ({ annotations, canvasIndex, duration, displayMotivat
    * @param {Event} e keydown event
    */
   const handleKeyDown = (e) => {
-    const annotationRows = annotationRowContainerRef.current.children;
+    // Get all annotation rows by the click-able element className
+    const annotationRows = annotationRowContainerRef.current.querySelectorAll('.ramp--annotations__annotation-row-time-tags');
     if (annotationRows?.length > 0) {
       let nextIndex = currentIndex.current;
       if (e.key === 'ArrowDown') {

--- a/src/components/MarkersDisplay/MarkersDisplay.scss
+++ b/src/components/MarkersDisplay/MarkersDisplay.scss
@@ -225,23 +225,22 @@
   }
 
   .ramp--annotations__annotation-row {
-    list-style: none;
-    cursor: pointer;
-    padding: 10px;
-
     &.active {
       background-color: $primaryLighter;
     }
 
-    &:hover,
-    &:focus {
-      background-color: $primaryGreenLight;
-    }
-
     .ramp--annotations__annotation-row-time-tags {
+      cursor: pointer;
       display: grid;
       grid-template-columns: repeat(2, 1fr);
       border-bottom: 1px dotted $primaryDarker;
+      padding: 0.5em; // Need to be same in .ramp--annotations__annotation-texts
+      padding-bottom: 0.25em;
+
+      &:hover,
+      &:focus {
+        background-color: $primaryGreenLight;
+      }
 
       .ramp--annotations__annotation-tags {
         display: flex;
@@ -305,8 +304,8 @@
     .ramp--annotations__annotation-texts {
       display: flex;
       flex-direction: column;
-      margin-top: 0.5em;
       line-height: 1.5em;
+      padding: 0.5em; // Need to be same in .ramp--annotations__annotation-row-time-tags
 
       :last-child {
         margin-left: auto;
@@ -314,7 +313,6 @@
 
       p.ramp--annotations__annotation-text {
         margin: 0;
-        margin-top: 0.5em;
 
         &.hidden {
           display: none;

--- a/src/services/utility-helpers.js
+++ b/src/services/utility-helpers.js
@@ -623,7 +623,7 @@ export function autoScroll(currentItem, containerRef, toTop = false) {
  * @param {Boolean} canvasIsEmpty flag to indicate empty Canvas
  * @returns {String} result of the triggered hotkey action
  */
-export function playerHotKeys(event, player, canvasIsEmpty) {
+export function playerHotKeys(event, player, canvasIsEmpty = false) {
   let playerInst = player?.player();
   let output = '';
 
@@ -641,7 +641,7 @@ export function playerHotKeys(event, player, canvasIsEmpty) {
   let buttonClassesToCheck = ['ramp--transcript_time', 'ramp--structured-nav__section-title',
     'ramp--structured-nav__item-link', 'ramp--structured-nav__collapse-all-btn',
     'ramp--annotations__multi-select-header', 'ramp--annotations__show-more-tags',
-    'ramp--annotations__show-more-less'
+    'ramp--annotations__show-more-less', 'ramp--annotations__annotation-row-time-tags'
   ];
 
   // Determine the focused element and pressed key combination needs to be skipped
@@ -893,11 +893,6 @@ const truncateNode = (node, maxLength) => {
       // anymore without truncating mid-word
       return maxLength;
     }
-  }
-
-  // Set tab-index of each Anchor node to -1 to remove them from tab order of the page
-  if (node.nodeType === Node.ELEMENT_NODE && node.nodeName.toLowerCase() === 'a') {
-    node.tabIndex = -1;
   }
 
   let currentRemaining = maxLength;

--- a/src/services/utility-helpers.test.js
+++ b/src/services/utility-helpers.test.js
@@ -916,7 +916,7 @@ describe('util helper', () => {
       // Character count for text "Bold and superscript text" is 25
       const html = '<p><strong>Bold</strong> and <sup><a href="http://example.com">superscript</a></sup> text</p>';
       const { isTruncated, truncated } = util.truncateText(html, 15);
-      expect(truncated).toBe('<p><strong>Bold</strong> and <sup><a href="http://example.com" tabindex="-1">supers...</a></sup></p>');
+      expect(truncated).toBe('<p><strong>Bold</strong> and <sup><a href="http://example.com">supers...</a></sup></p>');
       expect(isTruncated).toBe(true);
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1631,6 +1631,11 @@
   dependencies:
     "@babel/runtime" "^7.12.5"
 
+"@testing-library/user-event@^14.6.1":
+  version "14.6.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.6.1.tgz#13e09a32d7a8b7060fe38304788ebf4197cd2149"
+  integrity sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==
+
 "@tippyjs/react@4.1.0":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@tippyjs/react/-/react-4.1.0.tgz#be4e826ac198d2394a5ffed3508ca9c098c527f1"


### PR DESCRIPTION
Related issue: #817 

Limit ARIA role "button" to annotation's timestamp, allowing annotation text to display links and buttons without breaking accessibility. This change allows all links and buttons in the annotations display to be included to page's natural tab order allowing the user to continue with keyboard tab navigation without getting trapped inside the annotations component.

Additionally, this PR separates the click events on links within annotation texts in a separate event handler. This event handler provides links validation, and enables navigation in the same page when a link is valid.