### PR TITLE
Fix file download icon placement on Canvas change

### DIFF
--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -423,8 +423,13 @@ function VideoJSPlayer({
       }
 
       if (enableFileDownload) {
-        const fileDownloadIndex = controlBar.children()
-          .findIndex((c) => c.name_ == 'VideoJSFileDownload') || fullscreenIndex + 1;
+        // Index of the full-screen toggle in the player's control bar
+        const fullscreenIndex = controlBar.children()
+          .findIndex((c) => c.name_ == 'FullscreenToggle');
+        let fileDownloadIndex = controlBar.children()
+          .findIndex((c) => c.name_ == 'VideoJSFileDownload');
+        // If fileDownload button is not present, add it at the index of fullscreen toggle
+        fileDownloadIndex = fileDownloadIndex < 0 ? fullscreenIndex : fileDownloadIndex;
         controlBar.removeChild('videoJSFileDownload');
 
         if (renderingFiles?.length > 0) {


### PR DESCRIPTION
When switching between canvases the file download button gets added before the previous button in the player's control bar
This happens when switching from a Canvas without rendering files to a Canvas with rendering files;

https://github.com/user-attachments/assets/81b1a2ce-b2bc-4fb7-be4e-c742a0dea597

