### PR TITLE
Bug fix: keep original order of timespans for playlist

### DIFF
--- a/src/components/StructuredNavigation/StructuredNavigation.js
+++ b/src/components/StructuredNavigation/StructuredNavigation.js
@@ -71,15 +71,17 @@ const StructuredNavigation = ({ showAllSectionsButton = false, sectionsHeading =
         if (structures?.length > 0 && structures[0].isRoot) {
           canvasStructRef.current = structures[0].items;
         }
-        // Sort timespans; helps with activeSegment calculation in VideoJSPlayer
-        timespans.sort((a, b) => {
-          // If end times are equal, sort them by descending order of start time
-          if (a.times.end === b.times.end) {
-            return b.times.start - a.times.start;
-          }
-          // Else, sort ascending order by end times
-          return a.times.end - b.times.end;
-        });
+        // Sort timespans for non-playlist structure; helps with activeSegment calculation in VideoJSPlayer
+        if (!playlist.isPlaylist) {
+          timespans.sort((a, b) => {
+            // If end times are equal, sort them by descending order of start time
+            if (a.times.end === b.times.end) {
+              return b.times.start - a.times.start;
+            }
+            // Else, sort ascending order by end times
+            return a.times.end - b.times.end;
+          });
+        }
         manifestDispatch({ structures: canvasStructRef.current, type: 'setStructures' });
         manifestDispatch({ timespans, type: 'setCanvasSegments' });
         structureContainerRef.current.isScrolling = false;


### PR DESCRIPTION
While testing the code for 4.0.0 release, I noticed that playlists structure scroll to the item that has the lowest start time on page load, even though the player shows the first item on the page. Example: https://avalon-dev.dlib.indiana.edu/playlists/5, the structure scrolls to the playlist item at the 98th position even though the player is still on the first item.
This was a bug introduced in the work that was done to fix the display of overlapping timespans in the player.