### PR TITLE
Change popup menu direction based on player orientation

### DIFF
--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -210,11 +210,14 @@ function VideoJSPlayer({
         // Need to set this once experimentalSvgIcons option in Video.js options was enabled
         player.getChild('controlBar').qualitySelector.setIcon('cog');
       }
+
+      // Update popup menu directions as needed
+      updateMenuDirection(player);
     });
 
     player.on('emptied', () => {
       /**
-       * In the quality-selector plugin used in Ramp, when the player is using remote 
+       * In the quality-selector plugin used in Ramp, when the player is using remote
        * text tracks they get cleared upon quality selection.
        * This is a known issue with @silvermine/videojs-quality-selector plugin.
        * When a new source from the quality selector is selected 'emptied' event is trigger.
@@ -963,7 +966,7 @@ function VideoJSPlayer({
   };
 
   const {
-    activeId, fragmentMarker, isReadyRef, playerRef, setActiveId, setFragmentMarker, setIsReady
+    activeId, fragmentMarker, isReadyRef, playerRef, setActiveId, setFragmentMarker, setIsReady, updateMenuDirection
   } = useVideoJSPlayer({
     audioDescTracks, options, playerInitSetup, updatePlayer, startQuality, tracks, videoJSRef, videoJSLangMap
   });

--- a/src/components/MediaPlayer/VideoJS/videojs-theme.scss
+++ b/src/components/MediaPlayer/VideoJS/videojs-theme.scss
@@ -137,10 +137,9 @@
 
 /* When audio player is placed near the top of the page (e.g. in Avalon), the playback rate
 menu that opens upwards gets clipped by the top of the viewport. To prevent this, open the
-menu downwards on mobile audio players. 
+menu downwards.
 To keep the menus consistent apply the same styling for quality selector menu as well. */
-.vjs-theme-ramp.vjs-audio-only-mode.vjs-device-iphone,
-.vjs-theme-ramp.vjs-audio-only-mode.vjs-device-android {
+.vjs-theme-ramp.vjs-audio-only-mode.vjs-menu-open-down {
   .vjs-playback-rate .vjs-menu,
   .vjs-quality-selector .vjs-menu {
     bottom: auto;

--- a/src/services/ramp-hooks.js
+++ b/src/services/ramp-hooks.js
@@ -329,6 +329,7 @@ export const useSetupPlayer = ({
  * setActiveId: func,
  * setFragmentMarker: func,
  * setIsReady: func,
+ * updateMenuDirection: func,
  * }
  */
 export const useVideoJSPlayer = ({
@@ -549,12 +550,11 @@ export const useVideoJSPlayer = ({
       }
     });
 
-    // Listen for resize events on desktop browsers and trigger player.resize event
-    window.addEventListener('resize', () => {
-      // Check if player is initialized before triggering resize event, especially helpful
-      // when switching the Manifest in the demo site without a page reload
+    /* Check if player is initialized before triggering resize event, especially helpful
+      when switching the Manifest in the demo site without a page reload */
+    const callPlayerResize = () => {
       if (player?.player_) player.trigger('resize');
-    });
+    };
 
     /**
      * The 'resize' event on window doesn't catch zoom in/out in iOS Safari.
@@ -562,12 +562,27 @@ export const useVideoJSPlayer = ({
      * zoomed in/out using OS/browser settings.
      */
     if (window.visualViewport) {
-      window.visualViewport.addEventListener('resize', () => {
-        // Check if player is initialized before triggering resize event, especially helpful
-        // when switching the Manifest in the demo site without a page reload
-        if (player?.player_) player.trigger('resize');
-      });
+      window.visualViewport.addEventListener('resize', callPlayerResize);
     }
+
+    // Re-evaluate menu direction on scroll and window resize events
+    const handleScrollOrResize = () => updateMenuDirection(player);
+
+    window.addEventListener('scroll', handleScrollOrResize);
+    window.addEventListener('resize', () => {
+      handleScrollOrResize();
+      // Listen for resize events on desktop browsers and trigger player.resize event.
+      callPlayerResize();
+    });
+
+    // Clean up window listeners when the player is destroyed
+    player.on('dispose', () => {
+      window.removeEventListener('scroll', handleScrollOrResize);
+      window.removeEventListener('resize', () => {
+        handleScrollOrResize();
+        callPlayerResize();
+      });
+    });
   };
 
   /**
@@ -608,6 +623,33 @@ export const useVideoJSPlayer = ({
     }
   };
 
+  /**
+   * Change the direction of the popup menu based on whether there is enough
+   * space above the player to show them without getting clipped by the viewport
+   */
+  const updateMenuDirection = (player) => {
+    const playerEl = playerRef.current?.el();
+    if (!playerEl) return;
+    const playerTop = playerEl.getBoundingClientRect().top;
+    // Get all VideoJS menus in the player
+    const menus = playerEl.querySelectorAll(
+      '.vjs-playback-rate .vjs-menu, .vjs-quality-selector .vjs-menu'
+    );
+    // Calculate tallest popup menu by breifly making it visible
+    const menuHeight = Array.from(menus).reduce((max, el) => {
+      const prev = el.style.display;
+      el.style.display = 'block';
+      const h = el.children?.length > 0 ? el.children[0].offsetHeight : 0;
+      el.style.display = prev;
+      return Math.max(max, h);
+    }, 0);
+    if (menuHeight > 0 && playerTop < menuHeight) {
+      player.addClass('vjs-menu-open-down');
+    } else {
+      player.removeClass('vjs-menu-open-down');
+    }
+  };
+
   return {
     activeId,
     fragmentMarker,
@@ -615,7 +657,8 @@ export const useVideoJSPlayer = ({
     playerRef,
     setActiveId,
     setFragmentMarker,
-    setIsReady
+    setIsReady,
+    updateMenuDirection
   };
 };
 


### PR DESCRIPTION
Related issue: #931 

Changes in this PR:
- Calculate the tallest popup menu and compare it against the clearance on top of the player to check whether there is enough space to display the popup menu without getting clipped by the viewport. Depending on this change the direction of the popup menu as needed
- Use `window.resize` and `window.scroll` events to re-calculate this metrics to change the direction of the popup menus as needed