### PR TITLE
Remove timespan sorting in structured nav

### DIFF
--- a/public/manifests/dev/timespan-sorting-test.json
+++ b/public/manifests/dev/timespan-sorting-test.json
@@ -1,0 +1,211 @@
+{
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  "id": "http://localhost:3003/dev/timespan-sorting-test.json",
+  "type": "Manifest",
+  "label": {
+    "en": [
+      "Timespan Sorting Test Manifest"
+    ]
+  },
+  "metadata": [
+    {
+      "label": {
+        "none": [
+          "Title"
+        ]
+      },
+      "value": {
+        "none": [
+          "Test Manifest for Timespan Sorting Investigation"
+        ]
+      }
+    },
+    {
+      "label": {
+        "none": [
+          "Description"
+        ]
+      },
+      "value": {
+        "none": [
+          "This manifest is designed to test timespan sorting behavior in StructuredNavigation. It contains canvas timespans that are intentionally out of order to demonstrate the sorting issue."
+        ]
+      }
+    }
+  ],
+  "rights": "http://creativecommons.org/licenses/by-sa/3.0/",
+  "items": [
+    {
+      "id": "http://localhost:3003/dev/timespan-sorting-test/canvas/1",
+      "type": "Canvas",
+      "height": 360,
+      "width": 480,
+      "duration": 572.034,
+      "placeholderCanvas": {
+        "id": "http://localhost:3003/dev/timespan-sorting-test/canvas/1/placeholder",
+        "type": "Canvas",
+        "width": 640,
+        "height": 360,
+        "items": [
+          {
+            "id": "http://localhost:3003/dev/timespan-sorting-test/canvas/1/placeholder/1",
+            "type": "AnnotationPage",
+            "items": [
+              {
+                "id": "http://localhost:3003/dev/timespan-sorting-test/canvas/1/placeholder/1-image",
+                "type": "Annotation",
+                "motivation": "painting",
+                "body": {
+                  "id": "http://localhost:3003/lunchroom_manners/lunchroom_manners_poster.jpg",
+                  "type": "Image",
+                  "format": "image/jpeg",
+                  "width": 640,
+                  "height": 360
+                },
+                "target": "http://localhost:3003/dev/timespan-sorting-test/canvas/1/placeholder"
+              }
+            ]
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "http://localhost:3003/dev/timespan-sorting-test/canvas/1/page",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "http://localhost:3003/dev/timespan-sorting-test/canvas/1/page/annotation",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "type": "Choice",
+                "choiceHint": "user",
+                "items": [
+                  {
+                    "id": "http://localhost:3003/lunchroom_manners/high/lunchroom_manners_1024kb.mp4",
+                    "type": "Video",
+                    "format": "video/mp4",
+                    "label": {
+                      "en": [
+                        "High"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "http://localhost:3003/lunchroom_manners/medium/lunchroom_manners_512kb.mp4",
+                    "type": "Video",
+                    "format": "video/mp4",
+                    "label": {
+                      "en": [
+                        "Medium"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "http://localhost:3003/lunchroom_manners/low/lunchroom_manners_256kb.mp4",
+                    "type": "Video",
+                    "format": "video/mp4",
+                    "label": {
+                      "en": [
+                        "Low"
+                      ]
+                    }
+                  }
+                ]
+              },
+              "target": "http://localhost:3003/dev/timespan-sorting-test/canvas/1"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "structures": [
+    {
+      "id": "http://localhost:3003/dev/timespan-sorting-test/range/0",
+      "type": "Range",
+      "label": {
+        "en": [
+          "Test Structure with Out-of-Order Timespans"
+        ]
+      },
+      "items": [
+        {
+          "id": "http://localhost:3003/dev/timespan-sorting-test/range/3",
+          "type": "Range",
+          "label": {
+            "en": [
+              "Later Section (200-302.05 seconds)"
+            ]
+          },
+          "items": [
+            {
+              "id": "http://localhost:3003/dev/timespan-sorting-test/canvas/1#t=200,302.05",
+              "type": "Canvas"
+            }
+          ]
+        },
+        {
+          "id": "http://localhost:3003/dev/timespan-sorting-test/range/4",
+          "type": "Range",
+          "label": {
+            "en": [
+              "Earlier Section with Nested Range (0-200 seconds)"
+            ]
+          },
+          "items": [
+            {
+              "id": "http://localhost:3003/dev/timespan-sorting-test/canvas/1#t=0,200",
+              "type": "Canvas"
+            },
+            {
+              "id": "http://localhost:3003/dev/timespan-sorting-test/range/5",
+              "type": "Range",
+              "label": {
+                "en": [
+                  "Fully Nested Middle Section (100-250 seconds)"
+                ]
+              },
+              "items": [
+                {
+                  "id": "http://localhost:3003/dev/timespan-sorting-test/canvas/1#t=100,200",
+                  "type": "Canvas"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "http://localhost:3003/dev/timespan-sorting-test/range/6",
+          "type": "Range",
+          "label": {
+            "en": [
+              "Final Section (400-572.034 seconds)"
+            ]
+          },
+          "items": [
+            {
+              "id": "http://localhost:3003/dev/timespan-sorting-test/canvas/1#t=400,572.034",
+              "type": "Canvas"
+            }
+          ]
+        },
+        {
+          "id": "http://localhost:3003/dev/timespan-sorting-test/range/7",
+          "type": "Range",
+          "label": {
+            "en": [
+              "Overlapping Section (150-350 seconds)"
+            ]
+          },
+          "items": [
+            {
+              "id": "http://localhost:3003/dev/timespan-sorting-test/canvas/1#t=150,350",
+              "type": "Canvas"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/components/StructuredNavigation/StructuredNavigation.js
+++ b/src/components/StructuredNavigation/StructuredNavigation.js
@@ -71,17 +71,6 @@ const StructuredNavigation = ({ showAllSectionsButton = false, sectionsHeading =
         if (structures?.length > 0 && structures[0].isRoot) {
           canvasStructRef.current = structures[0].items;
         }
-        // Sort timespans for non-playlist structure; helps with activeSegment calculation in VideoJSPlayer
-        if (!playlist.isPlaylist) {
-          timespans.sort((a, b) => {
-            // If end times are equal, sort them by descending order of start time
-            if (a.times.end === b.times.end) {
-              return b.times.start - a.times.start;
-            }
-            // Else, sort ascending order by end times
-            return a.times.end - b.times.end;
-          });
-        }
         manifestDispatch({ structures: canvasStructRef.current, type: 'setStructures' });
         manifestDispatch({ timespans, type: 'setCanvasSegments' });
         structureContainerRef.current.isScrolling = false;


### PR DESCRIPTION
Related issue: #830 

Notes from investigation:
- Timespan sorting code in the `StructuredNavigation` component did not have any impact on the display of the structure in the component.
- The `timespans` variable that is sorted by time, is used in state management as `canvasSegments`. And this `canvasSegments` value is then used by `VideoJSPlayer` to calculate active segment for markers plugin to populate time-rail highlights for active structure.
-  `VideoJSPlayer` component [has the capability](https://github.com/samvera-labs/ramp/blob/main/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js#L860-L889) to filter relevant segments based on user interactions, which doesn't require sorting of timespans.

Changes made in the PR:
- Removed the `timespan` sorting code in `StructuredNavigation` component, as it seemed redundant in my testing
- New Manifest to test the changes (URL in localhost: http://localhost:3003/manifests/dev/timespan-sorting-test.json, in deployment: https://ramp.avalonmediasystem.org/manifests/dev/timespan-sorting-test.json). This Manifest contains fully nested timespans & overlapping timespans and these timespans are not in chronological order.

> [!NOTE]  
> This Manifest can be removed after testing

![Screenshot 2025-06-27 at 15-14-52 Ramp](https://github.com/user-attachments/assets/5c2f8a6d-ca82-4c72-bd80-43e1ee1d86d5)

Additionally, I tested these changes with different manifests from `avalon-dev` and did not see any breaking functionality. I used the following manifests;
- https://avalon-dev.dlib.indiana.edu/media_objects/rb68xb881/manifest.json - manifest without overlapping/nesting timespans
- https://avalon-dev.dlib.indiana.edu/media_objects/fj236208t/manifest.json - manifest with nesting timespans
- https://avalon-dev.dlib.indiana.edu/media_objects/12579s29x/manifest.json - manifest with nesting and overlapping timespans
- https://avalon-dev.dlib.indiana.edu/playlists/5/manifest.json - playlist manifest