### PR TITLE
Fix active and inactive tab playback and stalling for player

### DIFF
--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -290,6 +290,28 @@ function VideoJSPlayer({
       setStartVolume(player.volume());
     });
     /**
+     * On iOS, the OS audio session can be revoked by another tab or app, leaving the
+     * player in a stuck state where the playhead moves but no audio is produced, or
+     * the buffer stalls indefinitely. Reload the source to recover.
+     */
+    if (IS_IOS) {
+      let stallTimer = null;
+      player.on('stalled', () => {
+        stallTimer = setTimeout(() => {
+          if (!player.paused() && player.readyState() < 3) {
+            player.load();
+            player.play();
+          }
+        }, 2000);
+      });
+      player.on('playing', () => {
+        if (stallTimer) {
+          clearTimeout(stallTimer);
+          stallTimer = null;
+        }
+      });
+    }
+    /**
      * Setting 'isReady' to true triggers the 'videojs-markers' plugin to add track/playlist/search 
      * markers to the progress-bar.
      * When 'isReady' is set to true in the same event (loadedmetadata) where, player.load() is called for
@@ -869,7 +891,15 @@ function VideoJSPlayer({
        * highlights are correctly synchronized.
        */
       const targetTime = isEndedRef.current
-        ? 0 : Math.max(currentTimeRef.current, player.currentTime());
+        ? 0
+        /**
+         * On iOS, player.currentTime() cannot be trusted here, because iOS may advance the media
+         * clock in the background before the 'visibilitychange' handler has a chance to pause the
+         * player. This makes the player.currentTime() stale with the forward-jumped value. In this
+         * scenario trust the currentTimeRef which is alwayes paused/frozen by 'visibilitychange'
+         * handler.
+         */
+        : (IS_IOS ? currentTimeRef.current : Math.max(currentTimeRef.current, player.currentTime()));
       player.currentTime(targetTime);
 
       // Update control-bar width on player reload

--- a/src/services/ramp-hooks.js
+++ b/src/services/ramp-hooks.js
@@ -359,6 +359,7 @@ export const useVideoJSPlayer = ({
     isReadyRef.current = r;
   };
   const playerRef = useRef(null);
+  const visibilityHandlerRef = useRef(null);
   const setPlayer = (p) => {
     /**
      * When player is set to null, dispose player using Video.js' dispose()
@@ -374,6 +375,9 @@ export const useVideoJSPlayer = ({
       if (playerRef.current) {
         setPlayer(null);
         document.removeEventListener('keydown', playerHotKeys);
+        if (visibilityHandlerRef.current) {
+          document.removeEventListener('visibilitychange', visibilityHandlerRef.current);
+        }
         setIsReady(false);
       }
     };
@@ -583,6 +587,32 @@ export const useVideoJSPlayer = ({
         callPlayerResize();
       });
     });
+
+    /**
+     * On iOS/iPadOS, the browser does not reliably pause media when switching tabs.
+     * Media continues advancing its clock, and media can be interrupted unpredictably 
+     * by iOS's OS-level audio session management.
+     * To prevent the playhead from jumping forward when the user returns to the tab,
+     * the player is paused when the tab becomes inactive and resume it when it becomes
+     * active again.
+     */
+    let wasPlayingBeforeHide = false;
+    const handleVisibilityChange = () => {
+      if (!playerRef.current) return;
+      if (document.hidden) {
+        wasPlayingBeforeHide = !playerRef.current.paused();
+        if (wasPlayingBeforeHide) {
+          playerRef.current.pause();
+          playerDispatch({ isPlaying: false, type: 'setPlayingStatus' });
+        }
+      } else if (wasPlayingBeforeHide) {
+        wasPlayingBeforeHide = false;
+        playerRef.current.play();
+        playerDispatch({ isPlaying: true, type: 'setPlayingStatus' });
+      }
+    };
+    visibilityHandlerRef.current = handleVisibilityChange;
+    document.addEventListener('visibilitychange', handleVisibilityChange);
   };
 
   /**


### PR DESCRIPTION
Related issue: #714

Changes in this PR:
- adds a `visibilitychange` listener in `initializeEventHandlers` (`ramp-hooks.js`) that pauses the player when the tab becomes inactive and resumes it when the tab becomes active again, preventing the playhead from advancing while the tab is inactive on iOS/iPadOS
- on iOS, replaces `Math.max(currentTimeRef.current, player.currentTime())` with `currentTimeRef.current` when setting the seek target in `playerLoadedMetadata` event, because iOS can advance `player.currentTime()` in the background before the `visibilitychange` pause takes effect, causing the player's `seek` event to jump-forward on next load
- adds `stalled` event listener for iOS in to recover from stalling that happens in audio player. When VideoJS `stalled` event fires with `readyState < 3`, call `player.load()` and `player.play()` to un-stuck the player