### PR TITLE
Fix captions overlap with transcript cue clicks

### DIFF
--- a/src/components/Transcript/Transcript.js
+++ b/src/components/Transcript/Transcript.js
@@ -489,7 +489,11 @@ const Transcript = ({ playerID, manifestUrl, showMetadata = false, showNotes = f
 
   const seekPlayer = useCallback((time) => {
     setCurrentTime(time); // so selecting an item works in tests
-    syncPlayback(time);
+    /* Add 1ms offset so that, the player time lands strictly inside the current cue.
+    When 2 adjacent cues share a boundary, i.e. end time of cue 1 === start time of cue 2,
+    VideoJS treats both as active at the boundary time, which shows both captions
+    over the other. */
+    syncPlayback(Math.round((time + 0.001) * 1000) / 1000);
   }, []);
 
   if (!isLoading) {

--- a/src/components/Transcript/Transcript.test.js
+++ b/src/components/Transcript/Transcript.test.js
@@ -124,7 +124,7 @@ describe('Transcript component', () => {
         // Click on the cue's timestamp
         fireEvent.click(transcriptItem.children[0]);
         expect(transcriptItem.classList.contains('active')).toBeTruthy();
-        expect(syncPlaybackMock).toHaveBeenCalledWith(1.2);
+        expect(syncPlaybackMock).toHaveBeenCalledWith(1.201);
       });
 
       test('does nothing when clicking on the cue\'s text', () => {
@@ -190,7 +190,7 @@ describe('Transcript component', () => {
           // Click on the cue's timestamp
           fireEvent.click(transcriptItem.children[0]);
           expect(transcriptItem.classList.contains('active')).toBeTruthy();
-          expect(syncPlaybackMock).toHaveBeenCalledWith(22.2);
+          expect(syncPlaybackMock).toHaveBeenCalledWith(22.201);
         });
 
         test('does nothing when clicking on the cue\'s text', () => {


### PR DESCRIPTION
Related issue: #946

When there are adjacent transcript cues that share an end time and a start time (a common boundary), both cues get highlighted and and displayed in the VideoJS player when seeking. Adding a 1ms offset to the playback time when synchronizing the transcript component with the VideoJS player fixes this.

The screen recording shows the transcript cue highlighting and VideoJS caption display updates when player is paused for the following 3 cues in its transcript,
```
37
00:01:20.000 --> 00:01:24.000
LANDSCAPE,DERSTAND

38
00:01:24.000 --> 00:01:28.000
THE HOUSES HE DESIGNED.
WE ARE ALSO USING IT AS THE

39
00:01:28.000 --> 00:01:31.000
LIVES OF ENSLAVED PEOPLE.

```

https://github.com/user-attachments/assets/1286ba30-08bd-4fc1-8be5-ffda59bea651

