### PR TITLE
Add git workflow for build and notify avalon for new commits

### DIFF
--- a/github/workflows/build-and-deploy.yml
+++ b/github/workflows/build-and-deploy.yml
@@ -1,0 +1,76 @@
+name: Build and Notify Avalon
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.push-build.outputs.build_changed }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'yarn'
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Build library
+        run: NODE_ENV=production npx vite build
+      - name: Verify build output
+        run: |
+          test -f dist/ramp.cjs.js
+          test -f dist/ramp.esm.js
+          test -f dist/ramp.umd.js
+          test -f dist/ramp.css
+      - name: Deploy to ramp-build branch
+        id: push-build
+        run: |
+          MAIN_SHA=$(git rev-parse --short HEAD)
+          git fetch origin ramp-build || true
+          BEFORE_SHA=$(git rev-parse origin/ramp-build 2>/dev/null || echo "none")
+
+          # Stage only the build files and package.json for testing code changes
+          mkdir -p /tmp/ramp-publish/dist
+          cp -r dist/* /tmp/ramp-publish/dist/
+          cp package.json /tmp/ramp-publish/
+
+          # Use gh-pages to publish the content to the ramp-build branch
+          npx gh-pages \
+            -d /tmp/ramp-publish \
+            -b ramp-build \
+            -u "dwithana <dwithana@iu.edu>" \
+            -m "Auto-build from main ($MAIN_SHA)" \
+            -r "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git"
+
+          git fetch origin ramp-build
+          AFTER_SHA=$(git rev-parse origin/ramp-build)
+
+          # Do nothing if the build output hasn't changed to avoid unnecessary notifications
+          if [ "$BEFORE_SHA" = "$AFTER_SHA" ]; then
+            echo "No build changes, skipping notification"
+            echo "build_changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "build_changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  notify-avalon:
+    needs: build-and-deploy
+    if: needs.build-and-deploy.outputs.build_changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify new Ramp build
+        uses: peter-evans/repository-dispatch@v4
+        with:
+          token: ${{ secrets.AVALON_DISPATCH_TOKEN }}
+          repository: avalonmediasystem/avalon
+          event-type: ramp-build-updated
+          client-payload: '{"ramp_commit": "${{ github.sha }}"}'
+


### PR DESCRIPTION
Related issue: https://github.com/avalonmediasystem/avalon/issues/6121

This PR adds a Git workflow to do the following on new commits made to `main` branch.

1. Build the latest code from `main`
2. If there's new code use `gh-pages` library to create/update the `ramp-build` branch with latest build files and `package.json` file. Using `gh-pages` we are able to only keep track of the build files.
3. Check if the build files have changed to proceed to the next steps. This prevents from invoking the rest of the workflow on non-code changes that don't need testing in Avalon.
4. If there's changes notify Avalon to create a PR to update the Ramp dependency