### PR TITLE
Fix empty playlist annotation bug

### DIFF
--- a/src/services/ramp-hooks.js
+++ b/src/services/ramp-hooks.js
@@ -1522,7 +1522,9 @@ export const useAnnotations = () => {
       || annotations?.filter((a) => a.canvasIndex === canvasIndex).length === 0)
       && manifest !== null) {
       let annotationSet = parseAnnotationSets(manifest, canvasIndex);
-      manifestDispatch({ annotations: annotationSet, type: 'setAnnotations' });
+      if (annotationSet != null) {
+        manifestDispatch({ annotations: annotationSet, type: 'setAnnotations' });
+      }
     }
   }, [manifest]);
 


### PR DESCRIPTION
Guard against `null` `annotationSet` for empty playlists when there are zero canvases. Without this check, Ramp breaks and displays an error trying to filter through annotations from where there are `null` elements.