### PR TITLE
Fix voiceover and a11y for cues in transcripts & annotations

### DIFF
--- a/src/components/Annotations/OtherAnnotations/AnnotationRow.js
+++ b/src/components/Annotations/OtherAnnotations/AnnotationRow.js
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { autoScroll, screenReaderFriendlyText, screenReaderFriendlyTime, timeToHHmmss } from '@Services/utility-helpers';
+import { autoScroll, screenReaderFriendlyText, timeToHHmmss } from '@Services/utility-helpers';
 import { useAnnotationRow, useMediaPlayer, useShowMoreOrLess } from '@Services/ramp-hooks';
 import { SUPPORTED_MOTIVATIONS } from '@Services/annotations-parser';
 
@@ -202,20 +202,6 @@ const AnnotationRow = ({
     }
   };
 
-  /**
-   * Screen reader friendly label for the annotation row, that includes the start and/or 
-   * end time of the annotation and the text to be read by the screen reader.
-   */
-  const screenReaderLabel = useMemo(() => {
-    const textToRead = screenReaderFriendlyText(textToShow);
-    const startTimeToRead = time?.start != undefined ? screenReaderFriendlyTime(time?.start) : '';
-    if (time?.end != undefined) {
-      return `From ${startTimeToRead} to ${screenReaderFriendlyTime(time.end)}, ${textToRead}`;
-    } else {
-      return `${startTimeToRead}, ${textToRead}`;
-    }
-  }, [time, textToShow]);
-
   if (canDisplay) {
     return (
       <div
@@ -226,14 +212,13 @@ const AnnotationRow = ({
           'ramp--annotations__annotation-row',
           isActive && 'active'
         )}
-        aria-label={screenReaderLabel}
+        aria-label={screenReaderFriendlyText(textToShow)}
       >
         <div key={`row_${index}`}
           role='button'
           tabIndex={index === 0 ? 0 : -1}
           onClick={handleOnClick}
           onKeyDown={handleKeyDown}
-          aria-label={screenReaderLabel}
           data-testid='annotation-row-button'
           className='ramp--annotations__annotation-row-time-tags'>
           <div

--- a/src/components/Transcript/Transcript.js
+++ b/src/components/Transcript/Transcript.js
@@ -11,7 +11,7 @@ import {
   useSearchCounts
 } from '@Services/search';
 import { useTranscripts } from '@Services/ramp-hooks';
-import { autoScroll, screenReaderFriendlyText, screenReaderFriendlyTime, timeToHHmmss } from '@Services/utility-helpers';
+import { autoScroll, screenReaderFriendlyText, timeToHHmmss } from '@Services/utility-helpers';
 import Spinner from '@Components/Spinner';
 import './Transcript.scss';
 
@@ -213,7 +213,7 @@ const TranscriptLine = memo(({
           onClick={onClick}
           onKeyDown={handleKeyDown}
           tabIndex={isFirstItem ? 0 : -1}
-          aria-label={`${screenReaderFriendlyTime(item.begin)}, ${screenReaderFriendlyText(cueText)}`}
+          aria-label={`${timeToHHmmss(item.begin, true)}, ${screenReaderFriendlyText(cueText)}`}
         >
           [{timeToHHmmss(item.begin, true)}]
         </span>


### PR DESCRIPTION
Related issue: #815 

Since the cues in the `Transcript` component follows the same pattern for setting the accessible labels as the `Annotation` component, I took the time to review how the accessible labels in `Transcript` component are displayed and understood by the accessibility software as a part of this work. 
As a result, I identified an issue where the accessible label not matching with the visual text of the element. So, this PR includes a small code change in the `Transcript` component related to this issue.

This issue is related to the Avalon 8.1 release.