### PR TITLE
Scope playback pause on inactive tab to iOS

### DIFF
--- a/src/services/browser.js
+++ b/src/services/browser.js
@@ -273,13 +273,14 @@ if (!IS_CHROMIUM) {
 
     IS_WINDOWS = (/Windows/i).test(USER_AGENT);
 
+    // iPadOS 13+ changed the user agent to Mac, so this needs to check for touch support to detect if it's an iPad
+    IS_IPAD = /iPad/.test(navigator.userAgent) || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+
     IS_IPHONE = (/iPhone/i).test(USER_AGENT) && !IS_IPAD;
 
     IS_IOS = IS_IPHONE || IS_IPAD || IS_IPOD;
 
     IS_TOUCH_ONLY = navigator.maxTouchPoints && navigator.maxTouchPoints > 2 && !window.matchMedia("(pointer: fine").matches;
-
-    IS_IPAD = IS_TOUCH_ONLY && !IS_ANDROID && !IS_IPHONE;
 
     IS_MOBILE = IS_ANDROID || IS_IOS || IS_IPHONE || IS_TOUCH_ONLY || (/Mobi/i).test(USER_AGENT);
 }

--- a/src/services/ramp-hooks.js
+++ b/src/services/ramp-hooks.js
@@ -20,6 +20,7 @@ import {
   truncateText,
   autoScroll
 } from '@Services/utility-helpers';
+import { IS_IPAD } from '@Services/browser';
 import { getMediaInfo } from '@Services/iiif-parser';
 import videojs from 'video.js';
 import throttle from 'lodash/throttle';
@@ -595,24 +596,28 @@ export const useVideoJSPlayer = ({
      * To prevent the playhead from jumping forward when the user returns to the tab,
      * the player is paused when the tab becomes inactive and resume it when it becomes
      * active again.
+     * This is only applied to iPads, as iPhones use the native player for playback thus
+     * not affected by this issue.
      */
-    let wasPlayingBeforeHide = false;
-    const handleVisibilityChange = () => {
-      if (!playerRef.current) return;
-      if (document.hidden) {
-        wasPlayingBeforeHide = !playerRef.current.paused();
-        if (wasPlayingBeforeHide) {
-          playerRef.current.pause();
-          playerDispatch({ isPlaying: false, type: 'setPlayingStatus' });
+    if (IS_IPAD) {
+      let wasPlayingBeforeHide = false;
+      const handleVisibilityChange = () => {
+        if (!playerRef.current) return;
+        if (document.hidden) {
+          wasPlayingBeforeHide = !playerRef.current.paused();
+          if (wasPlayingBeforeHide) {
+            playerRef.current.pause();
+            playerDispatch({ isPlaying: false, type: 'setPlayingStatus' });
+          }
+        } else if (wasPlayingBeforeHide) {
+          wasPlayingBeforeHide = false;
+          playerRef.current.play();
+          playerDispatch({ isPlaying: true, type: 'setPlayingStatus' });
         }
-      } else if (wasPlayingBeforeHide) {
-        wasPlayingBeforeHide = false;
-        playerRef.current.play();
-        playerDispatch({ isPlaying: true, type: 'setPlayingStatus' });
-      }
-    };
-    visibilityHandlerRef.current = handleVisibilityChange;
-    document.addEventListener('visibilitychange', handleVisibilityChange);
+      };
+      visibilityHandlerRef.current = handleVisibilityChange;
+      document.addEventListener('visibilitychange', handleVisibilityChange);
+    }
   };
 
   /**


### PR DESCRIPTION
This PR fixes a regression introduced in #939 where the `visibilitychange` handler was registered unconditionally, causing the player to pause and resume on tab switch for all browsers and platforms. This`visibilitychange` handler should only be applied in iPads.