### PR TITLE
Fix layout shift for vertical scrollbar appearance

### DIFF
--- a/demo/app.scss
+++ b/demo/app.scss
@@ -1,6 +1,12 @@
 html {
   font-size: 1em;
   font-family: Arial, Helvetica, sans-serif;
+  /*
+    Use 'scrollbar-gutter' with 'overflow-y' as a fallback to fix
+    layout shifts in Chrome and Safari when content expands.
+  */
+  scrollbar-gutter: stable;
+  overflow-y: scroll;
 }
 
 .ramp-demo {


### PR DESCRIPTION
Related issue: #808 

This layout shift is caused by the vertical scrollbar when content on the demo page expands. When content expands and triggers a scrollbar, both Chrome and Safari reserve space for it which cases the content to shift left. Firefox uses overlay scrollbars by default, which keeps the content without shifting when the scrollbar is triggered. This PR adds overlay scrollbars to the demo site CSS to override Chrome and Safari's default scrollbar behavior.