### PR TITLE
Remove deprecation warnings in the build logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "rollup-plugin-postcss": "^3.1.8",
     "rollup-plugin-terser": "^7.0.1",
     "sass": "^1.28.0",
-    "sass-loader": "^10.0.5",
+    "sass-loader": "^16.0.5",
     "sinon": "^18.0.0",
     "stream-browserify": "^3.0.0",
     "style-loader": "^2.0.0",

--- a/src/components/Annotations/Annotations.scss
+++ b/src/components/Annotations/Annotations.scss
@@ -1,20 +1,20 @@
-@import '../../styles/vars';
+@use '../../styles/vars';
 
 .ramp--annotations-display {
   min-width: inherit;
   padding: 10px;
 
   .ramp--annotations__title {
-    border: 0.05rem solid $primaryLight;
+    border: 0.05rem solid vars.$primaryLight;
     border-radius: 0.25rem 0.25rem 0 0;
     margin-bottom: 1rem;
-    background: $primaryLightest;
+    background: vars.$primaryLightest;
 
     h4 {
       font-weight: normal;
       padding: 0.5rem 1.5rem;
       margin: 0;
-      color: $primaryDarker;
+      color: vars.$primaryDarker;
     }
   }
 
@@ -33,12 +33,12 @@
     }
 
     th {
-      border: 1px solid $primaryLightest;
+      border: 1px solid vars.$primaryLightest;
       padding: 0.5rem;
     }
 
     td {
-      border: 1px solid $primaryLightest;
+      border: 1px solid vars.$primaryLightest;
       text-align: left;
       padding: 0.5rem;
       font-weight: normal;
@@ -71,12 +71,12 @@
 
   .time-invalid {
     outline: none;
-    border-color: $danger;
-    box-shadow: 0 0 10px $danger;
+    border-color: vars.$danger;
+    box-shadow: 0 0 10px vars.$danger;
   }
 
   .ramp--markers-display__edit-button {
-    background-color: $primaryGreenDark;
+    background-color: vars.$primaryGreenDark;
     color: white;
     padding: 5px 10px;
     border: none;
@@ -86,7 +86,7 @@
   }
 
   .ramp--markers-display__edit-button-danger {
-    background-color: $danger;
+    background-color: vars.$danger;
     color: white;
     padding: 5px 10px;
     border: none;
@@ -96,7 +96,7 @@
   }
 
   .ramp--markers-display__error-message {
-    color: $danger;
+    color: vars.$danger;
     font-size: small;
     margin: auto;
   }
@@ -108,11 +108,11 @@
 }
 
 .ramp--markers-display__new-marker-form {
-  border: 1px solid $primaryLight;
+  border: 1px solid vars.$primaryLight;
   padding: 0.5rem;
   border-radius: 0.25rem;
   margin: 1rem 0;
-  font-size: $fontSizeMedium;
+  font-size: vars.$fontSizeMedium;
   font-weight: bold;
 
   table.create-marker-form-table {
@@ -137,19 +137,19 @@
   .ramp--annotations__select {
     padding: 0.5em;
     margin-bottom: 1em;
-    border: 1px solid $primaryLight;
+    border: 1px solid vars.$primaryLight;
     border-radius: 3px;
     display: flex;
     row-gap: 0.5em;
     flex-direction: column;
-    background-color: $primaryLightest;
+    background-color: vars.$primaryLightest;
 
     .ramp--annotations__multi-select {
       position: relative;
       font-family: Arial, sans-serif;
 
       .ramp--annotations__scroll input {
-        accent-color: $primaryGreenDark;
+        accent-color: vars.$primaryGreenDark;
       }
     }
 
@@ -205,12 +205,12 @@
 
     .annotations-dropdown-item input[type="checkbox"] {
       margin-right: 8px;
-      accent-color: $primaryGreenDark;
+      accent-color: vars.$primaryGreenDark;
     }
     .annotations-dropdown-menu li:focus {
       outline: none !important;
-      background-color: $primaryLighter;
-      border: 2px solid $primaryGreenDark;
+      background-color: vars.$primaryLighter;
+      border: 2px solid vars.$primaryGreenDark;
     }
   }
 
@@ -226,20 +226,20 @@
 
   .ramp--annotations__annotation-row {
     &.active {
-      background-color: $primaryLighter;
+      background-color: vars.$primaryLighter;
     }
 
     .ramp--annotations__annotation-row-time-tags {
       cursor: pointer;
       display: grid;
       grid-template-columns: repeat(2, 1fr);
-      border-bottom: 1px dotted $primaryDarker;
+      border-bottom: 1px dotted vars.$primaryDarker;
       padding: 0.5em; // Need to be same in .ramp--annotations__annotation-texts
       padding-bottom: 0.25em;
 
       &:hover,
       &:focus {
-        background-color: $primaryGreenLight;
+        background-color: vars.$primaryGreenLight;
       }
 
       .ramp--annotations__annotation-tags {
@@ -252,7 +252,7 @@
       p.ramp--annotations__annotation-tag {
         margin: 0;
         font-size: small;
-        border: 1px solid $primaryDarker;
+        border: 1px solid vars.$primaryDarker;
         border-radius: 3px;
         padding: 0 0.2em;
         align-self: flex-end;
@@ -320,9 +320,9 @@
 
         // Links within annotation texts
         a {
-          color: $primaryGreenDark;
+          color: vars.$primaryGreenDark;
           &:hover {
-            color: $primaryDarker;
+            color: vars.$primaryDarker;
           }
         }
       }
@@ -331,7 +331,7 @@
         font-size: small;
         cursor: pointer;
         background: none;
-        border: 1px solid $primaryDarker;
+        border: 1px solid vars.$primaryDarker;
         border-radius: 3px;
       }
     }

--- a/src/components/AutoAdvanceToggle/AutoAdvanceToggle.scss
+++ b/src/components/AutoAdvanceToggle/AutoAdvanceToggle.scss
@@ -1,12 +1,12 @@
-@import '../../styles/vars';
+@use '../../styles/vars';
 
 .ramp--auto-advance {
   user-select: none;
   display: flex;
   align-content: center;
-  border: 0.05rem solid $primaryLight;
+  border: 0.05rem solid vars.$primaryLight;
   border-radius: 0.25rem;
-  background: $primaryLightest;
+  background: vars.$primaryLightest;
   width: fit-content;
   padding: 0.5rem 1.5rem;
   max-height: 2rem;
@@ -17,7 +17,7 @@
   margin-bottom: 1rem;
   font-weight: normal;
   margin: 0;
-  color: $primaryDarker;
+  color: vars.$primaryDarker;
   padding: 0.25rem;
 }
 
@@ -47,7 +47,7 @@
 }
 
 .ramp--auto-advance[aria-checked="true"] .slider {
-  background: $primaryGreenDark;
+  background: vars.$primaryGreenDark;
   span {
     left: 28px;
   }

--- a/src/components/ErrorMessage/ErrorMessage.scss
+++ b/src/components/ErrorMessage/ErrorMessage.scss
@@ -1,10 +1,10 @@
-@import '../../styles/vars';
+@use '../../styles/vars';
 
 .ramp--error-message__alert {
 	display: flex;
 	justify-content: space-between;
 	padding: 1rem;
-	background-color: rgba($danger, 0.2);
+	background-color: rgba(vars.$danger, 0.2);
 	border-radius: 0.25rem;
 }
 
@@ -13,7 +13,7 @@
 }
 
 .ramp--error-message__reset-button {
-	background-color: $primaryGreenDark;
+	background-color: vars.$primaryGreenDark;
 	color: white !important;
 	padding: 12px 20px;
 	border: none;

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.scss
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.scss
@@ -1,10 +1,10 @@
-@import '../../../styles/vars';
+@use '../../../styles/vars';
 
 .ramp--media-player_inaccessible-message-content {
   width: 50%;
-  color: $primaryLightest;
+  color: vars.$primaryLightest;
   a {
-    color: $primaryGreen
+    color: vars.$primaryGreen
   }
 }
 
@@ -15,7 +15,7 @@
   button {
     border: 1px solid;
     color: white;
-    background-color: $primaryGreenDark;
+    background-color: vars.$primaryGreenDark;
     padding: 0.5em;
     border-radius: 0.3em;
     cursor: pointer;

--- a/src/components/MediaPlayer/VideoJS/components/styles/VideoJSFileDownload.scss
+++ b/src/components/MediaPlayer/VideoJS/components/styles/VideoJSFileDownload.scss
@@ -1,4 +1,4 @@
-@import '../../../../../styles/vars';
+@use '../../../../../styles/vars';
 
 .vjs-file-download {
   background-size: 1.25rem;
@@ -6,10 +6,10 @@
 
   .vjs-menu-title {
     &:hover {
-      background-color: $primaryDark;
+      background-color: vars.$primaryDark;
     }
 
-    background-color: $primaryDark;
+    background-color: vars.$primaryDark;
   }
 }
 
@@ -23,7 +23,7 @@
   bottom: 100%;
 
   .menu-header {
-    background-color: $primaryDark;
+    background-color: vars.$primaryDark;
   }
 }
 

--- a/src/components/MediaPlayer/VideoJS/components/styles/VideoJSProgress.scss
+++ b/src/components/MediaPlayer/VideoJS/components/styles/VideoJSProgress.scss
@@ -1,4 +1,4 @@
-@import '../../../../../styles/_vars.scss';
+@use '../../../../../styles/_vars.scss';
 
 .video-js .vjs-custom-progress-bar {
   cursor: pointer;
@@ -57,10 +57,10 @@
   color: white;
   height: 0.5em; // same height as .vjs-custom-progress-bar
   background: repeating-linear-gradient(45deg,
-      $primaryDarker,
-      $primaryDarker 8px,
-      $primaryDark 8px,
-      $primaryDark 16px);
+      vars.$primaryDarker,
+      vars.$primaryDarker 8px,
+      vars.$primaryDark 8px,
+      vars.$primaryDark 16px);
 }
 
 #right-block {
@@ -68,7 +68,7 @@
 }
 
 .video-js .vjs-play-progress {
-  background-color: $primaryGreenDark;
+  background-color: vars.$primaryGreenDark;
 }
 
 .video-js .vjs-play-progress>span>svg {
@@ -77,8 +77,8 @@
 
 .video-js .vjs-progress-holder.played-range {
   background: linear-gradient(90deg,
-      $primaryGreenDark var(--range-progress),
-      $primaryGreenLight var(--range-progress));
+      vars.$primaryGreenDark var(--range-progress),
+      vars.$primaryGreenLight var(--range-progress));
 }
 
 /* CSS for structure track highlight markers on progress bar */
@@ -117,7 +117,7 @@
 .vjs-marker.ramp--track-marker--search {
   &[style] {
     // specificity hack to beat inline styles
-    background-color: $primaryGreenDark !important;
+    background-color: vars.$primaryGreenDark !important;
     border-radius: 0 !important;
     width: 6px !important;
   }

--- a/src/components/MediaPlayer/VideoJS/components/styles/VideoJSTrackScrubber.scss
+++ b/src/components/MediaPlayer/VideoJS/components/styles/VideoJSTrackScrubber.scss
@@ -1,4 +1,4 @@
-@import '../../../../../styles/_vars.scss';
+@use '../../../../../styles/_vars.scss';
 
 .vjs-track-scrubber {
   cursor: pointer;
@@ -47,8 +47,8 @@
     height: 20px;
     width: 100%;
     background: linear-gradient(90deg,
-        $primaryGreen var(--range-scrubber),
-        $primaryDarker var(--range-scrubber))
+        vars.$primaryGreen var(--range-scrubber),
+        vars.$primaryDarker var(--range-scrubber))
   }
 
   .vjs-time {
@@ -75,7 +75,7 @@
   .tooltiptext {
     visibility: hidden;
     width: 5em;
-    background-color: $primaryDark;
+    background-color: vars.$primaryDark;
     color: #fff;
     text-align: center;
     border-radius: 6px;
@@ -100,6 +100,6 @@
     margin-left: -5px;
     border-width: 5px;
     border-style: solid;
-    border-color: $primaryDark transparent transparent transparent;
+    border-color: vars.$primaryDark transparent transparent transparent;
   }
 }

--- a/src/components/MetadataDisplay/MetadataDisplay.scss
+++ b/src/components/MetadataDisplay/MetadataDisplay.scss
@@ -1,4 +1,4 @@
-@import '../../styles/vars';
+@use '../../styles/vars';
 
 .ramp--metadata-display {
   min-width: inherit;
@@ -8,23 +8,23 @@
   }
 
   .ramp--metadata-display-title {
-    border: 0.05rem solid $primaryLight;
+    border: 0.05rem solid vars.$primaryLight;
     border-radius: 0.25rem 0.25rem 0 0;
     margin-bottom: 1rem;
-    background: $primaryLightest;
+    background: vars.$primaryLightest;
 
     h4 {
       font-weight: normal;
       padding: 0.5rem 1.5rem;
       margin: 0;
-      color: $primaryDarker;
+      color: vars.$primaryDarker;
     }
 
   }
 
   .ramp--metadata-display-content {
     padding: 0 1.5rem 1.5rem;
-    color: $primaryDarker;
+    color: vars.$primaryDarker;
     max-height: 30rem;
     overflow-y: auto;
 
@@ -33,14 +33,14 @@
       font-style: italic;
       padding: 0.5rem 0 0.5rem 1.5rem;
       margin: 00 0 0.75rem;
-      color: $primaryDarker;
-      border-bottom: 0.1rem solid $primaryDark;
+      color: vars.$primaryDarker;
+      border-bottom: 0.1rem solid vars.$primaryDark;
       display: block;
       margin: 0 -1.5rem 0.5rem -1.5rem;
     }
 
     .ramp--metadata-rights-heading {
-      border-bottom: 0.1rem solid $primary;
+      border-bottom: 0.1rem solid vars.$primary;
       margin: 0;
       padding: 0.5rem 0;
     }
@@ -55,7 +55,7 @@
     }
 
     a {
-      color: $primaryGreenDark;
+      color: vars.$primaryGreenDark;
     }
   }
 }

