### PR TITLE
Create a standalone bundle for non-React apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,15 @@ A ReactJS component library of interactive components created to display audio/v
 
 For full documentation of the component library, visit [GitHub Wiki](https://github.com/samvera-labs/ramp/wiki)
 
-Demo site built show-casing all the components at https://ramp.avalonmediasystem.org/
+Demo site built showcasing all the components at https://ramp.avalonmediasystem.org/
 
 ## Installation Guide:
 
-### Prerequisites
+### With React (NPM package)
+
+For React applications using a build tool (Webpack, Vite, etc.).
+
+#### Prerequisites
 
 Please ensure you have the following installed:
 - Node.js (>= 16.x)
@@ -26,26 +30,28 @@ Please ensure you have the following installed:
  - `@samvera/ramp` **v3.3.0** to **v4.0.2** support **React 18**. **Note:** `@samvera/ramp` v3.3.0 works with both React 17 and React 18. If upgrading to React 18, update both `react` and `react-dom` to the same version.
  - For **older versions** of `@samvera/ramp`, use **React 17**.
 
+For ReactJS upgrade instructions, see the [ReactJS official upgrade guide](https://react.dev/blog/2022/03/08/react-18-upgrade-guide#updates-to-client-rendering-apis).
 
- For ReactJS upgrade instructions, see the [ReactJS official upgrade guide](https://react.dev/blog/2022/03/08/react-18-upgrade-guide#updates-to-client-rendering-apis).
+#### Steps
 
-### Steps
-
-1. Add `@samvera/ramp` components library from NPM into your application"
+1. Add `@samvera/ramp` components library from NPM into your application:
 ```
 yarn add @samvera/ramp
-```
-OR
-```
 npm install @samvera/ramp
 ```
 
-**Important**:
-- Post `@samvera/ramp v4.0.2`, VideoJS is included as a dependency and does **not** need to be installed separately.
-- For older versions:
+**For `@samvera/ramp` versions < `5.x`**:
+For older versions:
   - `@samvera/ramp` versions < `v3.1.3`: Install `video.js@7.21.3`
   - `@samvera/ramp` versions between (inclusive) `v3.1.3` and `v4.0.2`: Install `video.js@8.10.0`
-- For best results, use the recommended VideoJS version for your Ramp version.
+
+For best results, use the recommended VideoJS version for your Ramp version.
+Add `Video.js` library to your app as follows:
+```
+yarn add video.js@<version>
+npm install video.js@<version>
+```
+From `@samvera/ramp v5.x`, VideoJS is included as a dependency and does **not** need to be installed separately.
 
 2. Import the library into your application:
 ```
@@ -83,6 +89,84 @@ const App = () => {
 }
 
 export default App;
+```
+---
+
+### Without React (Standalone bundle)
+
+For plain HTML/JS applications (Rails, PHP, etc.) with no React or build tools.
+The standalone bundle uses [Preact](https://preactjs.com/) internally to keep the file size small, but exposes the full React API so the app can render components using `React.createElement`.
+
+#### Steps
+
+1. In your HTML page, load the bundle and styles directly from [unpkg](https://unpkg.com/) (no download or build step required):
+
+```html
+<link rel="stylesheet" href="https://unpkg.com/@samvera/ramp/dist/ramp.css" />
+<script src="https://unpkg.com/@samvera/ramp/dist/ramp.standalone.umd.js"></script>
+```
+
+To pin to a specific version, include it in the URL:
+```html
+<link rel="stylesheet" href="https://unpkg.com/@samvera/ramp@5.0.0/dist/ramp.css" />
+<script src="https://unpkg.com/@samvera/ramp@5.0.0/dist/ramp.standalone.umd.js"></script>
+```
+
+Alternatively, download both files from the [latest release](https://github.com/samvera-labs/ramp/releases) and serve them locally.
+
+```html
+<link rel="stylesheet" href="ramp.css" />
+<script src="ramp.standalone.umd.js"></script>
+```
+
+2. In the HTML page, render the player:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <link rel="stylesheet" href="https://unpkg.com/@samvera/ramp/dist/ramp.css" />
+</head>
+
+<body>
+  <script src="https://unpkg.com/@samvera/ramp/dist/ramp.standalone.umd.js"></script>
+  <div id="root"></div>
+  <script>
+    // Import components and React
+    const { IIIFPlayer, MediaPlayer, StructuredNavigation, React, ReactDOM } = RampIIIF;
+    // Parse Manifest URL
+    const manifestUrl = new URLSearchParams(window.location.search).get('iiif-content');
+
+    if (!manifestUrl) {
+      alert('No manifest URL provided. Add ?iiif-content=<url> to the page URL.');
+    } else {
+      let parsed;
+      try {
+        parsed = new URL(manifestUrl);
+      } catch {
+        alert('Invalid URL in iiif-content parameter.');
+        parsed = null;
+      }
+
+      if (parsed) {
+        const root = document.getElementById('root');
+        const playerTree = React.createElement(
+          IIIFPlayer,
+          { manifestUrl },
+          React.createElement(
+            'div', { className: 'iiif-player-demo' },
+            React.createElement(MediaPlayer),
+            React.createElement(StructuredNavigation)
+          )
+        );
+
+        ReactDOM.createRoot(root).render(playerTree);
+      }
+    }
+  </script>
+</body>
+</html>
 ```
 
 ## Development

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "/dist"
   ],
   "scripts": {
-    "build": "npm run clean && NODE_ENV=production vite build && styleguidist build",
+    "build": "npm run clean && NODE_ENV=production npm run bundle && styleguidist build",
+    "bundle": "vite build && PREACT=true vite build",
     "clean": "rimraf dist",
     "prepublishOnly": "npm run build",
     "dev": "styleguidist server",
@@ -59,6 +60,7 @@
     "gh-pages": "^5.0.0",
     "jest": "^26.4.2",
     "path-browserify": "^1.0.1",
+    "preact": "^10.29.0",
     "prop-types": "^15.7.2",
     "react": "^19.0.0",
     "react-compiler-runtime": "^19.1.0-rc.3",

--- a/src/main.standalone.js
+++ b/src/main.standalone.js
@@ -1,0 +1,3 @@
+export * from './main';
+export { default as React } from 'react';
+export * as ReactDOM from 'react-dom/client';

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,13 +6,32 @@ import { readFileSync } from 'fs';
 // Read package.json for build outputs
 const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'));
 
+const baseAlias = {
+  '@Components': resolve(__dirname, 'src/components'),
+  '@TestData': resolve(__dirname, 'src/test_data'),
+  '@Services': resolve(__dirname, 'src/services'),
+  // Node.js polyfills for browser compatibility
+  'stream': 'stream-browserify',
+  'path': 'path-browserify',
+};
+
+const preactAlias = {
+  ...baseAlias,
+  // Alias 'react' to 'preact/compat'
+  'react': 'preact/compat',
+  'react-dom/client': 'preact/compat/client',
+  'react-dom': 'preact/compat',
+};
+
+const isPreact = process.env.PREACT === 'true';
+
 export default defineConfig({
   plugins: [
     react({
       babel: {
         plugins: [
-          // Add the React Compiler Babel plugin
-          ['babel-plugin-react-compiler', { target: '19' }],
+          // React Compiler Babel plugin is incompatible with Preact
+          ...(!isPreact ? [['babel-plugin-react-compiler', { target: '19' }]] : []),
         ],
       },
     }),
@@ -23,16 +42,8 @@ export default defineConfig({
     include: /.*\.[jt]sx?$/,
     exclude: /node_modules/,
   },
-  // Resolve path aliases and Node.js polyfills
   resolve: {
-    alias: {
-      '@Components': resolve(__dirname, 'src/components'),
-      '@TestData': resolve(__dirname, 'src/test_data'),
-      '@Services': resolve(__dirname, 'src/services'),
-      // Node.js polyfills for browser compatibility
-      'stream': 'stream-browserify',
-      'path': 'path-browserify',
-    },
+    alias: isPreact ? preactAlias : baseAlias,
   },
   // Environment variables
   define: {
@@ -47,7 +58,21 @@ export default defineConfig({
     },
   },
   // Build configuration for library
-  build: {
+  build: isPreact ? {
+    outDir: 'dist',
+    emptyOutDir: false,
+    lib: {
+      entry: resolve(__dirname, 'src/main.standalone.js'),
+      name: 'RampIIIF',
+      formats: ['umd'],
+      fileName: () => 'ramp.standalone.umd.js',
+    },
+    rollupOptions: {
+      // No external dependencies, bundles all aliasing react -> preact
+      external: [],
+      output: { globals: {} },
+    },
+  } : {
     outDir: 'dist',
     emptyOutDir: true,
     // Library mode configuration
@@ -55,9 +80,7 @@ export default defineConfig({
       entry: resolve(__dirname, 'src/main.js'),
       name: 'RampIIIF',
       formats: ['esm', 'cjs', 'umd'],
-      fileName: (format) => {
-        return `ramp.${format}.js`;
-      },
+      fileName: (format) => `ramp.${format}.js`,
     },
     // Rollup options for external dependencies
     rollupOptions: {
@@ -75,8 +98,8 @@ export default defineConfig({
           'classnames': 'cx'
         },
       },
-    }
+    },
   },
-  // Prevent inlcuding files from the public directory in the build
+  // Prevent including files from the public directory in the build
   publicDir: false,
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2095,9 +2095,9 @@
     redent "^3.0.0"
 
 "@testing-library/react@^16.0.1":
-  version "16.0.1"
-  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-16.0.1.tgz#29c0ee878d672703f5e7579f239005e4e0faa875"
-  integrity sha512-dSmwJVtJXmku+iocRhWOUFbrERC76TX2Mnf0ATODz8brzAZrMBbzLwQixlBSanZxR6LddK3eiwpSFZgDET1URg==
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-16.3.2.tgz#672883b7acb8e775fc0492d9e9d25e06e89786d0"
+  integrity sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==
   dependencies:
     "@babel/runtime" "^7.12.5"
 
@@ -7433,6 +7433,11 @@ postcss@^8.4.33, postcss@^8.5.6:
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 
+preact@^10.29.0:
+  version "10.29.0"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.29.0.tgz#a6e5858670b659c4d471c6fea232233e03b403e8"
+  integrity sha512-wSAGyk2bYR1c7t3SZ3jHcM6xy0lcBcDel6lODcs9ME6Th++Dx2KU+6D3HD8wMMKGA8Wpw7OMd3/4RGzYRpzwRg==
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -7646,11 +7651,11 @@ react-docgen@^5.0.0:
     strip-indent "^3.0.0"
 
 react-dom@^19.0.0:
-  version "19.1.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.1.1.tgz#2daa9ff7f3ae384aeb30e76d5ee38c046dc89893"
-  integrity sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==
+  version "19.2.4"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.2.4.tgz#6fac6bd96f7db477d966c7ec17c1a2b1ad8e6591"
+  integrity sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==
   dependencies:
-    scheduler "^0.26.0"
+    scheduler "^0.27.0"
 
 react-error-boundary@^4.0.11:
   version "4.0.11"
@@ -7774,9 +7779,9 @@ react-styleguidist@13.1.3:
     webpack-merge "^4.2.2"
 
 react@^19.0.0:
-  version "19.1.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-19.1.1.tgz#06d9149ec5e083a67f9a1e39ce97b06a03b644af"
-  integrity sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==
+  version "19.2.4"
+  resolved "https://registry.yarnpkg.com/react/-/react-19.2.4.tgz#438e57baa19b77cb23aab516cf635cd0579ee09a"
+  integrity sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==
 
 read-pkg-up@^7.0.1:
   version "7.0.1"
@@ -8181,10 +8186,10 @@ saxes@^5.0.1:
   dependencies:
     xmlchars "^2.2.0"
 
-scheduler@^0.26.0:
-  version "0.26.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.26.0.tgz#4ce8a8c2a2095f13ea11bf9a445be50c555d6337"
-  integrity sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==
+scheduler@^0.27.0:
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.27.0.tgz#0c4ef82d67d1e5c1e359e8fc76d3a87f045fe5bd"
+  integrity sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==
 
 schema-utils@2.7.0:
   version "2.7.0"


### PR DESCRIPTION
Related issue: #920 

Changes in this PR:
- adds `preact` as a `devDependency`
- adds additional config to the `vite.config.js` to create the standalone bundle with `preact/comact`
- document the usage of the standalone bundle in `README.md` (the unpkg URLs are the expected values for when/if this is published to NPM)