### PR TITLE
Change WebVTT validation to allow files with embedded metadata

### DIFF
--- a/src/components/Transcript/Transcript.md
+++ b/src/components/Transcript/Transcript.md
@@ -7,6 +7,7 @@ Transcript component displays any available transcript data in a given IIIF mani
    **Important**: _When using with a different media player (not the IIIFPlayer), the player should have a `dataset` property called, `data-canvasindex` (starts with 0) which points to the current canvas rendered from the IIIF manfiest._
 - `manifestUrl`: URL of the Manifest used with the player pointed by the `playerID` prop. `Supplementing` annotations within the Manifest for each Canvas are parsed into a list of transcripts by the component (**added in `@samvera/ramp@3.0.0`**) 
 - `showNotes`: display NOTE comments in SRT/VTT timed-text files, which has a default value of `false` and is _not required_. (**added in `@samvera/ramp@3.2.0`**)
+- `showMetadata`: display embedded metadata according to the [FADGI guidelines](https://www.digitizationguidelines.gov/guidelines/FADGI_WebVTT_embed_guidelines_v0.1_2024-04-18.pdf) in the header of a given WebVTT file, which has a default value of `false` and is _not required_. (future release)
 - `transcripts`: transcript related data as an array of JSON objects for each Canvas in the Manifest with the following props;
 
    - `canvasId`: to identify transcript data associated with each Canvas in a multi-canvas IIIF Manifest used in the media player, transcript data is grouped by `canvasId` in the props

--- a/src/components/Transcript/Transcript.scss
+++ b/src/components/Transcript/Transcript.scss
@@ -42,7 +42,7 @@ span.ramp--transcript_item {
   margin: 10px 10px 10px 10px;
   text-decoration: none;
   transition: background-color 0.2s ease-in;
-  align-items: center;
+  align-items: baseline;
 
   &.untimed {
     // Enable pointer events for untimed items to allow scrolling on click
@@ -52,6 +52,13 @@ span.ramp--transcript_item {
     &:hover {
       background-color: $primaryGreenLight;
     }
+  }
+
+  &.metadata-block {
+    background: $primaryLighter;
+    padding: 0.5em;
+    border: 0.01em solid $primary;
+    border-radius: 0.25em;
   }
 
   &.active {

--- a/src/components/Transcript/TranscriptMenu/TranscriptMenu.scss
+++ b/src/components/Transcript/TranscriptMenu/TranscriptMenu.scss
@@ -27,6 +27,7 @@
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
+  justify-content: space-between;
 }
 
 .ramp--transcript_search_input input,

--- a/src/services/ramp-hooks.js
+++ b/src/services/ramp-hooks.js
@@ -885,6 +885,8 @@ export const useCollapseExpandAll = () => {
  * @param {String} obj.manifestUrl
  * @param {String} obj.playerID
  * @param {Function} obj.setCurrentTime 
+ * @param {Boolean} obj.showMetadata
+ * @param {Boolean} obj.showNotes
  * @param {Array} obj.transcripts
  * @returns {
  * canvasIndexRef,
@@ -903,6 +905,8 @@ export const useTranscripts = ({
   manifestUrl,
   playerID,
   setCurrentTime,
+  showMetadata,
+  showNotes,
   transcripts,
 }) => {
   const manifestState = useContext(ManifestStateContext);
@@ -1134,7 +1138,7 @@ export const useTranscripts = ({
     } else {
       // Parse new transcript data from the given sources
       await Promise.resolve(
-        parseTranscriptData(url, format, canvasIndexRef.current)
+        parseTranscriptData(url, format, canvasIndexRef.current, showMetadata, showNotes)
       ).then(function (value) {
         if (value != null) {
           const { tData, tUrl, tType, tFileExt } = value;

--- a/src/services/search.js
+++ b/src/services/search.js
@@ -2,7 +2,7 @@ import { useRef, useEffect, useState, useMemo, useCallback, useContext } from 'r
 import { PlayerDispatchContext } from '../context/player-context';
 import { ManifestStateContext } from '../context/manifest-context';
 import { getSearchService } from '@Services/iiif-parser';
-import { getMatchedTranscriptLines, parseContentSearchResponse, TRANSCRIPT_CUE_TYPES } from './transcript-parser';
+import { getMatchedTranscriptLines, parseContentSearchResponse } from './transcript-parser';
 
 export const defaultMatcherFactory = (items) => {
   const mappedItems = items.map(item => item.text.toLocaleLowerCase());
@@ -92,7 +92,6 @@ export function useFilteredTranscripts({
   transcripts,
   canvasIndex,
   selectedTranscript,
-  showNotes,
   showMarkers = defaultSearchOpts.showMarkers,
   matchesOnly = defaultSearchOpts.matchesOnly,
   matcherFactory = defaultSearchOpts.matcherFactory
@@ -105,10 +104,6 @@ export function useFilteredTranscripts({
 
   const { matcher, itemsWithIds, itemsIndexed } = useMemo(() => {
     let transcriptsDisplayed = transcripts || [];
-    // Filter note cues, if showNotes prop it set to 'false'
-    if (!showNotes && transcriptsDisplayed?.length > 0) {
-      transcriptsDisplayed = transcripts.filter((t) => t.tag !== TRANSCRIPT_CUE_TYPES.note);
-    }
     const itemsWithIds = transcriptsDisplayed.map((item, idx) => (
       (typeof item === 'string'
         ? { text: item, id: idx }


### PR DESCRIPTION
Related issue: https://github.com/samvera-labs/ramp/issues/836

When `showMetadata=true` and the WebVTT file has embedded metadata in the header it is displayed as follows;
![Screenshot 2025-07-07 at 10-38-34 Ramp](https://github.com/user-attachments/assets/191a8a67-baac-4638-8862-a553b5e4e0f4)

Example Manifest:https://markpbaggett.github.io/static_iiif/manifests/tests/tamuwhisper-video.json