--- a/src/components/StructuredNavigation/StructuredNavigation.scss
+++ b/src/components/StructuredNavigation/StructuredNavigation.scss
@@ -1,4 +1,4 @@
-@import '../../styles/_vars.scss';
+@use '../../styles/_vars.scss';
 
 .ramp--structured-nav.display {
   display: flow-root;
@@ -8,22 +8,22 @@
     display: flex;
     justify-content: space-between;
     padding: 0.5em;
-    background-color: $primaryLightest;
-    border: 1px solid $primaryLight;
+    background-color: vars.$primaryLightest;
+    border: 1px solid vars.$primaryLight;
     border-radius: 0.25em 0.25em 0 0;
     border-bottom: none;
 
     .ramp--structured-nav__sections-text {
       font-weight: bold;
-      font-size: $fontSizeLarge;
+      font-size: vars.$fontSizeLarge;
       &.hidden {
         visibility: hidden;
       }
     }
 
     .ramp--structured-nav__collapse-all-btn {
-      background-color: $primaryGreenDark;
-      color: $primaryLightest;
+      background-color: vars.$primaryGreenDark;
+      color: vars.$primaryLightest;
       padding: 0.5em 0.75em;
       border: none;
       border-radius: 0.3em;
@@ -32,7 +32,7 @@
       font-size: 13px;
 
       .arrow {
-        border: solid $primaryLightest;
+        border: solid vars.$primaryLightest;
         border-width: 0 0.1em 0.1em 0;
         display: inline-block;
         padding: 0.25em;
@@ -70,7 +70,7 @@
   overflow-y: auto;
 
   a {
-    color: $primaryGreenDark;
+    color: vars.$primaryGreenDark;
     transition: 0.25s;
     text-decoration: none;
     display: inline-flex;
@@ -78,13 +78,13 @@
 
     &:hover,
     &:focus {
-      color: $primaryDarker;
+      color: vars.$primaryDarker;
     }
   }
 
   p {
     padding-top: 1em;
-    color: $primaryDarker;
+    color: vars.$primaryDarker;
   }
 
   span {
@@ -96,7 +96,7 @@
     &:first-child {
       border-top: none;
     }
-    border-top: 1px solid $primaryLight;
+    border-top: 1px solid vars.$primaryLight;
   }
 }
 
@@ -143,7 +143,7 @@
 
 // Scroll to see more message
 .ramp--structured-nav__border>span.scrollable {
-  background: $primary;
+  background: vars.$primary;
   text-align: center;
   display: block;
   position: absolute;
@@ -173,7 +173,7 @@ ul.ramp--structured-nav__tree {
   // E.g. IIIF cookbook: https://iiif.io/api/cookbook/recipe/0065-opera-multiple-canvases
   li.section-tree-item {
     padding: 0;
-    border-top: 1px solid $primaryLight;
+    border-top: 1px solid vars.$primaryLight;
   }
 
   // Remove padding when line-height is set
@@ -213,7 +213,7 @@ ul.ramp--structured-nav__tree {
   }
 
   li.active>a {
-    color: $primaryDarkest;
+    color: vars.$primaryDarkest;
   }
 
   li.active {
@@ -223,7 +223,7 @@ ul.ramp--structured-nav__tree {
       width: 0;
       height: 0;
       border-top: 3px solid transparent;
-      border-left: 7px solid $primaryDarker;
+      border-left: 7px solid vars.$primaryDarker;
       border-bottom: 3px solid transparent;
       display: inline-block;
       margin-left: -1rem;
@@ -246,13 +246,13 @@ ul.ramp--structured-nav__tree {
     grid-template-columns: 1fr auto;
 
     span.ramp--structured-nav__section-title {
-      background: $primaryLightest;
+      background: vars.$primaryLightest;
     }
   }
 
   background-color: transparent;
-  border-top: 1px solid $primaryLight;
-  font-size: $fontSizeLarge;
+  border-top: 1px solid vars.$primaryLight;
+  font-size: vars.$fontSizeLarge;
   font-weight: 400;
 
   .not-clickable {
@@ -266,22 +266,22 @@ ul.ramp--structured-nav__tree {
     width: 100%;
     padding: 1rem;
     font-weight: inherit;
-    background: $primaryLightest;
+    background: vars.$primaryLightest;
 
     &:hover,
     &:not(.not-clickable):focus {
-      background-color: $primaryGreenLight;
+      background-color: vars.$primaryGreenLight;
     }
 
     span {
       padding-left: 0;
-      font-size: $fontSizeLarge;
+      font-size: vars.$fontSizeLarge;
     }
   }
 
   span.collapse-expand-button {
     padding: 1em;
-    background: $primaryLightest;
+    background: vars.$primaryLightest;
     cursor: pointer;
 
     .arrow {
@@ -303,7 +303,7 @@ ul.ramp--structured-nav__tree {
       transition: transform .35s ease-in-out;
     }
     &:hover {
-      background-color: $primaryLightest;
+      background-color: vars.$primaryLightest;
     }
   }
 
@@ -317,10 +317,10 @@ ul.ramp--structured-nav__tree {
     }
 
     span.ramp--structured-nav__section-duration {
-      border: 1px solid $primaryDark;
+      border: 1px solid vars.$primaryDark;
       border-radius: 999px;
-      color: $primaryDarkest;
-      font-size: $fontSizeMedium;
+      color: vars.$primaryDarkest;
+      font-size: vars.$fontSizeMedium;
       letter-spacing: 0.02rem;
       line-height: 1.6;
       padding: 0 0.5rem;

--- a/src/components/SupplementalFiles/SupplementalFiles.scss
+++ b/src/components/SupplementalFiles/SupplementalFiles.scss
@@ -1,31 +1,31 @@
-@import '../../styles/vars';
+@use '../../styles/vars';
 
 .ramp--supplemental-files {
   dd {
     padding-bottom: 1rem;
 
     a {
-      color: $primaryGreenDark;
+      color: vars.$primaryGreenDark;
     }
   }
 
   .ramp--supplemental-files-heading {
-    border: 0.05rem solid $primaryLight;
+    border: 0.05rem solid vars.$primaryLight;
     border-radius: 0.25rem 0.25rem 0 0;
     margin-bottom: 1rem;
-    background: $primaryLightest;
+    background: vars.$primaryLightest;
 
     h4 {
       font-weight: normal;
       padding: 0.5rem 1.5rem;
       margin: 0;
-      color: $primaryDarker;
+      color: vars.$primaryDarker;
     }
   }
 
   .ramp--supplemental-files-display-content {
     padding: 0 0 1.5rem 1.5rem;
-    color: $primaryDarker;
+    color: vars.$primaryDarker;
     max-height: 30rem;
 
     dt {
@@ -43,7 +43,7 @@
     }
 
     a {
-      color: $primaryGreenDark;
+      color: vars.$primaryGreenDark;
     }
   }
 

--- a/src/components/Transcript/Transcript.scss
+++ b/src/components/Transcript/Transcript.scss
@@ -1,4 +1,4 @@
-@import '../../styles/_vars.scss';
+@use '../../styles/_vars.scss';
 
 .ramp--transcript_nav {
   max-height: 30em;
@@ -9,7 +9,7 @@
     overflow-y: auto;
 
     p {
-      color: $primaryDarker;
+      color: vars.$primaryDarker;
     }
 
     #no-transcript {
@@ -45,19 +45,19 @@ span.ramp--transcript_item {
     // Highlight entire cue on hover
     &:focus,
     &:hover {
-      background-color: $primaryGreenLight;
+      background-color: vars.$primaryGreenLight;
     }
   }
 
   &.metadata-block {
-    background: $primaryLighter;
+    background: vars.$primaryLighter;
     padding: 0.5em;
-    border: 0.01em solid $primary;
+    border: 0.01em solid vars.$primary;
     border-radius: 0.25em;
   }
 
   &.active {
-    background-color: $primaryLighter;
+    background-color: vars.$primaryLighter;
   }
 
   &.disabled {
@@ -67,7 +67,7 @@ span.ramp--transcript_item {
   &.focused,
   &.focused:hover,
   &.focused:focus {
-    background-color: $primaryGreenSemiLight;
+    background-color: vars.$primaryGreenSemiLight;
   }
 
   &.focused {
@@ -80,7 +80,7 @@ span.ramp--transcript_item {
   .ramp--transcript_time {
     cursor: pointer;
     margin-right: 1em;
-    color: $primaryGreenDark;
+    color: vars.$primaryGreenDark;
 
     &:hover {
       text-decoration: underline;
@@ -104,7 +104,7 @@ span.ramp--transcript_item {
 
 .ramp--transcript_highlight {
   font-weight: bold;
-  color: $primaryGreenDimmer;
+  color: vars.$primaryGreenDimmer;
   text-decoration: underline;
   text-underline-offset: 3px;
 }
@@ -127,7 +127,7 @@ span.ramp--transcript_item {
     font-size: small;
     cursor: pointer;
     background: none;
-    border: 1px solid $primaryDarker;
+    border: 1px solid vars.$primaryDarker;
     border-radius: 3px;
   }
 }

--- a/src/components/Transcript/TranscriptMenu/TranscriptMenu.scss
+++ b/src/components/Transcript/TranscriptMenu/TranscriptMenu.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/_vars.scss';
+@use '../../../styles/_vars.scss';
 
 .ramp--transcript_nav {
   container: transcript_nav / inline-size;
@@ -8,10 +8,10 @@
   position: sticky;
   top: 0;
   margin-bottom: 20px;
-  background-color: $primaryLightest;
-  border: 1px solid $primaryLight;
+  background-color: vars.$primaryLightest;
+  border: 1px solid vars.$primaryLight;
   padding: 0.5rem;
-  border-color: $primaryLight;
+  border-color: vars.$primaryLight;
   border-radius: 3px;
   row-gap: 0.5em;
   display: flex;
@@ -34,7 +34,7 @@
 .ramp--transcript_selector select {
   box-sizing: border-box;
   width: 100%;
-  font-family: $fontPrimary;
+  font-family: vars.$fontPrimary;
   max-height: 2rem;
   min-height: 2rem;
 }
@@ -88,7 +88,7 @@
   line-height: 1.25em;
 
   & input {
-    accent-color: $primaryGreenDark;
+    accent-color: vars.$primaryGreenDark;
   }
 
   & label {
@@ -110,7 +110,7 @@
 
     & label {
       cursor: not-allowed;
-      color: $primary;
+      color: vars.$primary;
     }
   }
 }
@@ -121,11 +121,11 @@
   flex: 1 1 auto;
   max-height: 2rem;
   min-height: 2rem;
-  color: $primaryLightest;
+  color: vars.$primaryLightest;
   border-radius: 0.15rem;
   text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.3);
-  border: 1px solid $primaryGreenDark;
-  background-color: $primaryGreenDim;
+  border: 1px solid vars.$primaryGreenDark;
+  background-color: vars.$primaryGreenDim;
   cursor: pointer;
   transition: background-color 0.2s ease-in;
 
@@ -134,12 +134,12 @@
   }
 
   &:hover:not(:disabled):not([disabled]) {
-    background-color: $primaryGreenDark;
-    border: 1px solid $primaryGreenDarker;
+    background-color: vars.$primaryGreenDark;
+    border: 1px solid vars.$primaryGreenDarker;
   }
 
   &:active:not(:disabled):not([disabled]) {
-    background-color: $primaryGreenDarker;
+    background-color: vars.$primaryGreenDarker;
   }
 
   &[disabled],

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -1,8 +1,8 @@
-@import './vars';
+@use 'vars';
 
 [class*='ramp--'] {
-  font-family: $fontPrimary;
-  color: $primaryDarker;
+  font-family: vars.$fontPrimary;
+  color: vars.$primaryDarker;
   font-size: 16px;
 }
 
@@ -27,10 +27,10 @@
   }
 
   li.vjs-selected {
-    background-color: $primaryGreen;
+    background-color: vars.$primaryGreen;
 
     &:hover {
-      background-color: $primary;
+      background-color: vars.$primary;
     }
   }
 }
@@ -120,11 +120,11 @@
 
 /* captions button selection */
 .is-mobile .captions-on {
-  border-bottom: 0.3rem ridge $primaryGreen !important;
+  border-bottom: 0.3rem ridge vars.$primaryGreen !important;
 }
 
 .captions-on {
-  border-bottom: 0.35rem ridge $primaryGreen !important;
+  border-bottom: 0.35rem ridge vars.$primaryGreen !important;
 }
 
 /* display text track cues above the controls when controls are visible */
@@ -172,7 +172,7 @@
   width: 6px;
   height: 18px;
   border-radius: 20%;
-  background: $primaryGreenDark;
+  background: vars.$primaryGreenDark;
 }
 
 .lds-spinner div:nth-child(1) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6696,11 +6696,6 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-klona@^2.0.4:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.6.tgz#85bffbf819c03b2f53270412420a4555ef882e22"
-  integrity sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==
-
 launch-editor@^2.6.0, launch-editor@^2.6.1:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/launch-editor/-/launch-editor-2.10.0.tgz#5ca3edfcb9667df1e8721310f3a40f1127d4bc42"
@@ -9065,16 +9060,12 @@ sanitize-html@^2.10.0:
     parse-srcset "^1.0.2"
     postcss "^8.3.11"
 
-sass-loader@^10.0.5:
-  version "10.4.1"
-  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-10.4.1.tgz#bea4e173ddf512c9d7f53e9ec686186146807cbf"
-  integrity sha512-aX/iJZTTpNUNx/OSYzo2KsjIUQHqvWsAhhUijFjAPdZTEhstjZI9zTNvkTTwsx+uNUJqUwOw5gacxQMx4hJxGQ==
+sass-loader@^16.0.5:
+  version "16.0.5"
+  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-16.0.5.tgz#257bc90119ade066851cafe7f2c3f3504c7cda98"
+  integrity sha512-oL+CMBXrj6BZ/zOq4os+UECPL+bWqt6OAC6DWS8Ln8GZRcMDjlJ4JC3FBDuHJdYaFWIdKNIBYmtZtK2MaMkNIw==
   dependencies:
-    klona "^2.0.4"
-    loader-utils "^2.0.0"
     neo-async "^2.6.2"
-    schema-utils "^3.0.0"
-    semver "^7.3.2"
 
 sass@^1.28.0:
   version "1.59.3"


### PR DESCRIPTION
This PR fixes the following deprecation warnings in the build logs;

Issue:
```
Deprecation Warning [import]: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.

More info and automated migrator: https://sass-lang.com/d/import

  ╷
1 │ @import '../../styles/vars';
  │         ^^^^^^^^^^^^^^^^^^^
```

Fix from https://sass-lang.com/documentation/breaking-changes/import/: 
```
npm install -g sass-migrator
sass-migrator module --migrate-deps <filename>.scss
```

Issue:
```
Deprecation Warning [legacy-js-api]: The legacy JS API is deprecated and will be removed in Dart Sass 2.0.0.

More info: https://sass-lang.com/d/legacy-js-api
```
Fix: Upgrade `sass-loader` used in `Webpack` server and `Styleguidist` docs configurations. Even though the main build doesn't need these configurations, they are run along with the build command, thus issuing the deprecation warnings.

Related issues: #837, #862 
