### PR TITLE
Fix close/expand for cookbook ToC recipe 0065

### DIFF
--- a/src/components/StructuredNavigation/NavUtils/TreeNode.js
+++ b/src/components/StructuredNavigation/NavUtils/TreeNode.js
@@ -319,7 +319,7 @@ const TreeNode = ({
         aria-posinset={isPlaylist ? itemIndex : null}
       >
         {renderTreeNode()}
-        {((!sectionIsCollapsed && hasChildren) || isTitle) && (
+        {(!sectionIsCollapsed && hasChildren) && (
           <ul className='ramp--structured-nav__tree' role='group' data-testid='tree-group'>
             {items.map((item, index) => {
               return (

--- a/src/components/StructuredNavigation/StructuredNavigation.scss
+++ b/src/components/StructuredNavigation/StructuredNavigation.scss
@@ -106,13 +106,8 @@
     >li>ul {
       padding: 0;
     }
-    >li {
-      >ul>li {
-        padding: 0 0 0.5rem 0;
-      }
-      >ul>li:last-child {
-        padding: 0 0 0 0;
-      }
+    >li>ul>li:last-child {
+      padding: 0 0 0 0;
     }
   }
 }


### PR DESCRIPTION
The close/expand functionality was broken for a [IIIF Cookbook A/V ToC recipe](https://ramp.avalonmediasystem.org/?iiif-content=https://iiif.io/api/cookbook/recipe/0065-opera-multiple-canvases/manifest.json), because the format of its `structures` property sets the conditional rendering of the section's children to always be displayed breaking the close/expand functionality.