### PR TITLE
Fixes progressbar for clipped playlist items, MIME type support

### DIFF
--- a/src/components/MediaPlayer/VideoJS/components/js/VideoJSProgress.js
+++ b/src/components/MediaPlayer/VideoJS/components/js/VideoJSProgress.js
@@ -93,7 +93,6 @@ class CustomSeekBar extends SeekBar {
   // Update component's variables on Canvas changes
   updateComponent() {
     const { srcIndex, targets } = this.player;
-    if (!srcIndex || !targets) return;
 
     this.setSrcIndex(srcIndex);
     this.setCanvasTargets(targets);


### PR DESCRIPTION
Bugs fixed in this PR:
- Refine file extension calculation for MIME type resolution
- Update browser support check for MIME types supported via `'videojs-http-streaming'` VideoJS plugin
- Fix bug in progress-bar custom code, which blocked striped appearance for clipped items in playlists

These were introduced in https://github.com/samvera-labs/ramp/pull/887

