### PR TITLE
Restore the playback state in the source fallback logic

### DIFF
--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -168,6 +168,9 @@ function VideoJSPlayer({
   // Flag to track whether srcIndex has changed since last load
   const srcIndexChangedRef = useRef();
 
+  // Flag to track whether the player was playing during a fallback for source selection
+  const wasPlayingRef = useRef();
+
   /**
    * Setup player with player-related information parsed from the IIIF
    * Manifest Canvas. This gets called on both initial page load and each
@@ -331,6 +334,11 @@ function VideoJSPlayer({
       handleTimeUpdate();
     });
     player.on('qualityRequested', (e, quality) => {
+      /* Remember the player state before source selection changes, which is used in the error
+      handler to determine whether to resume playback after fallback efforts in source selection. */
+      if (wasPlayingRef.current == undefined) {
+        wasPlayingRef.current = !player.paused() ? true : false;
+      }
       // Prevent selection of known failed sources going through
       if (player.failedSources && player.failedSources.includes(quality.src)) {
         console.warn(`Cannot select ${quality.label}, this source previously failed to load`);
@@ -461,26 +469,29 @@ function VideoJSPlayer({
             try {
               updateQualityMenuItems(player, player.failedSources);
 
-              // Get current player state before switching
-              const allSources = player.currentSources();
-              const currentTime = player.currentTime();
-              const isPaused = player.paused();
-
               /**
                * Mark all sources as not selected and update the player's src information.
                * Then trigger a 'qualityRequested' event manually to let quality selector
                * plugin to update the source in the player. This helps persist the source
                * selection.
                */
+              const allSources = player.currentSources();
               allSources.forEach(s => { s.selected = false; });
               player.src(allSources);
               player.trigger('qualityRequested', fallbackResult.nextSource);
 
-              // Once the player is ready, restore playback state and flags
-              player.ready(function () {
-                if (currentTime > 0) player.currentTime(currentTime);
-                if (!isPaused) player.play();
+              // Once the player is loaded, reset the fallback flag
+              player.one('loadedmetadata', function () {
+                if (currentTimeRef.current > 0) player.currentTime(currentTimeRef.current);
                 player.isFallingBack = false;
+              });
+
+              /* Once the quality-selector plugin resets the player state to zero it emits a 'seeked'
+              event. Listen to this 'seeked' event once and restore player status from saved refs
+              overriding the default reset by the quality-selector plugin */
+              player.one('seeked', function () {
+                if (currentTimeRef.current > 0) player.currentTime(currentTimeRef.current);
+                if (wasPlayingRef.current) player.play();
               });
 
               // Reset fallback flag on error when fallback attempt also fails

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -492,6 +492,7 @@ function VideoJSPlayer({
               player.one('seeked', function () {
                 if (currentTimeRef.current > 0) player.currentTime(currentTimeRef.current);
                 if (wasPlayingRef.current) player.play();
+                wasPlayingRef.current = undefined;
               });
 
               // Reset fallback flag on error when fallback attempt also fails

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.test.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.test.js
@@ -406,4 +406,78 @@ describe('VideoJSPlayer component', () => {
       });
     });
   });
+
+  describe('feature: quality selection fallback', () => {
+    const HIGH_SRC = 'https://example.com/manifest/high/lunchroom_manners_1024kb.mp4';
+    const MED_SRC = 'https://example.com/manifest/medium/lunchroom_manners_512kb.mp4';
+
+    // Helper function to set up the player for testing quality selection fallback logic
+    const setupPlayerInFallbackState = async ({ isPlaying = false } = {}) => {
+      await renderPlayer({ manifest: videoManifest, canvasIndex: 0 });
+      await waitFor(() => {
+        expect(screen.getAllByTestId('videojs-video-element').length).toBeGreaterThan(0);
+      });
+      const player = screen.getAllByTestId('videojs-video-element')[0].player;
+      act(() => { player.trigger('loadedmetadata'); });
+
+      // Setup player state for fallback logic
+      player.failedSources = [];
+      player.isFallingBack = false;
+      player.currentSources = jest.fn(() => [
+        { src: HIGH_SRC, type: 'video/mp4', label: 'High', selected: true },
+        { src: MED_SRC, type: 'video/mp4', label: 'Medium', selected: false },
+      ]);
+      /* Stub,
+      - player.error() - set default getter to return a code 4
+      - player.currentTime() - default getter returns 0
+      - player.paused() - default getter returns based on isPlaying arg
+      - player.play() - stub to track play() calls without breaking    
+      */
+      player.error = jest.fn((code) => (code !== undefined ? undefined : { code: 4 }));
+      player.currentTime = jest.fn((t) => (t !== undefined ? undefined : 0));
+      player.play = jest.fn(() => Promise.resolve());
+      player.paused = jest.fn(() => !isPlaying);
+
+      // Trigger 'qualityRequested' to set wasPlayingRef.current initially
+      act(() => {
+        player.trigger('qualityRequested', { src: HIGH_SRC, label: 'High' });
+      });
+
+      return player;
+    };
+
+    test('resumes playback in seeked event when player was playing before fallback', async () => {
+      const player = await setupPlayerInFallbackState({ isPlaying: true });
+
+      act(() => { player.trigger('error'); });
+      await act(async () => new Promise((r) => setTimeout(r, 150)));
+      // Simulate quality-selector plugin 'seeked' event
+      act(() => { player.trigger('seeked'); });
+
+      expect(player.play).toHaveBeenCalled();
+    });
+
+    test('doesn\'t resume playback in seeked event when player was paused before fallback', async () => {
+      const player = await setupPlayerInFallbackState({ isPlaying: false });
+
+      act(() => { player.trigger('error'); });
+      await act(async () => new Promise((r) => setTimeout(r, 150)));
+      // Simulate quality-selector plugin 'seeked' event
+      act(() => { player.trigger('seeked'); });
+
+      expect(player.play).not.toHaveBeenCalled();
+    });
+
+    test('sets isFallingBack to false after the fallback loadedmetadata fires', async () => {
+      const player = await setupPlayerInFallbackState();
+
+      act(() => { player.trigger('error'); });
+      await act(async () => new Promise((r) => setTimeout(r, 150)));
+
+      expect(player.isFallingBack).toBe(true);
+      act(() => { player.trigger('loadedmetadata'); });
+      expect(player.isFallingBack).toBe(false);
+    });
+  });
+
 });


### PR DESCRIPTION
Related issue: #953

Changes in this PR:
- memoize the playback state via `wasPlayingRef` in `qualityRequested` event before the source changes and use it to restore playback state after the fallback logic resolves the source selection to a working source
- use `player.one('loadedmetata', ..)` event instead of `player.ready()` to reset the `isFallingBack`, because this makes sure a working source is loaded into the player unlike `player.ready` which fire synchronously if the player is already ready
- use `player.one('seeked', ...)` event emitted by the quality-selector plugin after loading a valid source in the fallback logic to restore `currentTime` and resume playback with the memoized values. This ensures, the quality-selector's `seeked` event doesn't override the state reset on the Ramp side.
- add unit tests for the playback state restoring in the source fallback logic