### PR TITLE
Fix indefinite loading spinner in transcripts tab

### DIFF
--- a/src/components/Transcript/TranscriptMenu/TranscriptSelector.js
+++ b/src/components/Transcript/TranscriptMenu/TranscriptSelector.js
@@ -22,7 +22,7 @@ const TranscriptSelector = ({
     selectTranscript(event.target.value);
   };
 
-  if (transcriptData) {
+  if (transcriptData?.length > 0) {
     const result = [
       <div
         key="transcript-selector"

--- a/src/services/ramp-hooks.js
+++ b/src/services/ramp-hooks.js
@@ -1019,9 +1019,9 @@ export const useTranscripts = ({
       transcriptParseAbort?.current?.abort();
       const canvasAnnotations = annotations
         .filter((a) => a.canvasIndex == canvasIndexRef.current);
-      if (canvasAnnotations?.length > 0 && canvasAnnotations[0].annotationSets?.length > 0) {
+      if (canvasAnnotations?.length > 0 && canvasAnnotations[canvasIndexRef.current]?.annotationSets?.length > 0) {
         // Filter supplementing annotations from all annotations in the Canvas
-        const transcriptAnnotations = canvasAnnotations[0].annotationSets
+        const transcriptAnnotations = canvasAnnotations[canvasIndexRef.current].annotationSets
           .filter((as) => as.motivation?.includes(TRANSCRIPT_MOTIVATION) || as.isSupplementing);
         // Convert annotations into Transcript component friendly format
         const transcriptItems = transcriptAnnotations?.length > 0
@@ -1042,6 +1042,14 @@ export const useTranscripts = ({
         { canvasId: canvasIndexRef.current, items: transcriptItems }];
         setTranscriptsList(allTranscripts ?? []);
         initTranscriptData(allTranscripts ?? []);
+      } else {
+        // When annotations exist but no supplementing annotations found
+        setIsLoading(false);
+        setTranscript([]);
+        setTranscriptInfo({
+          tType: TRANSCRIPT_TYPES.noTranscript, id: '',
+          tError: NO_TRANSCRIPTS_MSG
+        });
       }
     } else {
       transcriptParseAbort.current = new AbortController();


### PR DESCRIPTION
Related issue: https://github.com/avalonmediasystem/avalon/issues/6608

This PR fixes the issue mentioned in the last item in [comment](https://github.com/avalonmediasystem/avalon/issues/6608#issuecomment-3499856979), where the transcripts tab is indefinitely showing the loading spinner.

The reason for this bug: when the annotations component parses `annotationSets` for the current Canvas and gives and empty list, the `else` condition was not in place to stop the loading spinner.