### PR TITLE
Display player controls in error state

### DIFF
--- a/src/components/MediaPlayer/VideoJS/components/js/VideoJSNextButton.js
+++ b/src/components/MediaPlayer/VideoJS/components/js/VideoJSNextButton.js
@@ -18,7 +18,7 @@ class VideoJSNextButton extends Button {
     super(player, options);
     // Use Video.js' stock SVG instead of setting it using CSS
     this.setIcon('next-item');
-    this.addClass('vjs-play-control vjs-control');
+    this.addClass('vjs-play-control vjs-control vjs-next-button');
     this.setAttribute('data-testid', 'videojs-next-button');
     this.controlText('Next');
     this.options = options;

--- a/src/components/MediaPlayer/VideoJS/components/js/VideoJSPreviousButton.js
+++ b/src/components/MediaPlayer/VideoJS/components/js/VideoJSPreviousButton.js
@@ -17,7 +17,7 @@ class VideoJSPreviousButton extends Button {
     super(player, options);
     // Use Video.js' stock SVG instead of setting it using CSS
     this.setIcon('previous-item');
-    this.addClass('vjs-play-control vjs-control');
+    this.addClass('vjs-play-control vjs-control vjs-previous-button');
     this.setAttribute('data-testid', 'videojs-previous-button');
     this.options = options;
     this.player = player;

--- a/src/components/MediaPlayer/VideoJS/videojs-theme.scss
+++ b/src/components/MediaPlayer/VideoJS/videojs-theme.scss
@@ -229,3 +229,27 @@
     transform: translateY(-10px);
   }
 }
+
+/* Force control bar to be visible even in error state */
+.vjs-force-control-bar .vjs-control-bar {
+  display: flex !important;
+  visibility: visible !important;
+  opacity: 1 !important;
+  z-index: 10000 !important;
+  pointer-events: auto !important;
+
+  // Disable all controls except previous/next buttons
+  >*:not(.vjs-previous-button):not(.vjs-next-button) {
+    pointer-events: none !important;
+    opacity: 0.3 !important;
+    cursor: not-allowed !important;
+  }
+
+  // Ensure previous/next buttons are enabled
+  .vjs-previous-button,
+  .vjs-next-button {
+    pointer-events: auto !important;
+    opacity: 1 !important;
+    cursor: pointer !important;
+  }
+}


### PR DESCRIPTION
Related issue: #878 

Changes in this PR:
- display player controls in the player's error state for multi-canvas manifests to provide users the ability to navigate between canvases. In this state only the previous/next buttons are enabled to allow canvas navigation
<img width="730" height="417" alt="multi-canvas error" src="https://github.com/user-attachments/assets/ddcd60d6-1dd5-4309-b921-48a2d549564f" />

- hide player controls in the player's error state for single-canvas manifests
<img width="730" height="417" alt="single-canvas error" src="https://github.com/user-attachments/assets/ba0336d2-fe32-4a8a-b1f6-27f1c49f6eb3" />

