### PR TITLE
Fix structure nav for multi-sectioned IA manifests

### DIFF
--- a/src/components/StructuredNavigation/StructuredNavigation.test.js
+++ b/src/components/StructuredNavigation/StructuredNavigation.test.js
@@ -676,6 +676,7 @@ describe('StructuredNavigation component', () => {
         // Focus is moved from section button to its first child
         expect(sectionButton).not.toHaveFocus();
         expect(treeItems[1].querySelectorAll('a')[0]).toHaveFocus();
+        expect(treeItems[1].children[1]).toHaveTextContent('Using Soap');
       });
 
       test('Enter keydown event loads media into the player', () => {
@@ -719,24 +720,29 @@ describe('StructuredNavigation component', () => {
       test('ArrowLeft keydown moves focus to section item', () => {
         const firstChild = treeItems[3].children[1];
 
-        // Press 'ArrowDown' key
+        // Press 'ArrowDown' key moves focus to the next timespan: Rinsing Well
         fireEvent.keyDown(firstChild, { key: 'ArrowDown', keyCode: 40 });
-        // Press 'ArrowLeft' key
-        fireEvent.keyDown(treeItems[3].children[1], { key: 'ArrowLeft', keyCode: 37 });
+        expect(treeItems[4].children[1]).toHaveFocus();
+        expect(treeItems[4].children[1]).toHaveTextContent('Rinsing Well');
 
-        expect(treeItems[3].children[1]).not.toHaveFocus();
-        expect(treeItems[20].children[0].children[0]).toHaveFocus();
+        // Press 'ArrowLeft' key moves focus to the parent section: Lunchroom Manners
+        fireEvent.keyDown(treeItems[4].children[1], { key: 'ArrowLeft', keyCode: 37 });
+
+        expect(treeItems[4].children[1]).not.toHaveFocus();
+        expect(treeItems[1].children[0].children[0]).toHaveFocus();
+        expect(treeItems[1].children[0].children[0]).toHaveTextContent('Lunchroom Manners');
       });
 
       test('ArrowDown keydown event moves focus to next timespan', () => {
         const firstChild = treeItems[3].children[1];
         expect(firstChild).toHaveFocus();
-        // Press 'ArrowDown' key
+        // Press 'ArrowDown' key moves focus to the next timespan: Rinsing Well
         fireEvent.keyDown(firstChild, { key: 'ArrowDown', keyCode: 40 });
 
         // Focus is moved from the first child to next
         expect(firstChild).not.toHaveFocus();
         expect(treeItems[4].children[1]).toHaveFocus();
+        expect(treeItems[4].children[1]).toHaveTextContent('Rinsing Well');
       });
 
       test('Space keydown event activates the timespan', () => {
@@ -748,6 +754,7 @@ describe('StructuredNavigation component', () => {
         // Focus is moved from the first child to next
         expect(firstChild).not.toHaveFocus();
         expect(treeItems[4].children[1]).toHaveFocus();
+        expect(treeItems[4].children[1]).toHaveTextContent('Rinsing Well');
 
         fireEvent.keyDown(treeItems[4].children[1], { key: '', code: 'Space', keyCode: 32 });
 

--- a/src/services/iiif-parser.js
+++ b/src/services/iiif-parser.js
@@ -607,7 +607,15 @@ export function getStructureRanges(manifest, canvasesInfo, isPlaylist = false) {
       // Set 'id' in the form of a mediafragment
       if (canvases.length > 0) {
         if (isCanvas) {
-          id = `${canvases[0].split(',')[0]},`;
+          const [uri, mediafragment] = canvases[0].split('#');
+          if (mediafragment) {
+            // Example: http://example.com/manifest/canvas#t=0,duration
+            id = `${canvases[0].split(',')[0]},`;
+          } else {
+            // Build mediafragment when it is not given in the Canvas id for the Range
+            // Example: http://example.com/manifest/canvas
+            id = `${uri}#t=0,`;
+          }
         } else {
           id = canvases[0];
         }

--- a/src/services/iiif-parser.test.js
+++ b/src/services/iiif-parser.test.js
@@ -674,6 +674,29 @@ describe('iiif-parser', () => {
       expect(firstTimespan).toEqual(firstStructCanvas);
     });
 
+    it('returns identical structures when Canvas id is not a mediafragment', () => {
+      const { structures, timespans, markRoot, hasCollapsibleStructure } = iiifParser.getStructureRanges(
+        autoAdvanceManifest, iiifParser.canvasesInManifest(autoAdvanceManifest)
+      );
+      expect(structures).toHaveLength(1);
+      expect(timespans).toHaveLength(2);
+      expect(markRoot).toBeTruthy();
+      expect(hasCollapsibleStructure).toBeFalsy();
+
+      const secondStructCanvas = structures[0].items[1];
+      expect(secondStructCanvas.label).toEqual('Atto Secondo');
+      expect(secondStructCanvas.items).toHaveLength(0);
+      expect(secondStructCanvas.isCanvas).toBeTruthy();
+      expect(secondStructCanvas.isEmpty).toBeFalsy();
+      expect(secondStructCanvas.isTitle).toBeFalsy();
+      expect(secondStructCanvas.rangeId).toEqual('https://iiif.io/api/cookbook/recipe/0065-opera-multiple-canvases/range/3');
+      expect(secondStructCanvas.id).toEqual('https://iiif.io/api/cookbook/recipe/0065-opera-multiple-canvases/canvas/2#t=0,');
+      expect(secondStructCanvas.isClickable).toBeTruthy();
+      expect(secondStructCanvas.duration).toEqual('55:07');
+      expect(secondStructCanvas.canvasDuration).toEqual(3307.22);
+      expect(secondStructCanvas.times).toEqual({ start: 0, end: 0 });
+    });
+
     it('returns mediafragment with only start time for structure item relevant to Canvas', () => {
       const { structures, timespans, markRoot, hasCollapsibleStructure } = iiifParser.getStructureRanges(
         lunchroomManifest, iiifParser.canvasesInManifest(lunchroomManifest)

--- a/src/services/ramp-hooks.js
+++ b/src/services/ramp-hooks.js
@@ -750,8 +750,7 @@ export const useActiveStructure = ({
     e.preventDefault();
     e.stopPropagation();
 
-    const { start, end } = times;
-    const inRange = checkSrcRange({ start, end }, { end: canvasDuration });
+    const inRange = checkSrcRange(times, { end: canvasDuration });
     /* 
       Only continue the click action if not both start and end times of 
       the timespan are not outside Canvas' duration

--- a/src/test_data/multiple-canvas-auto-advance.js
+++ b/src/test_data/multiple-canvas-auto-advance.js
@@ -151,7 +151,7 @@ export default {
           items: [
             {
               type: 'Canvas',
-              id: 'https://iiif.io/api/cookbook/recipe/0065-opera-multiple-canvases/canvas/2#t=0,',
+              id: 'https://iiif.io/api/cookbook/recipe/0065-opera-multiple-canvases/canvas/2',
             },
           ],
         },


### PR DESCRIPTION
Related issue: #818 

Following changes are made in this PR to improve structured navigation for Canvas ranges without mediafragment information. The IA Manifest in question has multiple canvases and are referenced in the `structures` property with the relevant Canvas ids. However, these ids don't have mediafragment information attached as expected by Ramp, e.g. `url#t=0,2.0`.
While working on this, I came across that if such ranges referencing to sections has children the collapsible UI is not operable by using left/right arrow keys to collapse/expand the sections as expected. This breaks accessibility for such structure displays. So, this PR has an additional fix to that as well.

Changes in the PR:
  - formatting the `id` with mediafragment in the parser, so that click handlers have required information to provide desired functionality (Related Manifest: https://iiif.archive.org/iiif/3/Weirdos_demo-1978/manifest.json)
  - changing the creation of `sectionRef` when building structured navigation to use fresh `ref`s for each section, which fixes automatic scrolling to the last section every time the page loads or a Canvas is changed. Observe this behavior for the IA Manifest at https://ramp.avalonmediasystem.org/?iiif-content=https://iiif.archive.org/iiif/3/Weirdos_demo-1978/manifest.json.
  - keeping keyboard-accessibility of such sections for collapsing/expanding sections using left/right arrow keys. Observe this behavior for a cookbook Manifest by following these steps to reproduce this behavior:
     1. Open cookbook [Manifest](https://iiif.io/api/cookbook/recipe/0065-opera-multiple-canvases/manifest.json) in [Ramp](https://ramp.avalonmediasystem.org?iiif-content=https://iiif.io/api/cookbook/recipe/0065-opera-multiple-canvases/manifest.json)
     2. Use `Tab` key to navigate to the structure
     3. Once the focus is on the structure container (blue highlight around the structure), press `ArrowDown` key to move focus inside the structure
     4. Keep pressing `ArrowDown` until focus is on **Atto Primo** structure item
     5. Press `ArrowLeft` -> nothing happens (this should ideally collapse the section), press `ArrowRight` -> nothing happens (this should ideally move the focus to the first structure child under this section)