### PR TITLE
Use workflow_dispatch for Git workflow

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -67,10 +67,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify new Ramp build
-        uses: peter-evans/repository-dispatch@v4
-        with:
-          token: ${{ secrets.AVALON_DISPATCH_TOKEN }}
-          repository: avalonmediasystem/avalon
-          event-type: ramp-build-updated
-          client-payload: '{"ramp_commit": "${{ github.sha }}"}'
-
+        run: |
+          curl -X POST \
+            -H "Authorization: Bearer ${{ secrets.AVALON_DISPATCH_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/avalonmediasystem/avalon/actions/workflows/update-ramp.yml/dispatches \
+            -d '{"ref":"develop","inputs":{"ramp_commit":"${{ github.sha }}"}}'


### PR DESCRIPTION
Related issue: https://github.com/avalonmediasystem/avalon/issues/6121

Use `workflow_dispatch` instead of `respository_dispatch` because `repository_dispatch` only triggers workflows in the default branch. In Avalon we need to create the PR from `develop` branch not `main` (the default branch).

Using `workflow_dispatch` along with `ref` flag, the PR creation can be triggered on branches other than the default branch. This changes introduces the following changes;
- requires a new PAT with workflow access in addition to repo
- commit hash variable in Avalon's workflow `github.event.client_payload.ramp_commit` -> `github.event.inputs.ramp_commit` (https://github.com/avalonmediasystem/avalon/pull/6724)
- a dummy workflow file in Avalon's `main` branch for the repo to register the workflow (https://github.com/avalonmediasystem/avalon/pull/6723)