### PR TITLE
Disable CircleCI for commits in the ramp-build branch

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -47,7 +47,7 @@ jobs:
             -d /tmp/ramp-publish \
             -b ramp-build \
             -u "dwithana <dwithana@iu.edu>" \
-            -m "Auto-build from main ($MAIN_SHA)" \
+            -m "Auto-build from main ($MAIN_SHA) [ci skip]" \
             -r "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git"
 
           git fetch origin ramp-build


### PR DESCRIPTION
Related issue: avalonmediasystem/avalon#6121

Add `[ci skip]` to `ramp-build` commit message to disable CircleCI from running on commits to the that branch. If this doesn't work explore configuring `config.yml` to ignore the branch in the workflow.