### PR TITLE
Iiif auth

### DIFF
--- a/src/components/MediaPlayer/MediaPlayer.js
+++ b/src/components/MediaPlayer/MediaPlayer.js
@@ -39,7 +39,7 @@ const MediaPlayer = ({
   const playerState = usePlayerState();
   const { showBoundary } = useErrorBoundary();
 
-  const { srcIndex, playlist, structures } = manifestState;
+  const { srcIndex, playlist, structures, auth, allCanvases } = manifestState;
   const { isPlaylist } = playlist;
   const { hasStructure } = structures;
   const { currentTime } = playerState;
@@ -50,6 +50,7 @@ const MediaPlayer = ({
   const [languageLoaded, setLanguageLoaded] = useState(false);
 
   const { canvasIsEmpty, canvasIndex, isMultiCanvased, lastCanvasIndex } = useMediaPlayer();
+  const authService = allCanvases[canvasIndex]?.authService ?? null;
 
   const {
     isMultiSourced,
@@ -196,16 +197,17 @@ const MediaPlayer = ({
             { trackScrubberRef, timeToolRef, isPlaylist },
           videoJSADButton: (audioDescTracks.length > 0) && { audioDescTracks }
         },
-        sources: isMultiSourced
-          ? [sources[srcIndex]]
-          : sources,
+        // Only pass along the sources with access in VideoJS options
+        sources: (authService && auth?.status !== 'authorized')
+          ? []
+          : (isMultiSourced ? [sources[srcIndex]] : sources),
         errorDisplay: {
           // Show the close button for the error modal, if more than one source OR multiple 
           // canvases are available
           uncloseable: (sources?.length > 1 || isMultiCanvased) ? false : true,
         },
       } : { ...defaultOptions, sources: [] };
-  }, [isVideo, playerConfig, srcIndex]);
+  }, [isVideo, playerConfig, srcIndex, authService, auth]);
 
   if (((ready && videoJSOptions != undefined && languageLoaded) || canvasIsEmpty)) {
     return (

--- a/src/components/MediaPlayer/VideoJS/AuthOverlay.js
+++ b/src/components/MediaPlayer/VideoJS/AuthOverlay.js
@@ -1,0 +1,219 @@
+import React, { useEffect, useRef, useState } from 'react';
+import PropTypes from 'prop-types';
+import { getLabelValue, sanitizeHTML } from '@Services/utility-helpers';
+import { probeResource, requestTokenViaIframe } from '@Services/auth-service';
+import './VideoJSPlayer.scss';
+
+/**
+ * Display authentication dialog and handle login/logout interactions for IIIF resources
+ * protected by IIIF Auth 2.0 spec. 
+ * It is rendered over the VideoJS player when a Canvas has an AuthProbeService2 defined.
+ * The flow is as follows;
+ * 1. On page load: probe the resource without a token to determine if login is required
+ * 2. Login: performs the authnentication flow based on the access service profile and gets a token
+ * 3. On token received: re-probe with token to confirm authorization, or show error if probe fails
+ * 4. Logout button (if present): open logout URL in new tab, clear token
+ * @param {Object} props
+ * @param {Object} props.authService
+ * @param {String} props.authToken
+ * @param {String} props.authStatus
+ * @param {Function} props.onTokenReceived
+ * @param {Function} props.onAuthStatus
+ */
+function AuthOverlay({ authService, authToken, authStatus, onTokenReceived, onAuthStatus }) {
+  const [errorMessage, setErrorMessage] = useState(null);
+  const [isLoggingIn, setIsLoggingIn] = useState(false);
+  const loginTabRef = useRef(null);
+  const pollIntervalRef = useRef(null);
+
+  const { probe, accessService, tokenService, logoutService } = authService;
+
+  // Probe without token on page load to determine if login is required
+  useEffect(() => {
+    if (authStatus !== 'idle') return;
+    onAuthStatus('probing');
+    probeResource(probe.id, null)
+      .then(({ status }) => {
+        if (status === 200) {
+          onAuthStatus('authorized');
+        } else {
+          onAuthStatus('login-required');
+        }
+      })
+      .catch(() => {
+        onAuthStatus('login-required');
+      });
+  }, []);
+
+  // Cleanup login tab pollin interval on unmount
+  useEffect(() => {
+    return () => {
+      clearInterval(pollIntervalRef.current);
+    };
+  }, []);
+
+  /**
+   * Acquire token via a hidden iframe using postMessage API, then save this token
+   * and update the auth status in state.
+   * For successful token acquisistion, re-probe the resource with a header carrying
+   * the token as Bearer token to confirm authorization.
+   */
+  const acquireToken = () => {
+    if (!tokenService) return;
+    const origin = window.location.origin;
+    requestTokenViaIframe(tokenService.id, origin)
+      .then(async ({ accessToken }) => {
+        // Re-probe the resource with token
+        const { status, heading, note } = await probeResource(probe.id, accessToken);
+        if (status === 200) {
+          setErrorMessage(null);
+          onTokenReceived(accessToken);
+          onAuthStatus('authorized');
+        } else {
+          const errHeading = heading ? getLabelValue(heading) : getLabelValue(probe?.errorHeading);
+          const errNote = note ? getLabelValue(note) : getLabelValue(probe?.errorNote);
+          setErrorMessage({ heading: errHeading, note: errNote });
+          onAuthStatus('error');
+          setIsLoggingIn(false);
+        }
+      })
+      .catch(() => {
+        setErrorMessage({
+          heading: getLabelValue(tokenService.errorHeading) || 'Authentication failed',
+          note: getLabelValue(tokenService.errorNote) || 'Could not obtain an access token.',
+        });
+        onAuthStatus('error');
+        setIsLoggingIn(false);
+      });
+  };
+
+  /**
+   * Handle login button click based on the access service profile:
+   * - kiosk: acquire token via iframe
+   * - active: open a login tab, poll for it closing, then acquire token via iframe
+   * If popup is blocked, fall back to direct token acquisition without opening a login tab
+   */
+  const handleLogin = () => {
+    if (!accessService || isLoggingIn) return;
+    setIsLoggingIn(true);
+    setErrorMessage(null);
+
+    if (accessService.profile === 'kiosk') {
+      acquireToken();
+      return;
+    }
+
+    // Open login tab, poll for it closing for active profile
+    const loginUrl = `${accessService.id}?origin=${encodeURIComponent(window.location.origin)}`;
+    // Do NOT use 'noopener' here, it breaks window ref and breaks the polling
+    const tab = window.open(loginUrl, '_blank');
+    loginTabRef.current = tab;
+
+    // When popup is blocked use token acquisition via iframe without opening login tab
+    if (!tab) {
+      acquireToken();
+      return;
+    }
+
+    // Start polling for login tab status to detect tab closing and initiate token acquisition
+    pollIntervalRef.current = setInterval(() => {
+      if (loginTabRef.current && loginTabRef.current.closed) {
+        clearInterval(pollIntervalRef.current);
+        loginTabRef.current = null;
+        acquireToken();
+      }
+    }, 500);
+  };
+
+  /**
+   * Handle Logout button click
+   */
+  const handleLogout = () => {
+    if (!logoutService) return;
+    window.open(logoutService.id, '_blank', 'noopener');
+    onTokenReceived(null);
+    onAuthStatus('idle');
+  };
+
+  /**
+   * Handle Cancel button click, close login tab if open, clear polling interval,
+   * and reset auth status in state
+   */
+  const handleCancel = () => {
+    clearInterval(pollIntervalRef.current);
+    if (loginTabRef.current && !loginTabRef.current.closed) {
+      loginTabRef.current.close();
+      loginTabRef.current = null;
+    }
+    setIsLoggingIn(false);
+    onAuthStatus('cancelled');
+  };
+
+  const loginLabel = accessService
+    ? getLabelValue(accessService.confirmLabel) || getLabelValue(accessService.label) || 'Log in'
+    : 'Log in';
+  const headingText = accessService
+    ? getLabelValue(accessService.heading) || getLabelValue(accessService.label)
+    : null;
+  const noteText = accessService ? getLabelValue(accessService.note) : null;
+  // Only show logout when the user already has a token and a logout service is provided
+  const logoutLabel = (logoutService && authToken) ? getLabelValue(logoutService.label) || 'Log out' : null;
+
+  if (authStatus === 'authorized' || authStatus === 'idle' || authStatus === 'probing' || authStatus === 'cancelled') {
+    return null;
+  }
+
+  return (
+    <div className='ramp--auth-overlay' data-testid='auth-overlay' role='region' aria-label='Authentication required'>
+      <div className='ramp--auth-overlay__content'>
+        {errorMessage ? (
+          <>
+            {errorMessage.heading && (
+              <p className='ramp--auth-overlay__error-heading' dangerouslySetInnerHTML={{ __html: sanitizeHTML(errorMessage.heading) }} />
+            )}
+            {errorMessage.note && (
+              <p className='ramp--auth-overlay__error-note' dangerouslySetInnerHTML={{ __html: sanitizeHTML(errorMessage.note) }} />
+            )}
+          </>
+        ) : (
+          <>
+            {headingText && (
+              <p className='ramp--auth-overlay__heading' dangerouslySetInnerHTML={{ __html: sanitizeHTML(headingText) }} />
+            )}
+            {noteText && (
+              <p className='ramp--auth-overlay__note' dangerouslySetInnerHTML={{ __html: sanitizeHTML(noteText) }} />
+            )}
+          </>
+        )}
+        <div className='ramp--auth-overlay__actions'>
+          <button className='ramp--auth-overlay__login-btn' onClick={handleLogin} disabled={isLoggingIn} data-testid='auth-login-btn'>
+            {isLoggingIn ? 'Waiting…' : loginLabel}
+          </button>
+          {logoutLabel && (
+            <button className='ramp--auth-overlay__logout-btn' onClick={handleLogout} data-testid='auth-logout-btn'>
+              {logoutLabel}
+            </button>
+          )}
+          <button className='ramp--auth-overlay__cancel-btn' onClick={handleCancel} data-testid='auth-cancel-btn'>
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+AuthOverlay.propTypes = {
+  authService: PropTypes.shape({
+    probe: PropTypes.object.isRequired,
+    accessService: PropTypes.object,
+    tokenService: PropTypes.object,
+    logoutService: PropTypes.object,
+  }).isRequired,
+  authToken: PropTypes.string,
+  authStatus: PropTypes.string.isRequired,
+  onTokenReceived: PropTypes.func.isRequired,
+  onAuthStatus: PropTypes.func.isRequired,
+};
+
+export default AuthOverlay;

--- a/src/components/MediaPlayer/VideoJS/AuthOverlay.js
+++ b/src/components/MediaPlayer/VideoJS/AuthOverlay.js
@@ -95,7 +95,16 @@ function AuthOverlay({ authService, authStatus, onTokenReceived, onAuthStatus })
    * If popup is blocked, fall back to direct token acquisition without opening a login tab
    */
   const handleLogin = () => {
-    if (!accessService || isLoggingIn) return;
+    if (isLoggingIn) return;
+    // If no accessService is give for the authService, show an error message
+    if (!accessService) {
+      setErrorMessage({
+        heading: 'Login unavailable',
+        note: 'No access service is configured for this resource.',
+      });
+      onAuthStatus('error');
+      return;
+    }
     setIsLoggingIn(true);
     setErrorMessage(null);
 
@@ -171,14 +180,14 @@ function AuthOverlay({ authService, authStatus, onTokenReceived, onAuthStatus })
         ) : (
           <>
             {headingText && (
-              <div className='ramp--auth-overlay__header'>
+              <div className='ramp--auth-overlay__header' data-testid='auth-overlay-heading'>
                 <span dangerouslySetInnerHTML={{ __html: sanitizeHTML(headingText) }} />
               </div>
             )}
             <div className='ramp--auth-overlay__body'>
               <p className='ramp--auth-overlay__label' dangerouslySetInnerHTML={{ __html: sanitizeHTML(loginLabel) }} />
               {noteText && (
-                <p className='ramp--auth-overlay__note' dangerouslySetInnerHTML={{ __html: sanitizeHTML(noteText) }} />
+                <p className='ramp--auth-overlay__note' data-testid='auth-overlay-note' dangerouslySetInnerHTML={{ __html: sanitizeHTML(noteText) }} />
               )}
             </div>
           </>

--- a/src/components/MediaPlayer/VideoJS/AuthOverlay.js
+++ b/src/components/MediaPlayer/VideoJS/AuthOverlay.js
@@ -5,28 +5,26 @@ import { probeResource, requestTokenViaIframe } from '@Services/auth-service';
 import './VideoJSPlayer.scss';
 
 /**
- * Display authentication dialog and handle login/logout interactions for IIIF resources
+ * Display authentication dialog and handle login interaction for IIIF resources
  * protected by IIIF Auth 2.0 spec. 
  * It is rendered over the VideoJS player when a Canvas has an AuthProbeService2 defined.
  * The flow is as follows;
  * 1. On page load: probe the resource without a token to determine if login is required
  * 2. Login: performs the authnentication flow based on the access service profile and gets a token
  * 3. On token received: re-probe with token to confirm authorization, or show error if probe fails
- * 4. Logout button (if present): open logout URL in new tab, clear token
  * @param {Object} props
  * @param {Object} props.authService
- * @param {String} props.authToken
  * @param {String} props.authStatus
  * @param {Function} props.onTokenReceived
  * @param {Function} props.onAuthStatus
  */
-function AuthOverlay({ authService, authToken, authStatus, onTokenReceived, onAuthStatus }) {
+function AuthOverlay({ authService, authStatus, onTokenReceived, onAuthStatus }) {
   const [errorMessage, setErrorMessage] = useState(null);
   const [isLoggingIn, setIsLoggingIn] = useState(false);
   const loginTabRef = useRef(null);
   const pollIntervalRef = useRef(null);
 
-  const { probe, accessService, tokenService, logoutService } = authService;
+  const { probe, accessService, tokenService } = authService;
 
   // Probe without token on page load to determine if login is required
   useEffect(() => {
@@ -61,6 +59,7 @@ function AuthOverlay({ authService, authToken, authStatus, onTokenReceived, onAu
   const acquireToken = () => {
     if (!tokenService) return;
     const origin = window.location.origin;
+
     requestTokenViaIframe(tokenService.id, origin)
       .then(async ({ accessToken }) => {
         // Re-probe the resource with token
@@ -70,8 +69,10 @@ function AuthOverlay({ authService, authToken, authStatus, onTokenReceived, onAu
           onTokenReceived(accessToken);
           onAuthStatus('authorized');
         } else {
-          const errHeading = heading ? getLabelValue(heading) : getLabelValue(probe?.errorHeading);
-          const errNote = note ? getLabelValue(note) : getLabelValue(probe?.errorNote);
+          const errHeading = heading ? getLabelValue(heading)
+            : probe?.heading ? getLabelValue(probe?.errorHeading) : 'Something went wrong';
+          const errNote = note ? getLabelValue(note)
+            : probe?.errorNote ? getLabelValue(probe?.errorNote) : 'Could not confirm authorization with token.';
           setErrorMessage({ heading: errHeading, note: errNote });
           onAuthStatus('error');
           setIsLoggingIn(false);
@@ -120,19 +121,11 @@ function AuthOverlay({ authService, authToken, authStatus, onTokenReceived, onAu
       if (loginTabRef.current && loginTabRef.current.closed) {
         clearInterval(pollIntervalRef.current);
         loginTabRef.current = null;
+        // Reset button state immediately so the button is not stuck on 'Waiting...'
+        setIsLoggingIn(false);
         acquireToken();
       }
     }, 500);
-  };
-
-  /**
-   * Handle Logout button click
-   */
-  const handleLogout = () => {
-    if (!logoutService) return;
-    window.open(logoutService.id, '_blank', 'noopener');
-    onTokenReceived(null);
-    onAuthStatus('idle');
   };
 
   /**
@@ -149,57 +142,59 @@ function AuthOverlay({ authService, authToken, authStatus, onTokenReceived, onAu
     onAuthStatus('cancelled');
   };
 
-  const loginLabel = accessService
-    ? getLabelValue(accessService.confirmLabel) || getLabelValue(accessService.label) || 'Log in'
-    : 'Log in';
-  const headingText = accessService
-    ? getLabelValue(accessService.heading) || getLabelValue(accessService.label)
-    : null;
-  const noteText = accessService ? getLabelValue(accessService.note) : null;
-  // Only show logout when the user already has a token and a logout service is provided
-  const logoutLabel = (logoutService && authToken) ? getLabelValue(logoutService.label) || 'Log out' : null;
+  const confirmLabel = getLabelValue(accessService?.confirmLabel) || 'Log in';
+  const loginLabel = getLabelValue(accessService?.label) || 'Login';
+  const headingText = getLabelValue(accessService?.heading) ?? null;
+  const noteText = getLabelValue(accessService?.note) ?? null;
 
+  // Do not show the auth overlay when auth status doesn't indicate that login is required
   if (authStatus === 'authorized' || authStatus === 'idle' || authStatus === 'probing' || authStatus === 'cancelled') {
     return null;
   }
 
   return (
-    <div className='ramp--auth-overlay' data-testid='auth-overlay' role='region' aria-label='Authentication required'>
+    <div className='ramp--auth-overlay' data-testid='auth-overlay' role='region' aria-label={loginLabel}>
       <div className='ramp--auth-overlay__content'>
         {errorMessage ? (
           <>
             {errorMessage.heading && (
-              <p className='ramp--auth-overlay__error-heading' dangerouslySetInnerHTML={{ __html: sanitizeHTML(errorMessage.heading) }} />
+              <div className='ramp--auth-overlay__header error'>
+                <span dangerouslySetInnerHTML={{ __html: sanitizeHTML(errorMessage.heading) }} />
+              </div>
             )}
             {errorMessage.note && (
-              <p className='ramp--auth-overlay__error-note' dangerouslySetInnerHTML={{ __html: sanitizeHTML(errorMessage.note) }} />
+              <div className='ramp--auth-overlay__body'>
+                <p className='ramp--auth-overlay__error-note' dangerouslySetInnerHTML={{ __html: sanitizeHTML(errorMessage.note) }} />
+              </div>
             )}
           </>
         ) : (
           <>
             {headingText && (
-              <p className='ramp--auth-overlay__heading' dangerouslySetInnerHTML={{ __html: sanitizeHTML(headingText) }} />
+              <div className='ramp--auth-overlay__header'>
+                <span dangerouslySetInnerHTML={{ __html: sanitizeHTML(headingText) }} />
+              </div>
             )}
-            {noteText && (
-              <p className='ramp--auth-overlay__note' dangerouslySetInnerHTML={{ __html: sanitizeHTML(noteText) }} />
-            )}
+            <div className='ramp--auth-overlay__body'>
+              <p className='ramp--auth-overlay__label' dangerouslySetInnerHTML={{ __html: sanitizeHTML(loginLabel) }} />
+              {noteText && (
+                <p className='ramp--auth-overlay__note' dangerouslySetInnerHTML={{ __html: sanitizeHTML(noteText) }} />
+              )}
+            </div>
           </>
         )}
-        <div className='ramp--auth-overlay__actions'>
-          <button className='ramp--auth-overlay__login-btn' onClick={handleLogin} disabled={isLoggingIn} data-testid='auth-login-btn'>
-            {isLoggingIn ? 'Waiting…' : loginLabel}
-          </button>
-          {logoutLabel && (
-            <button className='ramp--auth-overlay__logout-btn' onClick={handleLogout} data-testid='auth-logout-btn'>
-              {logoutLabel}
+        {authStatus != 'error' && (
+          <div className='ramp--auth-overlay__actions'>
+            <button className='ramp--auth-overlay__login-btn' onClick={handleLogin} disabled={isLoggingIn} data-testid='auth-login-btn'>
+              {isLoggingIn ? 'Waiting…' : confirmLabel}
             </button>
-          )}
-          <button className='ramp--auth-overlay__cancel-btn' onClick={handleCancel} data-testid='auth-cancel-btn'>
-            Cancel
-          </button>
-        </div>
+            <button className='ramp--auth-overlay__cancel-btn' onClick={handleCancel} data-testid='auth-cancel-btn'>
+              Cancel
+            </button>
+          </div>
+        )}
       </div>
-    </div>
+    </div >
   );
 }
 
@@ -208,9 +203,7 @@ AuthOverlay.propTypes = {
     probe: PropTypes.object.isRequired,
     accessService: PropTypes.object,
     tokenService: PropTypes.object,
-    logoutService: PropTypes.object,
   }).isRequired,
-  authToken: PropTypes.string,
   authStatus: PropTypes.string.isRequired,
   onTokenReceived: PropTypes.func.isRequired,
   onAuthStatus: PropTypes.func.isRequired,

--- a/src/components/MediaPlayer/VideoJS/AuthOverlay.js
+++ b/src/components/MediaPlayer/VideoJS/AuthOverlay.js
@@ -24,10 +24,19 @@ function AuthOverlay({ authService, authStatus, onTokenReceived, onAuthStatus })
   const loginTabRef = useRef(null);
   const pollIntervalRef = useRef(null);
 
-  const { probe, accessService, tokenService } = authService;
+  const { probe, accessService, tokenService, restricted } = authService;
 
-  // Probe without token on page load to determine if login is required
   useEffect(() => {
+    /* When the resource access is restricted without required access services, update auth status to 'error' in state and
+    set 'errorMessage' in component state with probe's 'errorHeading' & 'errorNote' if they are defined. */
+    if (restricted) {
+      onAuthStatus('error');
+      const restrictedHeading = getLabelValue(probe?.errorHeading) || 'Restricted content';
+      const restrictedNote = getLabelValue(probe?.errorNote) || 'Authentication is not available for this resource.';
+      setErrorMessage({ heading: restrictedHeading, note: restrictedNote });
+      return;
+    }
+    // Otherwise, probe without token on page load to determine if login is required
     if (authStatus !== 'idle') return;
     onAuthStatus('probing');
     probeResource(probe.id, null)
@@ -69,10 +78,10 @@ function AuthOverlay({ authService, authStatus, onTokenReceived, onAuthStatus })
           onTokenReceived(accessToken);
           onAuthStatus('authorized');
         } else {
-          const errHeading = heading ? getLabelValue(heading)
-            : probe?.heading ? getLabelValue(probe?.errorHeading) : 'Something went wrong';
-          const errNote = note ? getLabelValue(note)
-            : probe?.errorNote ? getLabelValue(probe?.errorNote) : 'Could not confirm authorization with token.';
+          const probeErrorHeading = getLabelValue(probe?.errorHeading) || 'Something went wrong';
+          const errHeading = getLabelValue(heading) || probeErrorHeading;
+          const probeErrorNote = getLabelValue(probe?.errorNote) || 'Could not confirm authorization with token.';
+          const errNote = getLabelValue(note) || probeErrorNote;
           setErrorMessage({ heading: errHeading, note: errNote });
           onAuthStatus('error');
           setIsLoggingIn(false);
@@ -96,15 +105,6 @@ function AuthOverlay({ authService, authStatus, onTokenReceived, onAuthStatus })
    */
   const handleLogin = () => {
     if (isLoggingIn) return;
-    // If no accessService is give for the authService, show an error message
-    if (!accessService) {
-      setErrorMessage({
-        heading: 'Login unavailable',
-        note: 'No access service is configured for this resource.',
-      });
-      onAuthStatus('error');
-      return;
-    }
     setIsLoggingIn(true);
     setErrorMessage(null);
 
@@ -192,7 +192,7 @@ function AuthOverlay({ authService, authStatus, onTokenReceived, onAuthStatus })
             </div>
           </>
         )}
-        {authStatus != 'error' && (
+        {(authStatus != 'error' && !restricted) && (
           <div className='ramp--auth-overlay__actions'>
             <button className='ramp--auth-overlay__login-btn' onClick={handleLogin} disabled={isLoggingIn} data-testid='auth-login-btn'>
               {isLoggingIn ? 'Waiting…' : confirmLabel}
@@ -212,6 +212,7 @@ AuthOverlay.propTypes = {
     probe: PropTypes.object.isRequired,
     accessService: PropTypes.object,
     tokenService: PropTypes.object,
+    restricted: PropTypes.bool.isRequired,
   }).isRequired,
   authStatus: PropTypes.string.isRequired,
   onTokenReceived: PropTypes.func.isRequired,

--- a/src/components/MediaPlayer/VideoJS/AuthOverlay.test.js
+++ b/src/components/MediaPlayer/VideoJS/AuthOverlay.test.js
@@ -1,0 +1,250 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import AuthOverlay from './AuthOverlay';
+import * as authService from '@Services/auth-service';
+
+jest.mock('dompurify', () => ({ sanitize: (html) => html }));
+jest.mock('@Services/auth-service', () => ({
+  probeResource: jest.fn(),
+  requestTokenViaIframe: jest.fn(),
+}));
+
+const mockAccessService = {
+  id: 'http://example.com/auth/login',
+  profile: 'active',
+  label: { en: ['Login Required'] },
+  heading: { en: ['Please Log In'] },
+  note: { en: ['This application requires that you log in with your account to view this content.'] },
+  confirmLabel: { en: ['Log In'] },
+};
+
+const defaultAuthService = {
+  probe: {
+    id: 'http://example.com/auth/probe',
+    errorHeading: { en: ['No access'] },
+    errorNote: { en: ['You do not have permission'] },
+  },
+  accessService: mockAccessService,
+  tokenService: {
+    id: 'http://example.com/auth/token',
+    errorHeading: { en: ['Something went wrong'] },
+    errorNote: { en: ['Could not get a token.'] },
+  },
+};
+
+describe('AuthOverlay', () => {
+  const onTokenReceivedMock = jest.fn();
+  const onAuthStatusMock = jest.fn();
+  const props = {
+    authService: defaultAuthService,
+    // authStatus: 'login-required',
+    onTokenReceived: onTokenReceivedMock,
+    onAuthStatus: onAuthStatusMock,
+  };
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('renders successfully', () => {
+    test('when authStatus=\'login-required\'', () => {
+      // renderOverlay({ authStatus: 'login-required' });
+      render(<AuthOverlay {...props} authStatus='login-required' />);
+      expect(screen.queryByTestId('auth-overlay')).toBeInTheDocument();
+    });
+
+    test('when authStatus=\'error\'', () => {
+      render(<AuthOverlay {...props} authStatus='error' />);
+      expect(screen.getByTestId('auth-overlay')).toBeInTheDocument();
+    });
+  });
+
+  describe('does not render', () => {
+    test('when authStatus=\'authorized\'', () => {
+      render(<AuthOverlay {...props} authStatus='authorized' />);
+      expect(screen.queryByTestId('auth-overlay')).not.toBeInTheDocument();
+    });
+
+    test('when authStatus=\'idle\'', () => {
+      /* Mock probeResource to return 200, so that auth overlay is not
+       displayed with authStatus='authorizd' */
+      authService.probeResource.mockResolvedValue({ status: 200 });
+      render(<AuthOverlay {...props} authStatus='idle' />);
+      expect(screen.queryByTestId('auth-overlay')).not.toBeInTheDocument();
+    });
+
+    test('when authStatus=\'probing\'', () => {
+      render(<AuthOverlay {...props} authStatus='probing' />);
+      expect(screen.queryByTestId('auth-overlay')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('renders the login', () => {
+    beforeEach(() => {
+      render(<AuthOverlay {...props} authStatus='login-required' />);
+    });
+
+    test('with the heading and label from the accessService info', () => {
+      expect(screen.getByText('Please Log In')).toBeInTheDocument();
+      expect(screen.getByText('Login Required')).toBeInTheDocument();
+    });
+
+    test('with the note from the accessService info', () => {
+      expect(screen.getByText('Login Required')).toHaveClass('ramp--auth-overlay__label');
+      expect(screen.getByText('This application requires that you log in with your account to view this content.'))
+        .toBeInTheDocument();
+      expect(screen.getByText('This application requires that you log in with your account to view this content.'))
+        .toHaveClass('ramp--auth-overlay__note');
+    });
+
+    test('with the confirmLabel as login button text', () => {
+      expect(screen.getByTestId('auth-login-btn')).toHaveTextContent('Log In');
+    });
+  });
+
+  describe('probes resource on first render and', () => {
+    test('updates authStatus=\'login-required\' in state when probe returns 401', async () => {
+      authService.probeResource.mockResolvedValue({ status: 401 });
+      render(<AuthOverlay {...props} authStatus='idle' />);
+      await waitFor(() => {
+        expect(onAuthStatusMock).toHaveBeenCalledWith('login-required');
+      });
+    });
+
+    test('updates authStatus=\'authorized\' in state when probe returns 200', async () => {
+      authService.probeResource.mockResolvedValue({ status: 200 });
+      render(<AuthOverlay {...props} authStatus='idle' />);
+      await waitFor(() => {
+        expect(onAuthStatusMock).toHaveBeenCalledWith('authorized');
+      });
+    });
+  });
+
+  describe('re-probes to confirm authorization and', () => {
+    const updatedProps = {
+      ...props,
+      authStatus: 'login-required',
+      authService: { ...defaultAuthService, accessService: { ...mockAccessService, profile: 'kiosk' } }
+    };
+    test('updates state when probe returns 200 with token', async () => {
+      // Mock token acquisition and successful probe
+      authService.requestTokenViaIframe.mockResolvedValue({ accessToken: 'valid-token' });
+      authService.probeResource.mockResolvedValue({ status: 200 });
+
+      // Test token acquisition flow with profile='kiosk' to skip login tab tracking
+      render(<AuthOverlay {...updatedProps} />);
+
+      // Simulate login button click user action
+      fireEvent.click(screen.getByTestId('auth-login-btn'));
+
+      await waitFor(() => {
+        expect(authService.probeResource).toHaveBeenCalledWith('http://example.com/auth/probe', 'valid-token');
+        expect(onTokenReceivedMock).toHaveBeenCalledWith('valid-token');
+        expect(onAuthStatusMock).toHaveBeenCalledWith('authorized');
+      });
+    });
+
+    test('displays an error when probe 401', async () => {
+      authService.requestTokenViaIframe.mockResolvedValue({ accessToken: 'bad-token' });
+      authService.probeResource.mockResolvedValue({
+        status: 401,
+        heading: { en: ['Something went wrong'] },
+        note: { en: ['Could not get a token.'] },
+      });
+      render(<AuthOverlay {...updatedProps} />);
+
+      fireEvent.click(screen.getByTestId('auth-login-btn'));
+
+      // Wait for the component to update with the error state
+      await waitFor(() => {
+        expect(onAuthStatusMock).toHaveBeenCalledWith('error');
+      });
+      expect(onTokenReceivedMock).not.toHaveBeenCalled();
+      expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+      expect(screen.getByText('Could not get a token.')).toBeInTheDocument();
+    });
+  });
+
+  describe('login button', () => {
+    let mockTab;
+    beforeEach(() => {
+      mockTab = { closed: false };
+      jest.spyOn(window, 'open').mockReturnValue(mockTab);
+      authService.probeResource.mockResolvedValue({ status: 200 });
+    });
+
+    test('is rendered', () => {
+      render(<AuthOverlay {...props} authStatus='login-required' />);
+      expect(screen.queryByTestId('auth-login-btn')).toBeInTheDocument();
+    });
+
+    test('opens a login tab for profile=\'active\'', async () => {
+      authService.requestTokenViaIframe.mockResolvedValue({ accessToken: 'new-token' });
+
+      render(<AuthOverlay {...props} authStatus='login-required' />);
+      fireEvent.click(screen.getByTestId('auth-login-btn'));
+
+      expect(window.open).toHaveBeenCalledWith(
+        expect.stringContaining('http://example.com/auth/login'),
+        '_blank'
+      );
+
+      // Token is requested via requestTokenViaIframe() after the tab is closed
+      mockTab.closed = true;
+      await waitFor(() => {
+        expect(authService.requestTokenViaIframe).toHaveBeenCalledWith(
+          'http://example.com/auth/token', window.location.origin
+        );
+        expect(onTokenReceivedMock).toHaveBeenCalledWith('new-token');
+      });
+    });
+
+    test('changes button text for relevant auth flow state', async () => {
+      render(<AuthOverlay {...props} authStatus='login-required' />);
+
+      // Button text changes to 'Waiting...' while waiting in the new tab for login
+      fireEvent.click(screen.getByTestId('auth-login-btn'));
+      expect(screen.getByTestId('auth-login-btn')).toHaveTextContent('Waiting…');
+
+      // Button text resets to 'Log In' when tab is closed
+      mockTab.closed = true;
+      await waitFor(() => {
+        expect(screen.getByTestId('auth-login-btn')).toHaveTextContent('Log In');
+      });
+    });
+
+    test('requests token for without tab for profile=\'kiosk\'', async () => {
+      authService.requestTokenViaIframe.mockResolvedValue({ accessToken: 'kiosk-token' });
+
+      render(<AuthOverlay {...props} authStatus='login-required'
+        authService={{
+          ...defaultAuthService,
+          accessService: { ...mockAccessService, profile: 'kiosk' },
+        }} />);
+
+      fireEvent.click(screen.getByTestId('auth-login-btn'));
+
+      // Access token is requested without opening a new tab for login
+      expect(window.open).not.toHaveBeenCalled();
+      await waitFor(() => {
+        expect(onTokenReceivedMock).toHaveBeenCalledWith('kiosk-token');
+      });
+    });
+  });
+
+  describe('cancel button', () => {
+    test('is rendered', () => {
+      render(<AuthOverlay {...props} authStatus='login-required' />);
+      expect(screen.queryByTestId('auth-cancel-btn')).toBeInTheDocument();
+    });
+
+    test('updates state with authStatus=\'cancelled\' when clicked', () => {
+      render(<AuthOverlay {...props} authStatus='login-required' />);
+      fireEvent.click(screen.getByTestId('auth-cancel-btn'));
+      expect(onAuthStatusMock).toHaveBeenCalledWith('cancelled');
+    });
+
+    test('does not render the overlay when authStatus=\'cancelled\'', () => {
+      render(<AuthOverlay {...props} authStatus='cancelled' />);
+      expect(screen.queryByTestId('auth-overlay')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/MediaPlayer/VideoJS/AuthOverlay.test.js
+++ b/src/components/MediaPlayer/VideoJS/AuthOverlay.test.js
@@ -30,6 +30,7 @@ const defaultAuthService = {
     errorHeading: { en: ['Something went wrong'] },
     errorNote: { en: ['Could not get a token.'] },
   },
+  restricted: false,
 };
 
 describe('AuthOverlay', () => {
@@ -37,7 +38,6 @@ describe('AuthOverlay', () => {
   const onAuthStatusMock = jest.fn();
   const props = {
     authService: defaultAuthService,
-    // authStatus: 'login-required',
     onTokenReceived: onTokenReceivedMock,
     onAuthStatus: onAuthStatusMock,
   };
@@ -46,7 +46,6 @@ describe('AuthOverlay', () => {
 
   describe('renders successfully', () => {
     test('when authStatus=\'login-required\'', () => {
-      // renderOverlay({ authStatus: 'login-required' });
       render(<AuthOverlay {...props} authStatus='login-required' />);
       expect(screen.queryByTestId('auth-overlay')).toBeInTheDocument();
     });
@@ -78,7 +77,7 @@ describe('AuthOverlay', () => {
   });
 
   describe('renders the login', () => {
-    describe('from accessService info', () => {
+    describe('from accessService\'s', () => {
       beforeEach(() => {
         render(<AuthOverlay {...props} authStatus='login-required' />);
       });
@@ -101,27 +100,38 @@ describe('AuthOverlay', () => {
       });
     });
 
-    describe('without accessService info', () => {
-      const updatedProps = {
-        ...props,
-        authStatus: 'login-required',
-        authService: { ...defaultAuthService, accessService: null }
-      };
-      beforeEach(() => {
-        render(<AuthOverlay {...updatedProps} />);
+    describe('restricted overlay (no login/cancel buttons) when', () => {
+      test('accessService is missing; shows probe errorHeading and errorNote', () => {
+        render(<AuthOverlay {...props} authStatus='login-required'
+          authService={{ ...defaultAuthService, accessService: null, restricted: true }} />);
+
+        expect(screen.getByText('No access')).toBeInTheDocument();
+        expect(screen.getByText('You do not have permission')).toBeInTheDocument();
+        expect(screen.queryByTestId('auth-login-btn')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('auth-cancel-btn')).not.toBeInTheDocument();
       });
 
-      test('with a default label and no heading', () => {
-        expect(screen.queryByTestId('auth-overlay-heading')).not.toBeInTheDocument();
-        expect(screen.getByText('Login')).toBeInTheDocument();
+      test('tokenService is missing; shows probe errorHeading and errorNote', () => {
+        render(<AuthOverlay {...props} authStatus='login-required'
+          authService={{ ...defaultAuthService, tokenService: null, restricted: true }} />);
+
+        expect(screen.getByText('No access')).toBeInTheDocument();
+        expect(screen.getByText('You do not have permission')).toBeInTheDocument();
+        expect(screen.queryByTestId('auth-login-btn')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('auth-cancel-btn')).not.toBeInTheDocument();
       });
 
-      test('no note text', () => {
-        expect(screen.queryByTestId('auth-overlay-note')).not.toBeInTheDocument();
-      });
+      test('accessService, tokenService, and probe error info are all missing; shows default heading and note', () => {
+        render(<AuthOverlay {...props} authStatus='login-required'
+          authService={{
+            probe: { id: 'http://example.com/auth/probe' },
+            accessService: null, tokenService: null, restricted: true
+          }} />);
 
-      test('with a default login button text', () => {
-        expect(screen.getByTestId('auth-login-btn')).toHaveTextContent('Log in');
+        expect(screen.getByText('Restricted content')).toBeInTheDocument();
+        expect(screen.getByText('Authentication is not available for this resource.')).toBeInTheDocument();
+        expect(screen.queryByTestId('auth-login-btn')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('auth-cancel-btn')).not.toBeInTheDocument();
       });
     });
   });
@@ -253,20 +263,6 @@ describe('AuthOverlay', () => {
       await waitFor(() => {
         expect(onTokenReceivedMock).toHaveBeenCalledWith('kiosk-token');
       });
-    });
-
-    test('displays an error when no accessService is given for authService', () => {
-      render(<AuthOverlay {...props} authStatus='login-required'
-        authService={{
-          ...defaultAuthService,
-          accessService: null,
-        }} />);
-
-      fireEvent.click(screen.getByTestId('auth-login-btn'));
-
-      // Error state updated in UI
-      expect(screen.getByText('Login unavailable')).toBeInTheDocument();
-      expect(screen.getByText('No access service is configured for this resource.')).toBeInTheDocument();
     });
   });
 

--- a/src/components/MediaPlayer/VideoJS/AuthOverlay.test.js
+++ b/src/components/MediaPlayer/VideoJS/AuthOverlay.test.js
@@ -78,25 +78,51 @@ describe('AuthOverlay', () => {
   });
 
   describe('renders the login', () => {
-    beforeEach(() => {
-      render(<AuthOverlay {...props} authStatus='login-required' />);
+    describe('from accessService info', () => {
+      beforeEach(() => {
+        render(<AuthOverlay {...props} authStatus='login-required' />);
+      });
+
+      test('heading and label', () => {
+        expect(screen.getByText('Please Log In')).toBeInTheDocument();
+        expect(screen.getByText('Login Required')).toBeInTheDocument();
+      });
+
+      test('note', () => {
+        expect(screen.getByText('Login Required')).toHaveClass('ramp--auth-overlay__label');
+        expect(screen.getByText('This application requires that you log in with your account to view this content.'))
+          .toBeInTheDocument();
+        expect(screen.getByText('This application requires that you log in with your account to view this content.'))
+          .toHaveClass('ramp--auth-overlay__note');
+      });
+
+      test('confirmLabel as login button text', () => {
+        expect(screen.getByTestId('auth-login-btn')).toHaveTextContent('Log In');
+      });
     });
 
-    test('with the heading and label from the accessService info', () => {
-      expect(screen.getByText('Please Log In')).toBeInTheDocument();
-      expect(screen.getByText('Login Required')).toBeInTheDocument();
-    });
+    describe('without accessService info', () => {
+      const updatedProps = {
+        ...props,
+        authStatus: 'login-required',
+        authService: { ...defaultAuthService, accessService: null }
+      };
+      beforeEach(() => {
+        render(<AuthOverlay {...updatedProps} />);
+      });
 
-    test('with the note from the accessService info', () => {
-      expect(screen.getByText('Login Required')).toHaveClass('ramp--auth-overlay__label');
-      expect(screen.getByText('This application requires that you log in with your account to view this content.'))
-        .toBeInTheDocument();
-      expect(screen.getByText('This application requires that you log in with your account to view this content.'))
-        .toHaveClass('ramp--auth-overlay__note');
-    });
+      test('with a default label and no heading', () => {
+        expect(screen.queryByTestId('auth-overlay-heading')).not.toBeInTheDocument();
+        expect(screen.getByText('Login')).toBeInTheDocument();
+      });
 
-    test('with the confirmLabel as login button text', () => {
-      expect(screen.getByTestId('auth-login-btn')).toHaveTextContent('Log In');
+      test('no note text', () => {
+        expect(screen.queryByTestId('auth-overlay-note')).not.toBeInTheDocument();
+      });
+
+      test('with a default login button text', () => {
+        expect(screen.getByTestId('auth-login-btn')).toHaveTextContent('Log in');
+      });
     });
   });
 
@@ -227,6 +253,20 @@ describe('AuthOverlay', () => {
       await waitFor(() => {
         expect(onTokenReceivedMock).toHaveBeenCalledWith('kiosk-token');
       });
+    });
+
+    test('displays an error when no accessService is given for authService', () => {
+      render(<AuthOverlay {...props} authStatus='login-required'
+        authService={{
+          ...defaultAuthService,
+          accessService: null,
+        }} />);
+
+      fireEvent.click(screen.getByTestId('auth-login-btn'));
+
+      // Error state updated in UI
+      expect(screen.getByText('Login unavailable')).toBeInTheDocument();
+      expect(screen.getByText('No access service is configured for this resource.')).toBeInTheDocument();
     });
   });
 

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -20,6 +20,7 @@ import { useLocalStorage } from '@Services/local-storage';
 import { usePlaybackPositions } from '@Services/save-playback-positions';
 import { showResumeModal } from './VideoJSResumeModal';
 import { showErrorModal } from './components/js/VideoJSErrorModal';
+import AuthOverlay from './AuthOverlay';
 import { SectionButtonIcon } from '@Services/svg-icons';
 import {
   useMediaPlayer, useSetupPlayer, useShowInaccessibleMessage, useVideoJSPlayer
@@ -86,6 +87,7 @@ function VideoJSPlayer({
     autoAdvance,
     structures,
     canvasSegments,
+    auth,
   } = manifestState;
   const { hasStructure, structItems } = structures;
   const { clickedUrl, isEnded, isPlaying, currentTime } = playerState;
@@ -111,6 +113,8 @@ function VideoJSPlayer({
   const vjsErrorModalRef = useRef(null);
 
   const { canvasIndex, canvasIsEmpty, isMultiCanvased, lastCanvasIndex } = useMediaPlayer();
+  const authService = allCanvases[canvasIndex]?.authService ?? null;
+
   const { isPlaylist, renderingFiles, srcIndex, switchPlayer }
     = useSetupPlayer({ enableFileDownload, withCredentials, lastCanvasIndex });
   const { messageTime } = useShowInaccessibleMessage({ lastCanvasIndex });
@@ -1583,7 +1587,7 @@ function VideoJSPlayer({
   };
 
   return (
-    <div>
+    <div style={{ position: 'relative' }}>
       <div data-vjs-player data-canvasindex={cIndexRef.current}>
         {canvasIsEmptyRef.current && (
           <div data-testid="inaccessible-message-display"
@@ -1597,11 +1601,11 @@ function VideoJSPlayer({
               zIndex: 101,
               aspectRatio: !playerRef.current ? '16/9' : '',
             }}>
-            <p className="ramp--media-player_inaccessible-message-content" data-testid="inaccessible-message-content"
+            <p className="ramp--media-player_inaccessible-message__content" data-testid="inaccessible-message-content"
               dangerouslySetInnerHTML={{ __html: placeholderText }}>
             </p>
             {lastCanvasIndex > 0 &&
-              <div className="ramp--media-player_inaccessible-message-buttons"
+              <div className="ramp--media-player_inaccessible-message__buttons"
                 data-testid="inaccessible-message-buttons">
                 {canvasIndex >= 1 &&
                   <button aria-label="Go back to previous item"
@@ -1628,7 +1632,7 @@ function VideoJSPlayer({
             {canvasIndex != lastCanvasIndex && lastCanvasIndex > 0 &&
               <p data-testid="inaccessible-message-timer"
                 className={cx(
-                  'ramp--media-player_inaccessible-message-timer',
+                  'ramp--media-player_inaccessible-message__timer',
                   autoAdvanceRef.current ? '' : 'hidden'
                 )}>
                 {`Next item in ${messageTime} second${messageTime === 1 ? '' : 's'}`}
@@ -1649,6 +1653,15 @@ function VideoJSPlayer({
         >
         </video>
       </div>
+      {authService && auth?.status !== 'authorized' && (
+        <AuthOverlay
+          authService={authService}
+          authToken={auth.token}
+          authStatus={auth.status}
+          onTokenReceived={(token) => manifestDispatch({ token, type: 'setAuthToken' })}
+          onAuthStatus={(status) => manifestDispatch({ status, type: 'setAuthStatus' })}
+        />
+      )}
       {(hasStructure || isPlaylist) &&
         (<div className="vjs-track-scrubber-container hidden" ref={trackScrubberRef} id="track_scrubber">
           <p className="vjs-time track-currenttime" role="presentation"></p>

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.scss
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.scss
@@ -1,36 +1,124 @@
 @use '../../../styles/vars';
 
 .ramp--media-player_inaccessible-message-content {
-  width: 50%;
-  color: vars.$primaryLightest;
-  a {
-    color: vars.$primaryGreen
+  &__content {
+    width: 50%;
+    color: vars.$primaryLightest;
+    a {
+      color: vars.$primaryGreen
+    }
+  }
+
+  &__buttons {
+    display: flex;
+    gap: 0.5em;
+
+    button {
+      border: 1px solid;
+      color: white;
+      background-color: vars.$primaryGreenDark;
+      padding: 0.5em;
+      border-radius: 0.3em;
+      cursor: pointer;
+      font-size: medium;
+      display: flex;
+      align-items: center;
+      gap: 0.25em;
+    }
+  }
+
+  &__timer {
+    color: inherit;
+    margin: 1em 0;
+
+    &.hidden {
+      visibility: hidden
+    }
   }
 }
 
-.ramp--media-player_inaccessible-message-buttons {
+.ramp--auth-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
   display: flex;
-  gap: 0.5em;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  color: #fff;
+  background-color: rgba(0, 0, 0, 0.85);
+  z-index: 101;
+  text-align: center;
 
-  button {
+  p {
+    margin: 0.4em 0;
+    color: vars.$primaryLightest;
+  }
+
+  a {
+    color: vars.$primaryGreen;
+  }
+
+  &__heading {
+    font-size: 1em;
+  }
+
+  &__error-heading {
+    font-size: 1.1em;
+    font-weight: bold;
+    color: vars.$warning !important;
+  }
+
+  &__error-note {
+    font-size: 0.9em;
+  }
+
+  &__actions {
+    display: flex;
+    gap: 0.75em;
+    margin-top: 1em;
+    justify-content: center;
+  }
+
+  &__login-btn {
     border: 1px solid;
     color: white;
     background-color: vars.$primaryGreenDark;
-    padding: 0.5em;
+    padding: 0.5em 1em;
     border-radius: 0.3em;
     cursor: pointer;
     font-size: medium;
-    display: flex;
-    align-items: center;
-    gap: 0.25em;
+
+    &:disabled {
+      opacity: 0.6;
+      cursor: wait;
+    }
+
+    &:hover:not(:disabled) {
+      background-color: vars.$primaryGreenDarker;
+    }
   }
-}
 
-.ramp--media-player_inaccessible-message-timer {
-  color: inherit;
-  margin: 1em 0;
-}
+  &__content {
+    border: 1px solid white;
+    padding: 1rem;
+    border-radius: 0.5rem;
+    background: vars.$primaryDarker;
+  }
 
-.ramp--media-player_inaccessible-message-timer.hidden {
-  visibility: hidden
+  &__logout-btn {
+    border: 1px solid vars.$primaryLight;
+    color: vars.$primaryLight;
+    background-color: transparent;
+    padding: 0.5em 1em;
+    border-radius: 0.3em;
+    cursor: pointer;
+    font-size: medium;
+
+    &:hover {
+      background-color: rgba(255, 255, 255, 0.1);
+    }
+  }
 }

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.scss
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.scss
@@ -1,6 +1,6 @@
 @use '../../../styles/vars';
 
-.ramp--media-player_inaccessible-message-content {
+.ramp--media-player_inaccessible-message {
   &__content {
     width: 50%;
     color: vars.$primaryLightest;

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.scss
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.scss
@@ -51,9 +51,10 @@
   background-color: rgba(0, 0, 0, 0.85);
   z-index: 101;
   text-align: center;
+  font-size: 1rem;
 
   p {
-    margin: 0.4em 0;
+    margin: 0.2em 0;
     color: vars.$primaryLightest;
   }
 
@@ -61,16 +62,34 @@
     color: vars.$primaryGreen;
   }
 
-  &__heading {
-    font-size: 1em;
+  &__content {
+    border: 1px solid white;
+    border-radius: 0.5rem;
+    background: vars.$primaryDarker;
   }
 
-  &__error-heading {
-    font-size: 1.1em;
+  &__body {
+    padding: 1rem;
+  }
+
+  &__header {
+    background-color: vars.$primaryLightest;
+    border-radius: 0.5rem 0.5rem 0 0;
+    font-size: 1.25em;
+    padding: 0.5em;
+
+    &.error {
+      font-size: 1.1em;
+      color: vars.$primaryLightest;
+      background-color: vars.$warning;
+    }
+  }
+
+  &__label {
     font-weight: bold;
-    color: vars.$warning !important;
   }
 
+  &__note,
   &__error-note {
     font-size: 0.9em;
   }
@@ -78,7 +97,7 @@
   &__actions {
     display: flex;
     gap: 0.75em;
-    margin-top: 1em;
+    margin: 1em 0;
     justify-content: center;
   }
 
@@ -98,27 +117,6 @@
 
     &:hover:not(:disabled) {
       background-color: vars.$primaryGreenDarker;
-    }
-  }
-
-  &__content {
-    border: 1px solid white;
-    padding: 1rem;
-    border-radius: 0.5rem;
-    background: vars.$primaryDarker;
-  }
-
-  &__logout-btn {
-    border: 1px solid vars.$primaryLight;
-    color: vars.$primaryLight;
-    background-color: transparent;
-    padding: 0.5em 1em;
-    border-radius: 0.3em;
-    cursor: pointer;
-    font-size: medium;
-
-    &:hover {
-      background-color: rgba(255, 255, 255, 0.1);
     }
   }
 }

--- a/src/components/MediaPlayer/VideoJS/videojs-theme.scss
+++ b/src/components/MediaPlayer/VideoJS/videojs-theme.scss
@@ -28,6 +28,13 @@
   min-height: 210px;
 }
 
+// Maintain player's 16/9 aspect ratio for auth dialog
+[data-vjs-player="true"]:has(.vjs-theme-ramp) {
+  background-color: black;
+  aspect-ratio: 16/9;
+}
+
+
 .vjs-theme-ramp .vjs-control-bar {
   height: 5em;
   background: linear-gradient(to bottom, rgba(0, 0, 0, 0), rgba(0, 0, 0, .75), rgba(0, 0, 0, .75));

--- a/src/context/manifest-context.js
+++ b/src/context/manifest-context.js
@@ -42,6 +42,10 @@ const defaultState = {
   },
   annotations: [], // [{ canvasIndex: Number, annotationSets: Array }]
   clickedAnnotation: null, // clicked annotation in the Canvas
+  auth: {
+    token: null, // auth token for the current Canvas
+    status: 'idle', // 'idle' | 'probing' | 'login-required' | 'authorized' | 'error' | 'cancelled'
+  },
 };
 
 function getHasStructure(canvasSegments, canvasIndex) {
@@ -94,7 +98,7 @@ function manifestReducer(state = defaultState, action) {
         },
         annotations: hasAnnotations
           ? [...state.annotations]
-          : [...state.annotations, parseAnnotationSets(state.manifest, action.canvasIndex)]
+          : [...state.annotations, parseAnnotationSets(state.manifest, action.canvasIndex)],
       };
     }
     case 'switchItem': {
@@ -252,6 +256,18 @@ function manifestReducer(state = defaultState, action) {
       return {
         ...state,
         clickedAnnotation: action.clickedAnnotation,
+      };
+    }
+    case 'setAuthToken': {
+      return {
+        ...state,
+        auth: { token: action.token, status: 'authorized' },
+      };
+    }
+    case 'setAuthStatus': {
+      return {
+        ...state,
+        auth: { ...state.auth, status: action.status },
       };
     }
     default: {

--- a/src/services/auth-service.js
+++ b/src/services/auth-service.js
@@ -1,0 +1,100 @@
+/**
+ * Probe a resource with a probe service defined with type='AuthProbeService2'. The
+ * response indicates whether the resource requires authentication.
+ * When token is provided, it is sent in the Authorization Header as a Bearer token to
+ * confirm authorization.
+ * https://iiif.io/api/auth/2.0/#probe-service-request
+ * @param {String} probeUrl URL of the AuthProbeService2
+ * @param {String} token access token from AuthAccessTokenService2 if exists
+ * @returns {Promise<Object>} { status: Number, heading: Object, note: Object, substitute: Array }
+ */
+export async function probeResource(probeUrl, token = null) {
+  const headers = new Headers({ 'Accept': 'application/json' });
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+  const response = await fetch(probeUrl, { headers });
+  let body = {};
+  try {
+    body = await response.json();
+  } catch {
+    // For non-JSON response, return empty body
+  }
+  return { status: response.status, ...body };
+}
+
+/**
+ * Request an access token from a token service with type='AuthAccessTokenService2'
+ * using a hidden iframe and postMessage API.
+ * https://iiif.io/api/auth/2.0/#access-token-service-request
+ * @param {String} tokenServiceUrl URL of the AuthAccessTokenService2
+ * @param {String} origin window.location.origin of the IIIF client
+ * @returns {Promise<Object>} { accessToken: String, expiresIn: Number }
+ */
+export function requestTokenViaIframe(tokenServiceUrl, origin) {
+  return new Promise((resolve, reject) => {
+    // A random value to correlate the token service requests
+    const messageId = generateMessageId();
+    let iframe = null;
+    let timeoutId = null;
+
+    const expectedOrigin = new URL(tokenServiceUrl).origin;
+
+    const cleanup = () => {
+      window.removeEventListener('message', onMessage);
+      clearTimeout(timeoutId);
+      // Remove the iframe immediately after receiving the response
+      if (iframe && iframe.parentNode) {
+        iframe.parentNode.removeChild(iframe);
+      }
+      iframe = null;
+    };
+
+    const onMessage = (event) => {
+      /* Validate event.origin against token service origin to prevent accepting
+       messages from malicious origins */
+      if (event.origin !== expectedOrigin) return;
+
+      const data = event.data;
+      if (!data || (data.messageId && data.messageId !== messageId)) return;
+      cleanup();
+      if (data.type === 'AuthAccessTokenError2' || data.error) {
+        reject(new Error(data.profile || data.error || 'Token request failed'));
+      } else if (data.accessToken) {
+        resolve({ accessToken: data.accessToken, expiresIn: data.expiresIn });
+      } else {
+        reject(new Error('Unexpected token service response'));
+      }
+    };
+
+    // Register an event listener to listen for dispatched messages via postMessage API
+    window.addEventListener('message', onMessage);
+
+    // Set a timeout for token service response to prevent hanging if something goes wrong
+    timeoutId = setTimeout(() => {
+      cleanup();
+      reject(new Error('Token service timed out'));
+    }, 10000);
+
+    iframe = document.createElement('iframe');
+    iframe.setAttribute('style', 'display:none;width:0;height:0;border:0');
+    iframe.setAttribute('title', '');
+    iframe.setAttribute('aria-hidden', 'true');
+    document.body.appendChild(iframe);
+
+    const url = new URL(tokenServiceUrl);
+    url.searchParams.set('messageId', messageId);
+    url.searchParams.set('origin', origin);
+    iframe.src = url.toString();
+  });
+}
+
+/**
+ * Generate a random message ID for correlating postMessage responses
+ * @returns {String} randomly generated, 36 character long v4 UUID
+ */
+function generateMessageId() {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+}

--- a/src/services/auth-service.js
+++ b/src/services/auth-service.js
@@ -53,7 +53,9 @@ export function requestTokenViaIframe(tokenServiceUrl, origin) {
     const onMessage = (event) => {
       /* Validate event.origin against token service origin to prevent accepting
        messages from malicious origins */
-      if (event.origin !== expectedOrigin) return;
+      if (event.origin !== expectedOrigin) {
+        reject(new Error('Invalid origin'));
+      }
 
       const data = event.data;
       if (!data || (data.messageId && data.messageId !== messageId)) return;

--- a/src/services/auth-service.test.js
+++ b/src/services/auth-service.test.js
@@ -1,6 +1,10 @@
-import { requestTokenViaIframe } from './auth-service';
+import { probeResource, requestTokenViaIframe } from './auth-service';
 
 describe('auth-service', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   describe('requestTokenViaIframe()', () => {
     const tokenServiceUrl = 'http://auth.example.com/token';
     const origin = 'http://example.com/ramp';
@@ -12,10 +16,6 @@ describe('auth-service', () => {
       jest.spyOn(document, 'createElement').mockReturnValueOnce(fakeIframe);
       document.body.appendChild = jest.fn();
       document.body.removeChild = jest.fn();
-    });
-
-    afterEach(() => {
-      jest.restoreAllMocks();
     });
 
     test('resolves with accessToken when token service request is successful', async () => {
@@ -79,6 +79,60 @@ describe('auth-service', () => {
       const iframeSrc = new URL(fakeIframe.src);
       expect(iframeSrc.searchParams.get('messageId')).toBe(fixedMessageId);
       expect(iframeSrc.searchParams.get('origin')).toBe(origin);
+    });
+  });
+
+  describe('probeResource()', () => {
+    describe('sends a GET request to the probe URL', () => {
+      test('without auth header when token is null', async () => {
+        global.fetch = jest.fn().mockResolvedValueOnce({
+          status: 401,
+          json: jest.fn().mockResolvedValue({ errorHeading: { en: ['No access'] } }),
+        });
+
+        const result = await probeResource('http://example.com/probe', null);
+
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+        const [url, options] = fetch.mock.calls[0];
+        expect(url).toBe('http://example.com/probe');
+        expect(options.headers.get('Authorization')).toBeNull();
+        expect(result.status).toBe(401);
+      });
+
+      test('with auth header when token is provided', async () => {
+        global.fetch = jest.fn().mockResolvedValueOnce({
+          status: 200,
+          json: jest.fn().mockResolvedValue({}),
+        });
+
+        await probeResource('http://example.com/probe', 'auth-token');
+
+        const [, options] = fetch.mock.calls[0];
+        expect(options.headers.get('Authorization')).toBe('Bearer auth-token');
+      });
+    });
+
+    describe('return status', () => {
+      test('200 and body on success', async () => {
+        global.fetch = jest.fn().mockResolvedValue({
+          status: 200,
+          json: jest.fn().mockResolvedValue({ type: 'AuthProbeResult2', substitute: [] }),
+        });
+
+        const result = await probeResource('http://example.com/probe', 'token');
+        expect(result.status).toBe(200);
+        expect(result.substitute).toEqual([]);
+        expect(result.type).toBe('AuthProbeResult2');
+      });
+
+      test('401 and empty body when response is not JSON', async () => {
+        global.fetch = jest.fn().mockResolvedValue({
+          status: 401
+        });
+
+        const result = await probeResource('http://example.com/probe', null);
+        expect(result.status).toBe(401);
+      });
     });
   });
 });

--- a/src/services/auth-service.test.js
+++ b/src/services/auth-service.test.js
@@ -1,0 +1,84 @@
+import { requestTokenViaIframe } from './auth-service';
+
+describe('auth-service', () => {
+  describe('requestTokenViaIframe()', () => {
+    const tokenServiceUrl = 'http://auth.example.com/token';
+    const origin = 'http://example.com/ramp';
+    const fixedMessageId = 'test-message-id-1234';
+    let fakeIframe;
+    beforeEach(() => {
+      jest.spyOn(crypto, 'randomUUID').mockReturnValue(fixedMessageId);
+      fakeIframe = { src: '', parentNode: document.body, setAttribute: jest.fn() };
+      jest.spyOn(document, 'createElement').mockReturnValueOnce(fakeIframe);
+      document.body.appendChild = jest.fn();
+      document.body.removeChild = jest.fn();
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    test('resolves with accessToken when token service request is successful', async () => {
+      const promise = requestTokenViaIframe(tokenServiceUrl, origin);
+
+      window.dispatchEvent(new MessageEvent('message', {
+        origin: 'http://auth.example.com',
+        data: {
+          '@context': 'http://iiif.io/api/auth/2/context.json',
+          type: 'AuthAccessToken2',
+          accessToken: 'test-token-abc',
+          expiresIn: 300,
+          messageId: fixedMessageId,
+        },
+      }));
+
+      const result = await promise;
+      expect(result.accessToken).toBe('test-token-abc');
+      expect(result.expiresIn).toBe(300);
+    });
+
+    test('rejects when the token service returns an error message', async () => {
+      const promise = requestTokenViaIframe(tokenServiceUrl, origin);
+
+      window.dispatchEvent(new MessageEvent('message', {
+        origin: 'http://auth.example.com',
+        data: {
+          type: 'AuthAccessTokenError2',
+          profile: 'invalidRequest',
+          messageId: fixedMessageId,
+        },
+      }));
+
+      await expect(promise).rejects.toThrow('invalidRequest');
+    });
+
+    test('rejects when the token service with mismatched origin', async () => {
+      const promise = requestTokenViaIframe(tokenServiceUrl, origin);
+
+      window.dispatchEvent(new MessageEvent('message', {
+        origin: 'http://malicious.example.com',
+        data: { accessToken: 'not-real-token', messageId: fixedMessageId },
+      }));
+
+      await expect(promise).rejects.toThrow('Invalid origin');
+    });
+
+    test('sets messageId and origin query params on the iframe src', async () => {
+      const promise = requestTokenViaIframe(tokenServiceUrl, origin);
+
+      window.dispatchEvent(new MessageEvent('message', {
+        origin: 'http://auth.example.com',
+        data: {
+          type: 'AuthAccessToken2',
+          accessToken: 'access-token',
+          messageId: fixedMessageId
+        },
+      }));
+      await promise;
+
+      const iframeSrc = new URL(fakeIframe.src);
+      expect(iframeSrc.searchParams.get('messageId')).toBe(fixedMessageId);
+      expect(iframeSrc.searchParams.get('origin')).toBe(origin);
+    });
+  });
+});

--- a/src/services/iiif-parser.js
+++ b/src/services/iiif-parser.js
@@ -739,9 +739,8 @@ export function getAuthService(canvas) {
     const probe = services.find(s => s.type === 'AuthProbeService2');
     if (probe) {
       // Read probe services as an array
-      const probeServices = Array.isArray(probe.service)
-        ? probe.service
-        : probe.service ? [probe.service] : [];
+      const probeServicesRaw = probe.service ?? [];
+      const probeServices = Array.isArray(probeServicesRaw) ? probeServicesRaw : [probeServicesRaw];
       const accessService = probeServices.find(
         s => s.type === 'AuthAccessService2' && ['active', 'kiosk'].includes(s.profile)
       ) ?? null;

--- a/src/services/iiif-parser.js
+++ b/src/services/iiif-parser.js
@@ -719,7 +719,7 @@ export function getSearchService(resource) {
  * @function IIIFParser#getAuthService
  * @param {Object} canvas current Canvas to read auth service endpoints
  * @returns {Object} { version: Number, probe: Object, accessService: Object,
- * tokenService: Object, logoutService: Object }
+ * tokenService: Object, logoutService: Object, restricted: Boolean }
  */
 export function getAuthService(canvas) {
   try {
@@ -751,8 +751,9 @@ export function getAuthService(canvas) {
         : accessService?.service ? [accessService.service] : [];
       const tokenService = accessServices.find(s => s.type === 'AuthAccessTokenService2') ?? null;
       const logoutService = accessServices.find(s => s.type === 'AuthLogoutService2') ?? null;
+      const restricted = !accessService || !tokenService;
 
-      return { version: 2, probe, accessService, tokenService, logoutService };
+      return { version: 2, probe, accessService, tokenService, logoutService, restricted };
     }
   } catch {
     return null;

--- a/src/services/iiif-parser.js
+++ b/src/services/iiif-parser.js
@@ -1,6 +1,5 @@
 import { parseManifest, PropertyValue } from 'manifesto.js';
 import mimeTypes from 'mime-types';
-import DOMPurify from 'dompurify';
 import {
   GENERIC_EMPTY_MANIFEST_MESSAGE,
   GENERIC_ERROR_MESSAGE,
@@ -9,15 +8,9 @@ import {
   parseResourceAnnotations,
   setCanvasMessageTimeout,
   timeToHHmmss,
-  identifyMachineGen
+  identifyMachineGen,
+  sanitizeHTML,
 } from './utility-helpers';
-
-// HTML tags and attributes allowed in IIIF metadata values.
-const DOMPURIFY_CONFIG = {
-  ALLOWED_TAGS: ['a', 'b', 'br', 'i', 'img', 'p', 'small', 'span', 'sub', 'sup'],
-  ALLOWED_ATTR: ['href', 'src', 'alt'],
-  ALLOWED_URI_REGEXP: /^(?:https?|mailto):/i,
-};
 
 // Do not build structures for the following 'Range' behaviors:
 // Reference: https://iiif.io/api/presentation/3.0/#behavior
@@ -76,7 +69,8 @@ export function canvasesInManifest(manifest) {
             summary: summary,
             homepage: homepage || '',
             label: canvasLabel,
-            searchService: getSearchService(canvas)
+            searchService: getSearchService(canvas),
+            authService: getAuthService(canvas)
           });
         } catch (error) {
           canvasesInfo.push({
@@ -89,7 +83,8 @@ export function canvasesInManifest(manifest) {
             summary: summary,
             homepage: homepage || '',
             label: getLabelValue(canvas.label) || `Section ${index + 1}`,
-            searchService: getSearchService(canvas)
+            searchService: getSearchService(canvas),
+            authService: getAuthService(canvas)
           });
         }
       });
@@ -485,7 +480,7 @@ export function parseMetadata(metadata, resourceType) {
     metadata.map(md => {
       // get value and replace \n characters with <br/> to display new lines in UI
       let value = getLabelValue(md.value, true)?.replace(/\n/g, "<br />");
-      let purifiedValue = DOMPurify.sanitize(value, { ...DOMPURIFY_CONFIG });
+      let purifiedValue = sanitizeHTML(value);
       parsedMetadata.push({
         label: getLabelValue(md.label),
         value: purifiedValue
@@ -714,4 +709,53 @@ export function getSearchService(resource) {
     }
   }
   return searchService;
+}
+
+/**
+ * Read 'services' block from a Canvas' Annotation body for IIIF Auth flow 2.0.
+ * When the Annotation body has a 'Choice', parse the service information in the first
+ * item in body's 'items' list, with the assumption that service information across
+ * choices are identical.
+ * @function IIIFParser#getAuthService
+ * @param {Object} canvas current Canvas to read auth service endpoints
+ * @returns {Object} { version: Number, probe: Object, accessService: Object,
+ * tokenService: Object, logoutService: Object }
+ */
+export function getAuthService(canvas) {
+  try {
+    const body = canvas?.items?.[0]?.items?.[0]?.body;
+    /* For Canvas 'body' with choice, parse auth service from within the an item
+    in the list of choices. Assumption: auth service info is identical across all listed
+    source choices within the Canvas. */
+    const source = body?.type === 'Choice' ? body?.items?.[0] : body;
+    const authService = source?.service;
+
+    if (!authService) return null;
+
+    const serviceArray = Array.isArray(authService) ? authService : [authService];
+    const services = serviceArray.flatMap(s => Array.isArray(s) ? s : [s]);
+
+    // Find and parse service type="AuthProbeService2"
+    const probe = services.find(s => s.type === 'AuthProbeService2');
+    if (probe) {
+      // Read probe services as an array
+      const probeServices = Array.isArray(probe.service)
+        ? probe.service
+        : probe.service ? [probe.service] : [];
+      const accessService = probeServices.find(
+        s => s.type === 'AuthAccessService2' && ['active', 'kiosk'].includes(s.profile)
+      ) ?? null;
+
+      // Parse access, token, and logout services if they exist
+      const accessServices = Array.isArray(accessService?.service)
+        ? accessService.service
+        : accessService?.service ? [accessService.service] : [];
+      const tokenService = accessServices.find(s => s.type === 'AuthAccessTokenService2') ?? null;
+      const logoutService = accessServices.find(s => s.type === 'AuthLogoutService2') ?? null;
+
+      return { version: 2, probe, accessService, tokenService, logoutService };
+    }
+  } catch {
+    return null;
+  }
 }

--- a/src/services/iiif-parser.test.js
+++ b/src/services/iiif-parser.test.js
@@ -859,6 +859,7 @@ describe('iiif-parser', () => {
       expect(result.accessService.profile).toBe('active');
       expect(result.tokenService.type).toBe('AuthAccessTokenService2');
       expect(result.logoutService.type).toBe('AuthLogoutService2');
+      expect(result.restricted).toBe(false);
     });
 
     describe('returns null when a Canvas', () => {
@@ -883,6 +884,22 @@ describe('iiif-parser', () => {
       expect(result.probe.type).toBe('AuthProbeService2');
       expect(result.accessService.profile).toBe('active');
       expect(result.tokenService.type).toBe('AuthAccessTokenService2');
+    });
+
+    describe('returns restricted=true when', () => {
+      test('auth service has no access service', () => {
+        const result = iiifParser.getAuthService(authManifest.items[3]);
+        expect(result).not.toBeNull();
+        expect(result.restricted).toBe(true);
+        expect(result.accessService).toBeNull();
+      });
+
+      test('access service has no token service', () => {
+        const result = iiifParser.getAuthService(authManifest.items[4]);
+        expect(result).not.toBeNull();
+        expect(result.restricted).toBe(true);
+        expect(result.tokenService).toBeNull();
+      });
     });
   });
 });

--- a/src/services/iiif-parser.test.js
+++ b/src/services/iiif-parser.test.js
@@ -9,6 +9,7 @@ import emptyManifest from '@TestData/empty-manifest';
 import singleCanvasManifest from '@TestData/single-canvas';
 import audiannotateTest from '@TestData/audiannotate-test';
 import adManifest from '@TestData/ad-annotation';
+import authManifest from '@TestData/auth-manifest';
 import * as iiifParser from './iiif-parser';
 import * as util from './utility-helpers';
 
@@ -119,6 +120,14 @@ describe('iiif-parser', () => {
         expect(canvases[4].homepage).toEqual('https://example.com/playlists/1?position=5');
         expect(canvases[4].searchService).toBeNull();
       });
+    });
+
+    test('returns authService on each Canvas', () => {
+      const canvases = iiifParser.canvasesInManifest(authManifest);
+      expect(canvases[0].authService).not.toBeNull();
+      expect(canvases[0].authService.version).toBe(2);
+      expect(canvases[0].authService.probe.type).toBe('AuthProbeService2');
+      expect(canvases[1].authService).toBeNull();
     });
   });
 
@@ -837,6 +846,43 @@ describe('iiif-parser', () => {
 
     test('returns null when service type is not equal to SearchService2', () => {
       expect(iiifParser.getSearchService(manifest.items[1])).toBeNull();
+    });
+  });
+
+  describe('getAuthService()', () => {
+    test('returns AuthProbeService2 for a given Canvas', () => {
+      const result = iiifParser.getAuthService(authManifest.items[0]);
+      expect(result).not.toBeNull();
+      expect(result.version).toBe(2);
+      expect(result.probe.type).toBe('AuthProbeService2');
+      expect(result.accessService.type).toBe('AuthAccessService2');
+      expect(result.accessService.profile).toBe('active');
+      expect(result.tokenService.type).toBe('AuthAccessTokenService2');
+      expect(result.logoutService.type).toBe('AuthLogoutService2');
+    });
+
+    describe('returns null when a Canvas', () => {
+      test('has no auth services', () => {
+        const result = iiifParser.getAuthService(authManifest.items[1]);
+        expect(result).toBeNull();
+      });
+
+      test('is undefined', () => {
+        expect(iiifParser.getAuthService(undefined)).toBeNull();
+      });
+
+      test('has no annotation body services', () => {
+        expect(iiifParser.getAuthService(singleCanvasManifest.items[0])).toBeNull();
+      });
+    });
+
+    test('returns auth service from the first choice when Annotation body type="Choice"', () => {
+      const result = iiifParser.getAuthService(authManifest.items[2]);
+      expect(result).not.toBeNull();
+      expect(result.version).toBe(2);
+      expect(result.probe.type).toBe('AuthProbeService2');
+      expect(result.accessService.profile).toBe('active');
+      expect(result.tokenService.type).toBe('AuthAccessTokenService2');
     });
   });
 });

--- a/src/services/testing-helpers.js
+++ b/src/services/testing-helpers.js
@@ -49,5 +49,6 @@ export function manifestState(manifest, canvasIndex = 0, isPlaylist = false) {
     structures: { hasStructure: false, isCollapsed: false },
     renderings: getRenderingFiles(manifest),
     annotations: [],
+    auth: { token: null, status: 'idle' },
   };
 };

--- a/src/services/utility-helpers.js
+++ b/src/services/utility-helpers.js
@@ -1,7 +1,8 @@
 import { decode } from 'html-entities';
 import isEmpty from 'lodash/isEmpty';
-import { getPlaceholderCanvas } from './iiif-parser';
 import mimeTypes from 'mime-types';
+import DOMPurify from 'dompurify';
+import { getPlaceholderCanvas } from './iiif-parser';
 import { IS_ANDROID, IS_MOBILE, IS_SAFARI } from '@Services/browser';
 
 const S_ANNOTATION_TYPE = { transcript: 1, caption: 2, both: 3, audioDescription: 4 };
@@ -25,6 +26,13 @@ export let GENERIC_EMPTY_MANIFEST_MESSAGE = DEFAULT_EMPTY_MANIFEST_MESSAGE;
 // Timer for displaying placeholderCanvas text when a Canvas is empty
 const DEFAULT_TIMEOUT = 10000;
 export let CANVAS_MESSAGE_TIMEOUT = DEFAULT_TIMEOUT;
+
+// HTML tags and attributes allowed in IIIF metadata values.
+const DOMPURIFY_CONFIG = {
+  ALLOWED_TAGS: ['a', 'b', 'br', 'i', 'img', 'p', 'small', 'span', 'sub', 'sup'],
+  ALLOWED_ATTR: ['href', 'src', 'alt'],
+  ALLOWED_URI_REGEXP: /^(?:https?|mailto):/i,
+};
 
 /**
  * Sets the timer for displaying the placeholderCanvas text in the player
@@ -1113,4 +1121,15 @@ const filterAndOffsetTextTrackCues = (track, altStart, duration) => {
       if (cue._originalText !== undefined) cue.text = cue._originalText;
     }
   }
+};
+
+/**
+ * Sanitize HTML string using DOMPurify library with allowed configuration
+ * from the IIIF 3.0 specification for HTML content in labels and metadata.
+ * @param {String} html text with possible inline HTML
+ * @returns {String}
+ */
+export const sanitizeHTML = (html) => {
+  if (!html) return '';
+  return DOMPurify.sanitize(html, { ...DOMPURIFY_CONFIG });
 };

--- a/src/styles/_vars.scss
+++ b/src/styles/_vars.scss
@@ -5,7 +5,7 @@ $primaryLighter: #ebebeb;
 $primaryLight: #d3d3d3;
 $primary: #bbbbbb;
 $primaryDark: #7e7e7e;
-$primaryDarker: #333333;
+$primaryDarker: #292929;
 $primaryDarkest: #000;
 $primaryGreenLight: #cfd8d3;
 $primaryGreenSemiLight: #d0dcdc;
@@ -19,6 +19,7 @@ $fontSizeLarge: 20px;
 $fontSizeMedium: 12px;
 
 $danger: #e0101a;
+$warning: #bf841b;
 
 $fontPrimary: 'Open Sans', sans-serif;
 

--- a/src/styles/_vars.scss
+++ b/src/styles/_vars.scss
@@ -19,7 +19,7 @@ $fontSizeLarge: 20px;
 $fontSizeMedium: 12px;
 
 $danger: #e0101a;
-$warning: #bf841b;
+$warning: #9c6100;
 
 $fontPrimary: 'Open Sans', sans-serif;
 

--- a/src/test_data/auth-manifest.js
+++ b/src/test_data/auth-manifest.js
@@ -1,0 +1,200 @@
+export default {
+  '@context': [
+    "http://www.w3.org/ns/anno.jsonld",
+    "http://iiif.io/api/auth/2/context.json",
+    "http://iiif.io/api/presentation/3/context.json"
+  ],
+  id: 'http://example.com/auth-manifest/manifest.json',
+  type: 'Manifest',
+  label: { en: ['Auth Test Manifest'] },
+  items: [
+    {
+      id: 'http://example.com/auth-manifest/canvas/1',
+      type: 'Canvas',
+      duration: 300,
+      label: { en: ['Protected Video'] },
+      items: [
+        {
+          id: 'http://example.com/auth-manifest/canvas/1/page/1',
+          type: 'AnnotationPage',
+          items: [
+            {
+              id: 'http://example.com/auth-manifest/canvas/1/page/1/annotation/1',
+              type: 'Annotation',
+              motivation: 'painting',
+              target: 'http://example.com/auth-manifest/canvas/1',
+              body: {
+                id: 'http://example.com/auth-manifest/video/protected.mp4',
+                type: 'Video',
+                format: 'video/mp4',
+                duration: 300,
+                service: [
+                  {
+                    id: 'http://example.com/auth/probe?id=protected.mp4',
+                    type: 'AuthProbeService2',
+                    errorHeading: { en: ['No access'] },
+                    errorNote: { en: ['You do not have permission to access this resource'] },
+                    service: [
+                      {
+                        id: 'http://example.com/auth/login',
+                        type: 'AuthAccessService2',
+                        profile: 'active',
+                        label: { en: ['Login to access restricted content'] },
+                        heading: { en: ['Authentication Required'] },
+                        note: { en: ['Please log in with your institution credentials'] },
+                        confirmLabel: { en: ['Log in'] },
+                        service: [
+                          {
+                            id: 'http://example.com/auth/token',
+                            type: 'AuthAccessTokenService2',
+                            errorHeading: { en: ['Something went wrong'] },
+                            errorNote: { en: ['Could not get a token.'] }
+                          },
+                          {
+                            id: 'http://example.com/auth/logout',
+                            type: 'AuthLogoutService2',
+                            label: { en: ['Log out'] }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      id: 'http://example.com/auth-manifest/canvas/2',
+      type: 'Canvas',
+      duration: 120,
+      label: { en: ['Open Access Video'] },
+      items: [
+        {
+          id: 'http://example.com/auth-manifest/canvas/2/page/1',
+          type: 'AnnotationPage',
+          items: [
+            {
+              id: 'http://example.com/auth-manifest/canvas/2/page/1/annotation/1',
+              type: 'Annotation',
+              motivation: 'painting',
+              target: 'http://example.com/auth-manifest/canvas/2',
+              body: {
+                id: 'http://example.com/auth-manifest/video/open.mp4',
+                type: 'Video',
+                format: 'video/mp4',
+                duration: 120
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      id: 'http://example.com/auth-manifest/canvas/3',
+      type: 'Canvas',
+      duration: 120,
+      label: { en: ['Multi Quality Video'] },
+      items: [
+        {
+          id: 'http://example.com/auth-manifest/canvas/3/page/1',
+          type: 'AnnotationPage',
+          items: [
+            {
+              id: 'http://example.com/auth-manifest/canvas/3/page/1/annotation/1',
+              type: 'Annotation',
+              motivation: 'painting',
+              target: 'http://example.com/auth-manifest/canvas/3',
+              body: {
+                type: 'Choice',
+                choiceHint: 'user',
+                items: [
+                  {
+                    id: 'http://example.com/auth-manifest/video/high.mp4',
+                    type: 'Video',
+                    format: 'video/mp4',
+                    duration: 300,
+                    label: { en: ['High Quality'] },
+                    service: [
+                      {
+                        id: 'http://example.com/auth/probe?id=high.mp4',
+                        type: 'AuthProbeService2',
+                        errorHeading: { en: ['No access'] },
+                        errorNote: { en: ['You do not have permission to access this resource'] },
+                        service: [
+                          {
+                            id: 'http://example.com/auth/login',
+                            type: 'AuthAccessService2',
+                            profile: 'active',
+                            label: { en: ['Login to access restricted content'] },
+                            heading: { en: ['Authentication Required'] },
+                            note: { en: ['Please log in with your institution credentials'] },
+                            confirmLabel: { en: ['Log in'] },
+                            service: [
+                              {
+                                id: 'http://example.com/auth/token',
+                                type: 'AuthAccessTokenService2',
+                                errorHeading: { en: ['Something went wrong'] },
+                                errorNote: { en: ['Could not get a token.'] }
+                              },
+                              {
+                                id: 'http://example.com/auth/logout',
+                                type: 'AuthLogoutService2',
+                                label: { en: ['Log out'] }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    id: 'http://example.com/auth-manifest/video/medium.mp4',
+                    type: 'Video',
+                    format: 'video/mp4',
+                    duration: 300,
+                    label: { en: ['Medium Quality'] },
+                    service: [
+                      {
+                        id: 'http://example.com/auth/probe?id=medium.mp4',
+                        type: 'AuthProbeService2',
+                        errorHeading: { en: ['No access'] },
+                        errorNote: { en: ['You do not have permission to access this resource'] },
+                        service: [
+                          {
+                            id: 'http://example.com/auth/login',
+                            type: 'AuthAccessService2',
+                            profile: 'active',
+                            label: { en: ['Login to access restricted content'] },
+                            heading: { en: ['Authentication Required'] },
+                            note: { en: ['Please log in with your institution credentials'] },
+                            confirmLabel: { en: ['Log in'] },
+                            service: [
+                              {
+                                id: 'http://example.com/auth/token',
+                                type: 'AuthAccessTokenService2',
+                                errorHeading: { en: ['Something went wrong'] },
+                                errorNote: { en: ['Could not get a token.'] }
+                              },
+                              {
+                                id: 'http://example.com/auth/logout',
+                                type: 'AuthLogoutService2',
+                                label: { en: ['Log out'] }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};

--- a/src/test_data/auth-manifest.js
+++ b/src/test_data/auth-manifest.js
@@ -195,6 +195,87 @@ export default {
           ]
         }
       ]
+    },
+    {
+      id: 'http://example.com/auth-manifest/canvas/4',
+      type: 'Canvas',
+      duration: 120,
+      label: { en: ['Probe w/o Access Service'] },
+      items: [
+        {
+          id: 'http://example.com/auth-manifest/canvas/4/page/1',
+          type: 'AnnotationPage',
+          items: [
+            {
+              id: 'http://example.com/auth-manifest/canvas/4/page/1/annotation/1',
+              type: 'Annotation',
+              motivation: 'painting',
+              target: 'http://example.com/auth-manifest/canvas/4',
+              body: {
+                id: 'http://example.com/auth-manifest/video/restricted.mp4',
+                type: 'Video',
+                format: 'video/mp4',
+                duration: 120,
+                service: [
+                  {
+                    id: 'http://example.com/auth/probe?id=restricted.mp4',
+                    type: 'AuthProbeService2',
+                    errorHeading: { en: ['Access restricted'] },
+                    errorNote: { en: ['This resource is not accessible.'] }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      id: 'http://example.com/auth-manifest/canvas/5',
+      type: 'Canvas',
+      duration: 120,
+      label: { en: ['Access Service w/o Token Service'] },
+      items: [
+        {
+          id: 'http://example.com/auth-manifest/canvas/5/page/1',
+          type: 'AnnotationPage',
+          items: [
+            {
+              id: 'http://example.com/auth-manifest/canvas/5/page/1/annotation/1',
+              type: 'Annotation',
+              motivation: 'painting',
+              target: 'http://example.com/auth-manifest/canvas/5',
+              body: {
+                id: 'http://example.com/auth-manifest/video/restricted2.mp4',
+                type: 'Video',
+                format: 'video/mp4',
+                duration: 120,
+                service: [
+                  {
+                    id: 'http://example.com/auth/probe?id=restricted2.mp4',
+                    type: 'AuthProbeService2',
+                    service: [
+                      {
+                        id: 'http://example.com/auth/login',
+                        type: 'AuthAccessService2',
+                        profile: 'active',
+                        label: { en: ['Login'] },
+                        service: [
+                          {
+                            id: 'http://example.com/auth/logout',
+                            type: 'AuthLogoutService2',
+                            label: { en: ['Log out'] }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
     }
   ]
 };


### PR DESCRIPTION
Related issue: #320

Changes in this PR:
- read and parse IIIF Auth 2.0 related services from a Canvas Annotation `body` including support for `Choice` Annotation `body`
- display an overlay with login action implemented as a separate component called `AuthOverlay` that renders over the player when a Canvas has protected behind a IIIF Auth 2.0 service
  - displays all available text information from the auth service as needed
  - if a `heading` text exists display it at the top of the login UI (e.g. 'Please Log In' in Avalon Manifest)
  - display `label` text below the heading in bold text
  - if a `note` text exists display it below the `label` text
- add a new module called `auth-service.js` to handle the probing, re-probing, access token acquisition via hidden iframe in the auth flow
- add state variables to keep track of the auth status of the current Manifest across components
- move sanitizing HTML using `DOMPurify` to `utility-helpers.js` as a util function called `sanitizeHtml`

Stanford IIIF Manifest with auth:
<img width="1255" height="715" alt="stanford-auth-manifest" src="https://github.com/user-attachments/assets/9d4d0ceb-2a3e-4eaf-8aa0-9fe7300ccd70" />

Avalon IIIF Manifest with auth and login waiting:
<img width="1255" height="715" alt="avalon-auth-manifest" src="https://github.com/user-attachments/assets/a6244757-9764-411b-a48f-3018c33ea267" />
<img width="1255" height="715" alt="avalon-auth-manifest-waiting" src="https://github.com/user-attachments/assets/c553347c-bc1b-4da2-9c26-55ed213443a1" />
