### PR TITLE
Adjust the big-play-button in video player

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -105,8 +105,16 @@
 /* big-play button */
 .video-js .vjs-big-play-button {
   border-radius: 50%;
-  width: 50px;
-  scale: 2;
+  // Use 'font-size' instead of 'scale' to avoid blurriness in Safari
+  font-size: 6em;
+  // Make it a perfect circle by matching width to height
+  width: 1.7em;
+  height: 1.7em;
+  // Center the button horizontally (width / 2) because width is changed
+  // and videojs positions this button using specific margin values
+  margin-left: -0.85em;
+  // Override background-color alpha to make the button opaque
+  background-color: rgb(43, 51, 63) !important;
 }
 
 .vjs-disabled {


### PR DESCRIPTION
Related issue: #871 

Changes made in this PR:
- make the big play button icon opaque
- change the CSS properties used to scale the button so that it's not blurry in Safari 

This is how the button look in Safari after all the changes:
<img width="956" height="542" alt="Screenshot 2025-11-06 at 9 59 45 AM" src="https://github.com/user-attachments/assets/391fac06-4b1c-4775-bfe0-ef0cf52e1da6" />

