### PR TITLE
Cdl playlist items

### DIFF
--- a/src/components/MediaPlayer/MediaPlayer.js
+++ b/src/components/MediaPlayer/MediaPlayer.js
@@ -110,7 +110,11 @@ const MediaPlayer = ({
       // where the native iOS player is used by default or on fullscreen-mode.
       // i.e. Both Safari and Chrome on iPhones, only Chrome on iPads.
       html5: {
-        nativeTextTracks: !IS_ANDROID && ((IS_IPAD && !IS_SAFARI) || IS_IPHONE)
+        nativeTextTracks: !IS_ANDROID && ((IS_IPAD && !IS_SAFARI) || IS_IPHONE),
+        vhs: {
+          // Stop VHS from retrying CORS-blocked/403 HLS manfiests indefinitely
+          maxPlaylistRetries: 0,
+        },
       },
       // Make error display modal dismissable
       errorDisplay: {

--- a/src/components/MediaPlayer/VideoJS/VideoJSErrorModal.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSErrorModal.js
@@ -12,34 +12,44 @@ export function showErrorModal(player, vjsErrorModalRef, isMultiCanvased, setCon
   message = 'This item may require special access. Please contact support for assistance.') {
   if (vjsErrorModalRef.current) return;
 
-  const label = 'This item is currently unavailable.';
+  let label = 'This item is currently unavailable.';
+  /* Combine the message into the label for audio-only mode, as there is less space to display
+  to display it in a new paragraph in the audio player container. */
+  if (player.audioOnlyMode_) {
+    label = message;
+  }
+
   const modal = player.createModal(label, { temporary: false, uncloseable: true });
   vjsErrorModalRef.current = modal;
   modal.addClass('vjs-custom-error-modal');
   modal.setAttribute('data-testid', 'error-access-modal');
-
+  modal.el().setAttribute('tabindex', '0');
   modal.el().setAttribute('role', 'alertdialog');
   modal.el().setAttribute('aria-label', label);
   modal.contentEl().setAttribute('aria-live', 'assertive');
   modal.contentEl().setAttribute('aria-atomic', 'true');
 
-  const messageEl = document.createElement('p');
-  messageEl.className = 'vjs-custom-error-modal-message';
-  messageEl.textContent = message;
-  modal.contentEl().appendChild(messageEl);
-  player.removeClass('vjs-disabled');
+  // Only use a separate message element in the modal for Video mode, as there is more space to display it.
+  if (!player.audioOnlyMode_) {
+    const messageEl = document.createElement('p');
+    messageEl.className = 'vjs-custom-error-modal-message';
+    messageEl.textContent = message;
+    modal.contentEl().appendChild(messageEl);
+  }
 
+  // Enable player and unvail player control-bar in blocked state
+  player.removeClass('vjs-disabled');
+  setControlBar(player, true);
+
+  /* Show the previous/next button in the control bar for multi-Canvas players so that,
+  the user can navigate between canvases in error-mode. */
   if (isMultiCanvased) {
-    // Show the control bar with only prev/next buttons focusable
-    setControlBar(player, true);
     player.controlBar.el().querySelectorAll('button, [tabindex]').forEach((focusable) => {
       if (!focusable.closest('.vjs-previous-button')
         && !focusable.closest('.vjs-next-button')) {
         focusable.setAttribute('tabindex', '-1');
       }
     });
-  } else {
-    player.controlBar.hide();
   }
 
   modal.el().focus();

--- a/src/components/MediaPlayer/VideoJS/VideoJSErrorModal.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSErrorModal.js
@@ -1,0 +1,46 @@
+/**
+ * Build and display an error modal to provide feedback to the user when an error
+ * pops up when loading the sources
+ * e.g. loading playlist items behind a CDL wall in playlists
+ * @param {Object} player VideoJS player instance
+ * @param {Object} vjsErrorModalRef React ref to hold the modal instance for cleanup
+ * @param {Boolean} isMultiCanvased whether there are multiple canvases to navigate
+ * @param {Function} setControlBar function to show/hide the player control bar
+ * @param {String} message optional message to display; defaults access related message
+ */
+export function showErrorModal(player, vjsErrorModalRef, isMultiCanvased, setControlBar,
+  message = 'This item may require special access. Please contact support for assistance.') {
+  if (vjsErrorModalRef.current) return;
+
+  const label = 'This item is currently unavailable.';
+  const modal = player.createModal(label, { temporary: false, uncloseable: true });
+  vjsErrorModalRef.current = modal;
+  modal.addClass('vjs-custom-error-modal');
+  modal.setAttribute('data-testid', 'error-access-modal');
+
+  modal.el().setAttribute('role', 'alertdialog');
+  modal.el().setAttribute('aria-label', label);
+  modal.contentEl().setAttribute('aria-live', 'assertive');
+  modal.contentEl().setAttribute('aria-atomic', 'true');
+
+  const messageEl = document.createElement('p');
+  messageEl.className = 'vjs-custom-error-modal-message';
+  messageEl.textContent = message;
+  modal.contentEl().appendChild(messageEl);
+  player.removeClass('vjs-disabled');
+
+  if (isMultiCanvased) {
+    // Show the control bar with only prev/next buttons focusable
+    setControlBar(player, true);
+    player.controlBar.el().querySelectorAll('button, [tabindex]').forEach((focusable) => {
+      if (!focusable.closest('.vjs-previous-button')
+        && !focusable.closest('.vjs-next-button')) {
+        focusable.setAttribute('tabindex', '-1');
+      }
+    });
+  } else {
+    player.controlBar.hide();
+  }
+
+  modal.el().focus();
+}

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -19,6 +19,7 @@ import {
 import { useLocalStorage } from '@Services/local-storage';
 import { usePlaybackPositions } from '@Services/save-playback-positions';
 import { showResumeModal } from './VideoJSResumeModal';
+import { showErrorModal } from './VideoJSErrorModal';
 import { SectionButtonIcon } from '@Services/svg-icons';
 import {
   useMediaPlayer, useSetupPlayer, useShowInaccessibleMessage, useVideoJSPlayer
@@ -107,6 +108,7 @@ function VideoJSPlayer({
   // Ref to store track.change event handler with up-to-date sticky settings
   const trackChangeHandlerRef = useRef(null);
   const resumeModalRef = useRef(null);
+  const vjsErrorModalRef = useRef(null);
 
   const { canvasIndex, canvasIsEmpty, isMultiCanvased, lastCanvasIndex } = useMediaPlayer();
   const { isPlaylist, renderingFiles, srcIndex, switchPlayer }
@@ -410,12 +412,6 @@ function VideoJSPlayer({
           break;
       }
 
-      // Stop retrying if the player is currently in a fallback attempt
-      if (player.isFallingBack) {
-        e.stopPropagation();
-        return;
-      }
-
       // Determine if this is a multi-source Canvas failure or source quality choice failure
       /** ASSUMPTION: A Canvas is either multi-sourced OR multi-choice and not both at the same time */
       const isMultiSource = player.targets?.length > 1;
@@ -444,8 +440,12 @@ function VideoJSPlayer({
 
           e.stopPropagation();
           return;
-        } else {
+        } else if (failureResult.isCanvasInaccessible) {
           // When all sources failed, set the error message
+          showErrorModal(player, vjsErrorModalRef, isMultiCanvased, setControlBar, failureResult.errorMessage);
+          e.stopPropagation();
+          return;
+        } else {
           errorMessage = failureResult.errorMessage;
         }
       } else {
@@ -493,13 +493,17 @@ function VideoJSPlayer({
           // Prevent error modal from showing during fallback
           e.stopPropagation();
           return;
-        } else {
+        } else if (fallbackResult.isCanvasInaccessible) {
           // When all sources fail, show an error message
-          errorMessage = fallbackResult.errorMessage;
+          showErrorModal(player, vjsErrorModalRef, isMultiCanvased, setControlBar, fallbackResult.errorMessage);
+          e.stopPropagation();
+          return;
+        } else {
+          errorMessage = failureResult.errorMessage;
         }
       }
 
-      // Show dismissable error display modal from Video.js
+      // Show dismissable error display modal from Video.js for other generic errors
       var errorDisplay = player.getChild('ErrorDisplay');
       if (errorDisplay) {
         errorDisplay.contentEl().innerText = errorMessage;
@@ -528,6 +532,29 @@ function VideoJSPlayer({
         errorDisplay.el().focus();
       }
       e.stopPropagation();
+    });
+    /**
+     * VideoJS HTTP Streaming (VHS) plugin (included in VideoJS) retries CORS-blocked/403 media sources
+     * indefintely without surfacing an error event in VideoJS. This causes the player to get stuck in a
+     * loading state without providing useful feedback to the user. 
+     * For each source a new VhsHandler is created, using this in combination with the VideoJS option
+     * 'vhs.maxPlaylistRetries=0' Ramp can display an error for CORS errors in playback.
+     */
+    const handleRetryPlaylist = () => {
+      const playlists = player.tech(true)?.vhs?.playlistController_
+        ?.mainPlaylistLoader_?.main?.playlists || [];
+      // With maxPlaylistRetries=0, any HLS playlist with is permanently excluded
+      const hasExhausted = playlists.some(p => p.playlistErrors_ > 0);
+      if (hasExhausted) {
+        showErrorModal(player, vjsErrorModalRef, isMultiCanvased, setControlBar);
+      }
+    };
+    player.on('loadstart', () => {
+      const tech = player.tech(true);
+      if (!tech) return;
+      // Remove any previously registered listeners befor adding a new one
+      tech.off('retryplaylist', handleRetryPlaylist);
+      tech.on('retryplaylist', handleRetryPlaylist);
     });
     playerLoadedMetadata(player);
     /**
@@ -570,7 +597,7 @@ function VideoJSPlayer({
 
       console.error('All sources in the Canvas have failed to load.');
       return {
-        shouldFallback: false,
+        shouldFallback: false, isCanvasInaccessible: true,
         errorMessage: 'None of the available sources could be loaded. Please try again later.'
       };
     }
@@ -596,7 +623,7 @@ function VideoJSPlayer({
 
     // Check if all sources have failed
     if (failedSourceIndices.length >= targets.length) {
-      return { shouldAdvance: false, errorMessage: allSegmentFailMsg };
+      return { shouldAdvance: false, errorMessage: allSegmentFailMsg, isCanvasInaccessible: true };
     }
 
     // Find next available source, wrap to the first segment when final segment is reached
@@ -607,7 +634,7 @@ function VideoJSPlayer({
       attempts++;
     }
     if (attempts >= targets.length) {
-      return { shouldAdvance: false, errorMessage: allSegmentFailMsg };
+      return { shouldAdvance: false, errorMessage: allSegmentFailMsg, isCanvasInaccessible: true };
     }
 
     return {
@@ -691,9 +718,13 @@ function VideoJSPlayer({
    * @param {Object} player
    */
   const updatePlayer = (player) => {
-    // Reset failed sources when Canvas changes
-    player.failedSources = [];
-    player.isFallingBack = false;
+    /* Reset failed source tracking only on Canvas change, not on source 
+    change within the same Canvas in a multi-source Canvas */
+    if (player.canvasIndex !== cIndexRef.current) {
+      player.failedSources = [];
+      player.failedSourceIndices = [];
+      player.isFallingBack = false;
+    }
 
     // Clear error state when changing Canvas
     player.error(null);
@@ -710,11 +741,16 @@ function VideoJSPlayer({
       });
     }
 
-    /* Remove any resume playback modal in the DOM. Call close() to restore
+    /* Remove any VideoJS modals instances in the DOM. Call close() to restore
     player controls before removing the modal element from the DOM. */
     if (resumeModalRef.current) {
       resumeModalRef.current.close();
       resumeModalRef.current.el()?.remove();
+    }
+    if (vjsErrorModalRef.current) {
+      vjsErrorModalRef.current.close();
+      vjsErrorModalRef.current.el()?.remove();
+      vjsErrorModalRef.current = null;
     }
 
     player.duration(canvasDuration);

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -267,7 +267,10 @@ function VideoJSPlayer({
       handleTimeUpdate();
     });
     player.on('resize', () => {
-      setControlBar(player);
+      /* Keep the control-bar visible with an active VideoJSErrorModal for multi-Canvas
+      manifests when player is resized. */
+      const errorModalActive = !!vjsErrorModalRef.current;
+      setControlBar(player, errorModalActive && isMultiCanvased);
     });
     player.on('ended', () => {
       /**
@@ -556,16 +559,15 @@ function VideoJSPlayer({
       tech.off('retryplaylist', handleRetryPlaylist);
       tech.on('retryplaylist', handleRetryPlaylist);
     });
-    playerLoadedMetadata(player);
     /**
-     * Show resume modal only for the initial page load, not on Canvas switches.
-     * This first loaded Canvas can be either the first Canvas in the Manifest or the
-     * Canvas corresponding to the 'startCanavasId' prop if it is provided.
-     * With the use of 'player.one' this is scoped only to the first load.
+     * Show resume modal on initial setup of the player. This is invoked once for
+     * a given Manifest, as the playback positions in 'localStorage' are indexed by
+     * the Manifest URL, So the resume modal will not be show again on Canvas switches.
+     * And this allows, the player to show resume modal even if the first Canvas is not 
+     * playable, but there is a saved position for the Manifest on a different Canvas.
      */
-    player.one('loadedmetadata', () => {
-      resumePlaybackModal(player);
-    });
+    resumePlaybackModal();
+    playerLoadedMetadata(player);
   };
 
   /**
@@ -598,7 +600,7 @@ function VideoJSPlayer({
       console.error('All sources in the Canvas have failed to load.');
       return {
         shouldFallback: false, isCanvasInaccessible: true,
-        errorMessage: 'None of the available sources could be loaded. Please try again later.'
+        errorMessage: 'None of the available sources could be loaded. Please try again later or contact support for help.'
       };
     }
     // Select the next viable available source
@@ -614,7 +616,8 @@ function VideoJSPlayer({
    */
   const handleMultiSourceFailure = (player) => {
     const { srcIndex, targets, failedSourceIndices } = player;
-    const allSegmentFailMsg = 'All video segments in this item are currently unavailable.';
+    const allSegmentFailMsg = `All ${player.audioOnlyMode_ ? 'audio' : 'video'} segments in this item are currently unavailable.
+    Please try again later or contact support for help.`;
 
     // Memorize the current failed source index
     if (!failedSourceIndices.includes(srcIndex)) {
@@ -1500,12 +1503,13 @@ function VideoJSPlayer({
   };
 
   /**
-   * Show the resume modal if a saved playback position exists for the current Manifest.
-   * For multi-canvas manifests, load the saved Canvas first, then show the resume modal
-   * after the Canvas switch settles.
+   * Check for a saved playback position in the current Manifest.
+   * Store a pending resume so 'loadedmetadata' event can show the modal only after media
+   * loads successfully. This avoids stacking the resume modal on top of an error modal if
+   * the media fails to load for any reason.
    * @param {Object} player Video.js player instance
    */
-  const resumePlaybackModal = (player) => {
+  const resumePlaybackModal = () => {
     /* Skip the resume playback modal when,
     - there is a custom start indicated via 'startCanvasTime' prop
     - the Manifest is a playlist
@@ -1535,14 +1539,14 @@ function VideoJSPlayer({
         clearPosition(manifestURL);
         return;
       }
-      // Store pending resume info so 'playerLoadedMetadata' can show the modal after the switch
+      // Store pending resume info so 'loadedmetadata' can show the modal after the switch
       pendingResumeRef.current = { time: savedTime, manifestURL };
       manifestDispatch({ type: 'switchCanvas', canvasIndex: savedCanvasIndex });
       return;
     }
 
-    // If the loaded Canvas is the same as the saved one, show the modal immediately
-    showResumeModal(player, resumeModalRef, savedTime, manifestURL, clearPosition);
+    // Store same-Canvas resume for 'loadedmetadata' to show after confirming media loaded successfully
+    pendingResumeRef.current = { time: savedTime, manifestURL, isSameCanvas: true };
   };
 
   /**

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -19,7 +19,7 @@ import {
 import { useLocalStorage } from '@Services/local-storage';
 import { usePlaybackPositions } from '@Services/save-playback-positions';
 import { showResumeModal } from './VideoJSResumeModal';
-import { showErrorModal } from './VideoJSErrorModal';
+import { showErrorModal } from './components/js/VideoJSErrorModal';
 import { SectionButtonIcon } from '@Services/svg-icons';
 import {
   useMediaPlayer, useSetupPlayer, useShowInaccessibleMessage, useVideoJSPlayer
@@ -744,17 +744,8 @@ function VideoJSPlayer({
       });
     }
 
-    /* Remove any VideoJS modals instances in the DOM. Call close() to restore
-    player controls before removing the modal element from the DOM. */
-    if (resumeModalRef.current) {
-      resumeModalRef.current.close();
-      resumeModalRef.current.el()?.remove();
-    }
-    if (vjsErrorModalRef.current) {
-      vjsErrorModalRef.current.close();
-      vjsErrorModalRef.current.el()?.remove();
-      vjsErrorModalRef.current = null;
-    }
+    // Remove any existing VideoJS modals instances in the DOM
+    cleanupExistingModals();
 
     player.duration(canvasDuration);
     player.src(options.sources);
@@ -1019,7 +1010,7 @@ function VideoJSPlayer({
         player.altStart = mediaRange.start;
       } else {
         player.playableDuration = canvasDuration;
-        player.altStart = targets[srcIndex].altStart;
+        player.altStart = targets[srcIndex]?.altStart ?? 0;
       }
 
       player.canvasIndex = cIndexRef.current;
@@ -1040,9 +1031,10 @@ function VideoJSPlayer({
 
       // After a Canvas switch for resume playback, show the modal on the new Canvas
       if (pendingResumeRef.current) {
-        const { time, manifestURL } = pendingResumeRef.current;
+        const { time, manifestURL, isSameCanvas } = pendingResumeRef.current;
         pendingResumeRef.current = null;
-        showResumeModal(player, resumeModalRef, time, manifestURL, clearPosition, true);
+        cleanupExistingModals();
+        showResumeModal(player, resumeModalRef, time, manifestURL, clearPosition, !isSameCanvas);
       }
     });
   };
@@ -1059,6 +1051,22 @@ function VideoJSPlayer({
   const activeIdRef = useRef();
   activeIdRef.current = useMemo(() => { return activeId; }, [activeId]);
 
+  /**
+   * Remove any VideoJS modals instances in the DOM. Call close() to restore
+   * player controls before removing the modal element from the DOM.
+   */
+  const cleanupExistingModals = () => {
+    if (resumeModalRef.current) {
+      resumeModalRef.current.close();
+      resumeModalRef.current.el()?.remove();
+      resumeModalRef.current = null;
+    }
+    if (vjsErrorModalRef.current) {
+      vjsErrorModalRef.current.close();
+      vjsErrorModalRef.current.el()?.remove();
+      vjsErrorModalRef.current = null;
+    }
+  };
   /**
    * Setup captions for the player based on context
    * @param {Object} player Video.js player instance

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.test.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.test.js
@@ -5,6 +5,7 @@ import MediaPlayer from '@Components/MediaPlayer/MediaPlayer';
 import { withManifestAndPlayerProvider, manifestState } from '@Services/testing-helpers';
 import videoManifest from '@TestData/lunchroom-manners';
 import playlistManifest from '@TestData/playlist';
+import singleCanvasManifest from '@TestData/single-canvas';
 
 describe('VideoJSPlayer component', () => {
   const MANIFEST_URL = 'https://example.com/manifest/lunchroom_manners';
@@ -56,7 +57,12 @@ describe('VideoJSPlayer component', () => {
       expect(screen.getAllByTestId('videojs-video-element').length).toBeGreaterThan(0);
     });
     const player = screen.getAllByTestId('videojs-video-element')[0].player;
+    // Wait for player 'ready' to fire, i.e. player.canvasIndex is set
+    await waitFor(() => {
+      expect(player.canvasIndex).toBeDefined();
+    });
     act(() => { player.trigger('loadedmetadata'); });
+    return player;
   };
 
   describe('feature: resume playback modal', () => {
@@ -304,6 +310,99 @@ describe('VideoJSPlayer component', () => {
             expect(screen.getByText(/Resume playback from 00:45?/i)).toBeInTheDocument();
           });
         });
+      });
+    });
+  });
+
+  describe('feature: error modal', () => {
+    let player;
+
+    describe('when all sources of a single-source Canvas fail', () => {
+      beforeEach(async () => {
+        await renderPlayer({ manifest: singleCanvasManifest, canvasIndex: 0 });
+        player = await triggerLoadedMetadata();
+        // Mark the source as failed to trigger error modal
+        player.failedSources = player.currentSources().map((s) => s.src);
+        // Fire the 'error' event by setting player.error(err)
+        act(() => { player.error({ code: 2, message: 'network error' }); });
+      });
+
+      test('renders the error display modal', async () => {
+        await waitFor(() => {
+          expect(screen.queryByTestId('error-display-modal')).toBeInTheDocument();
+        });
+      });
+
+      test('renders the error display modal with the unavailable sources message', async () => {
+        await waitFor(() => {
+          expect(screen.queryByTestId('error-display-modal')).toBeInTheDocument();
+        });
+        expect(screen.getByText(
+          'None of the available sources could be loaded. Please try again later or contact support for help.'
+        )).toBeInTheDocument();
+      });
+    });
+
+    describe('when all multi-source segments of a Canvas fail', () => {
+      beforeEach(async () => {
+        await renderPlayer({ manifest: singleCanvasManifest, canvasIndex: 0 });
+        player = await triggerLoadedMetadata();
+        // Set player.targets to simulate a multi-source Canvas
+        player.targets = [
+          { start: 0, end: 330, altStart: 0, duration: 330 },
+          { start: 330, end: 660, altStart: 330, duration: 330 },
+        ];
+        player.srcIndex = 0;
+        // Mark both segment indices as already failed to trigger error modal
+        player.failedSourceIndices = [0, 1];
+        act(() => { player.error({ code: 2, message: 'network error' }); });
+      });
+
+      test('renders the error display modal', async () => {
+        await waitFor(() => {
+          expect(screen.queryByTestId('error-display-modal')).toBeInTheDocument();
+        });
+      });
+
+      test('renders the error display modal with the all segments failed message', async () => {
+        await waitFor(() => {
+          expect(screen.queryByTestId('error-display-modal')).toBeInTheDocument();
+        });
+        expect(
+          screen.getByText(/All video segments in this item are currently unavailable/i)
+        ).toBeInTheDocument();
+      });
+    });
+
+    describe('when a CORS error exhausts HLS playlist retries', () => {
+      test('renders the error display modal with the default message', async () => {
+        await renderPlayer({ manifest: singleCanvasManifest, canvasIndex: 0 });
+        const player = await triggerLoadedMetadata();
+        const mockVHSTech = {
+          vhs: {
+            playlistController_: {
+              mainPlaylistLoader_: {
+                main: { playlists: [{ playlistErrors_: 1 }] },
+              },
+            },
+          },
+          on: jest.fn(),
+          off: jest.fn(),
+        };
+
+        // Simulate HLS retry errors in vhs' playlist controller
+        jest.spyOn(player, 'tech').mockReturnValue(mockVHSTech);
+        // Trigger 'loadstart' to set up the 'retryplaylist' event listener
+        act(() => { player.trigger('loadstart'); });
+        const retryCall = mockVHSTech.on.mock.calls.find(([evt]) => evt === 'retryplaylist');
+        act(() => { retryCall[1](); });
+
+        await waitFor(() => {
+          expect(screen.queryByTestId('error-display-modal')).toBeInTheDocument();
+        });
+        expect(screen.getByText(
+          'This item may require special access. Please contact support for assistance.'
+        )).toBeInTheDocument();
       });
     });
   });

--- a/src/components/MediaPlayer/VideoJS/components/js/VideoJSErrorModal.js
+++ b/src/components/MediaPlayer/VideoJS/components/js/VideoJSErrorModal.js
@@ -12,24 +12,27 @@ export function showErrorModal(player, vjsErrorModalRef, isMultiCanvased, setCon
   message = 'This item may require special access. Please contact support for assistance.') {
   if (vjsErrorModalRef.current) return;
 
-  let label = 'This item is currently unavailable.';
-  /* Combine the message into the label for audio-only mode, as there is less space to display
-  to display it in a new paragraph in the audio player container. */
+  // Error modal title for video mode
+  let errorLabel = 'This item is currently unavailable.';
+
+  /* Override the modal title with the message for audio-only mode, as there is less
+  space to display it in a new paragraph in the audio player container */
   if (player.audioOnlyMode_) {
-    label = message;
+    errorLabel = message;
   }
 
-  const modal = player.createModal(label, { temporary: false, uncloseable: true });
+  const modal = player.createModal(errorLabel, { temporary: false, uncloseable: true });
   vjsErrorModalRef.current = modal;
   modal.addClass('vjs-custom-error-modal');
-  modal.setAttribute('data-testid', 'error-access-modal');
+  modal.setAttribute('data-testid', 'error-display-modal');
   modal.el().setAttribute('tabindex', '0');
+  // Make the modal accessible by setting appropriate ARIA attributes
   modal.el().setAttribute('role', 'alertdialog');
-  modal.el().setAttribute('aria-label', label);
+  modal.el().setAttribute('aria-label', errorLabel);
   modal.contentEl().setAttribute('aria-live', 'assertive');
   modal.contentEl().setAttribute('aria-atomic', 'true');
 
-  // Only use a separate message element in the modal for Video mode, as there is more space to display it.
+  // Set the message in a separate elemet for video mode as there is more space to display it
   if (!player.audioOnlyMode_) {
     const messageEl = document.createElement('p');
     messageEl.className = 'vjs-custom-error-modal-message';

--- a/src/components/MediaPlayer/VideoJS/components/js/VideoJSTrackScrubber.js
+++ b/src/components/MediaPlayer/VideoJS/components/js/VideoJSTrackScrubber.js
@@ -374,7 +374,7 @@ class VideoJSTrackScrubber extends Button {
     if (trackScrubberRef.current && trackScrubberRef.current.children) {
       // Attach mouse pointer events to track scrubber progress bar
       let [_, progressBar, __] = trackScrubberRef.current.children;
-      progressBar.setAttribute('aria-valuenow', trackoffset);
+      progressBar.setAttribute('aria-valuenow', trackoffset || 0);
     }
   };
 

--- a/src/components/MediaPlayer/VideoJS/videojs-theme.scss
+++ b/src/components/MediaPlayer/VideoJS/videojs-theme.scss
@@ -339,3 +339,27 @@ and outside of the player (e.g. when quality selector opens downwards of the pla
   padding: 0.3em 0.7em;
   font-size: 1em;
 }
+
+/* Custom eror modal for unavailable items */
+.vjs-custom-error-modal .vjs-modal-dialog-content {
+  color: white;
+  font-size: 1.5em;
+  font-weight: bold;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.vjs-custom-error-modal-message {
+  font-size: 1em;
+  font-weight: 400;
+  max-width: 28em;
+}
+
+.vjs-audio-only-mode .vjs-custom-error-modal .vjs-modal-dialog-content {
+  padding: 0.4em 1em;
+  font-size: 1.2em;
+  gap: 0.3em;
+}

--- a/src/components/MediaPlayer/VideoJS/videojs-theme.scss
+++ b/src/components/MediaPlayer/VideoJS/videojs-theme.scss
@@ -340,7 +340,12 @@ and outside of the player (e.g. when quality selector opens downwards of the pla
   font-size: 1em;
 }
 
-/* Custom eror modal for unavailable items */
+/* Custom error modal for unavailable items */
+.vjs-custom-error-modal.vjs-modal-dialog {
+  background: rgba(0, 0, 0, 0.9);
+  border-radius: 4px 4px 0 0;
+}
+
 .vjs-custom-error-modal .vjs-modal-dialog-content {
   color: white;
   font-size: 1.5em;
@@ -358,8 +363,14 @@ and outside of the player (e.g. when quality selector opens downwards of the pla
   max-width: 28em;
 }
 
+// Compact layout for audio-only mode (shorter player height)
 .vjs-audio-only-mode .vjs-custom-error-modal .vjs-modal-dialog-content {
   padding: 0.4em 1em;
   font-size: 1.2em;
+  font-weight: 400;
   gap: 0.3em;
+  line-height: 1.5em;
+  z-index: 10001;
+  margin: 0 25%;
+  width: 50%;
 }


### PR DESCRIPTION
Related issue: https://github.com/avalonmediasystem/avalon/issues/5001

Changes in this PR:
- add `VideoJSErrorModal.js` with a `showErrorModal` function to display a custom uncloseable error modal when media is inaccessible (e.g. CDL-gated playlist items)
- use VideoJS's config `vhs.maxPlaylistRetries: 0` to prevent VHS from retrying CORS-blocked/403 HLS manifests indefinitely. Then using `retryplaylist` event from VHS to detect the exhausted HLS playlist retries and display an error modal to the user. In audio-only mode the error message is compressed into a single line to avoid overflow. For multi-canvased manifests, previous/next buttons are left active while the other controls are blocked so that the user can navigate between sections/playlist items.
- defer the resume modal to `loadedmetadata` event both same-Canvas and cross-Canvas playback resumes so it does not stack on top of an existing error modal when media fails to load

Multi-source Canvas trying each segment until it reaches the end and displays the error message;

https://github.com/user-attachments/assets/24384774-e135-426e-a24c-bb7703748c47

Multi-source unavailable message display in an audio player;
<img width="888" height="73" alt="audio-multi-source-unavailable-message" src="https://github.com/user-attachments/assets/722742de-9869-4bc4-9b1a-c9cd95234ea2" />

Multi-canvas source unavailable message display in an audio player with previous/next buttons enabled;
<img width="888" height="73" alt="audio-player-unavailable-message" src="https://github.com/user-attachments/assets/3b66f6e7-f8fb-45c6-9f1e-13ce08630149" />



