### PR TITLE
Enable prop descriptions in controls

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,5 @@
 import 'video.js/dist/video-js.css';
+import './storybook-styles.scss';
 
 /**
  * Generate a hash for the given arguments. Used in IIIFPlayer component on storybook stories to create a unique key for
@@ -15,7 +16,7 @@ export const hashArgs = (args) =>
 /********** Shared Storybook Controls **********/
 export const manifestUrlControl = {
   control: { type: 'text' },
-  description: 'IIIF Manifest URL',
+  description: 'IIIF Manifest URL for creating state in Context Providers in Ramp',
   table: { category: 'IIIFPlayer' },
 };
 
@@ -46,7 +47,12 @@ export const videoJSLanguageOptions = {
 const preview = {
   parameters: {
     controls: {
-      disableSaveFromUI: true
+      disableSaveFromUI: true,
+      expanded: true,
+    },
+    docs: {
+      // Display a code tab in the controls panel
+      codePanel: true
     },
   },
 };

--- a/.storybook/storybook-styles.scss
+++ b/.storybook/storybook-styles.scss
@@ -1,0 +1,9 @@
+@use '../src/styles/vars.scss';
+
+/* Styling for components and others in the Storybook docs site */
+
+// Add a border to the transcript component in the Storybook docs site
+.ramp--transcript_nav {
+  border: 1px solid vars.$primaryLighter;
+  border-radius: 0.25rem;
+}

--- a/public/transcripts/lunchroom_base.json
+++ b/public/transcripts/lunchroom_base.json
@@ -11,15 +11,6 @@
   {
     "spans": [
       {
-        "begin": 10,
-        "end": 21,
-        "text": "<b>Hello</b> world!"
-      }
-    ]
-  },
-  {
-    "spans": [
-      {
         "begin": 22.2,
         "end": 26.6,
         "text": "Just before lunch one day, a puppet show was put on at school."

--- a/src/components/Annotations/Annotations.js
+++ b/src/components/Annotations/Annotations.js
@@ -5,9 +5,10 @@ import { timeToS } from '@Services/utility-helpers';
 import CreateMarker from './MarkerAnnotations/CreateMarker';
 import MarkerRow from './MarkerAnnotations/MarkerRow';
 import { useErrorBoundary } from 'react-error-boundary';
-import './Annotations.scss';
 import AnnotationList from './OtherAnnotations/AnnotationList';
 import { useAnnotations } from '@Services/ramp-hooks';
+import './Annotations.scss';
+import cx from 'classnames';
 
 /**
  * Display annotations from 'annotations' list associated with the current Canvas
@@ -25,6 +26,12 @@ const Annotations = ({
   showHeading = true,
   showMoreSettings = { enableShowMore: false, textLineLimit: 6 },
 }) => {
+  // Default showMoreSettings
+  const defaultShowMoreSettings = { enableShowMore: false, textLineLimit: 6 };
+
+  // Fill in missing properties, e.g. if prop only set to { enableShowMore: true }
+  showMoreSettings = { ...defaultShowMoreSettings, ...showMoreSettings, };
+
   const { allCanvases, annotations, canvasDuration, canvasIndex, playlist } = useManifestState();
   const manifestDispatch = useManifestDispatch();
 
@@ -173,7 +180,7 @@ const Annotations = ({
   }, [canvasPlaylistsMarkers]);
 
   return (
-    <div className={`ramp--annotations-display${showHeading ? ' with-heading' : ''}`}
+    <div className={cx('ramp--annotations-display', showHeading && 'with-heading')}
       data-testid='annotations-display'
       role='complementary'
       aria-label='annotations display'
@@ -206,10 +213,10 @@ const Annotations = ({
 };
 
 Annotations.propTypes = {
-  /** List of IIIF supported Annotation [motivations](https://iiif.io/api/registry/motivations/) to display in the current instance.
-   * An empty array displays `supplementing`, `commenting`, and `tagging` annotations related to the Canvas. For playlist manifests 
-   * Ramp overwrites the value of this prop to `['highlighting']`, as this component is intended for displaying markers in playlists.
-   * (**added in `@samvera/ramp@4.0.0`**) */
+  /** List of IIIF supported Annotation [motivations](https://iiif.io/api/registry/motivations/) to be displayed in the component.
+   * An empty array (default value) displays `supplementing`, `commenting`, and `tagging` annotations related to the Canvas.
+   * For playlist manifests, Ramp overwrites the current value of this prop to `['highlighting']`, as this component is only intended to
+   * display markers in playlists. * (**added in `@samvera/ramp@4.0.0`**) */
   displayMotivations: PropTypes.array,
   /** Label text shown in the component's heading. */
   headingText: PropTypes.string,

--- a/src/components/Annotations/Annotations.stories.jsx
+++ b/src/components/Annotations/Annotations.stories.jsx
@@ -40,6 +40,8 @@ const propControls = {
   manifestUrl: manifestUrlControl,
   displayMotivations: {
     control: { type: 'check' },
+    description: 'Choose one or more of the IIIF supported Annotation [motivations](https://iiif.io/api/registry/motivations/) from\
+    the list to display related annotations in the Canvas.',
     options: ['highlighting', 'commenting', 'supplementing', 'tagging'],
     table: { type: { summary: 'string[] (multi-select)' } },
   },
@@ -59,7 +61,8 @@ export const HighlightingMotivation = {
   args: {
     manifestUrl: `${config.url}/storybook-manifests/${config.env}/playlist-manifest.json`,
     headingText: 'Markers',
-    displayMotivations: ['highlighting']
+    displayMotivations: ['highlighting'],
+    showHeading: true,
   },
 };
 
@@ -70,12 +73,12 @@ export const OtherMotivations = {
     // Show more settings for textual annotations
     enableShowMore: {
       control: { type: 'boolean' },
-      description: 'Enable Show more/less toggle for long annotation texts',
+      description: 'Enable \'Show more/less\' toggle button for long annotation texts.',
       table: { category: 'showMoreSettings' },
     },
     textLineLimit: {
       control: { type: 'number', min: 1 },
-      description: 'Number of lines to show before truncating',
+      description: 'Number of lines to show before truncating the annotation text.',
       table: { category: 'showMoreSettings' },
     },
   },
@@ -92,5 +95,6 @@ export const OtherMotivations = {
     displayMotivations: [],
     enableShowMore: false,
     textLineLimit: 6,
+    showHeading: true,
   },
 };

--- a/src/components/AutoAdvanceToggle/AutoAdvanceToggle.stories.jsx
+++ b/src/components/AutoAdvanceToggle/AutoAdvanceToggle.stories.jsx
@@ -35,9 +35,9 @@ export const MultiCanvasManifest = {
   },
   render: ({ manifestUrl, ...args }) => (
     <IIIFPlayer key={hashArgs({ manifestUrl, ...args })} manifestUrl={manifestUrl}>
-      <AutoAdvanceToggle {...args} />
-      <br />
       <MediaPlayer />
+      <br />
+      <AutoAdvanceToggle {...args} />
     </IIIFPlayer>
   ),
   args: {
@@ -54,9 +54,9 @@ export const PlaylistManifest = {
   },
   render: ({ manifestUrl, ...args }) => (
     <IIIFPlayer key={hashArgs({ manifestUrl, ...args })} manifestUrl={manifestUrl}>
-      <AutoAdvanceToggle {...args} />
-      <br />
       <MediaPlayer />
+      <br />
+      <AutoAdvanceToggle {...args} />
     </IIIFPlayer>
   ),
   args: {

--- a/src/components/IIIFPlayer/IIIFPlayer.js
+++ b/src/components/IIIFPlayer/IIIFPlayer.js
@@ -55,17 +55,17 @@ IIIFPlayer.propTypes = {
   /** A IIIF Manifest JSON object. Takes precedence over `manifestUrl` when both are provided. */
   manifest: PropTypes.object,
   /** Custom message shown to the user in the unlikely event of the components crashing. The message can include
-   * HTML markup. This prop has a defaulf value for a generic message. (**added in `@samvera/ramp@3.0.0`**) */
+   * HTML markup (**added in `@samvera/ramp@3.0.0`**). */
   customErrorMessage: PropTypes.string,
-  /** Message text to be shown when a given Manifest has no canvases in it yet (e.g. an empty playlist). This has
-   * a default generic message. (**added in `@samvera/ramp@3.0.0`**) */
+  /** Message text to be shown when a given Manifest has no canvases in it yet (e.g. an empty playlist)
+   * (**added in `@samvera/ramp@3.0.0`**) */
   emptyManifestMessage: PropTypes.string,
   /** A valid Canvas ID in the given Manifest to show in Ramp on initialization. This can be mapped to the
-   * [`start` property](https://iiif.io/api/presentation/3.0/#start) in a IIIF Manifest. If a `start` property is
-   * also present in the given Manfiest, this value overrides it. (**added in `@samvera/ramp@3.0.0`**) */
+   * [`start` property](https://iiif.io/api/presentation/3.0/#start) in a IIIF Manifest. This prop value overrides
+   * a defined `start` property in the given Manfiest, this value overrides it (**added in `@samvera/ramp@3.0.0`**). */
   startCanvasId: PropTypes.string,
   /** A valid numer for a time in seconds to start playback in Ramp on initialization. Similar to the previous prop,
-   * this can be used to override the `start` property in the Manifest. (**added in `@samvera/ramp@3.0.0`**) */
+   * this can be used to override the `start` property in the Manifest (**added in `@samvera/ramp@3.0.0`**). */
   startCanvasTime: PropTypes.number,
 };
 

--- a/src/components/MediaPlayer/MediaPlayer.js
+++ b/src/components/MediaPlayer/MediaPlayer.js
@@ -239,21 +239,20 @@ const MediaPlayer = ({
 };
 
 MediaPlayer.propTypes = {
-  /** Adds the file download button for files listed in the active Canvas's `rendering` property in the player's control-bar, which is hidden
-   * by default. When enabled, this button displays a dropdown menu of files and allows the user to download them.
-   * This is a custom VideoJS component added to the VideoJS instance in Ramp. 
-   */
+  /** Adds the file download button for files listed in the active Canvas's `rendering` property in the player's control-bar.
+   * When enabled, this button displays a dropdown menu of files and allows the user to download them.
+   * This is a custom VideoJS component added to the VideoJS instance in Ramp.  */
   enableFileDownload: PropTypes.bool,
-  /** Adds VideoJS's built-in Picture-in-Picture control in the player's control-bar, which is hidden by default.
-   * When enabled VideoJS's built-in Picture-In-Picture functionality allows user to enable PiP playback and other functionalities.
+  /** Adds VideoJS's built-in Picture-in-Picture control in the player's control-bar. When enabled VideoJS's built-in
+   * Picture-In-Picture functionality allows user to enable PiP playback and other functionalities.
    * This is only enabled if the current browser supports Picture-In-Picture functionality. */
   enablePIP: PropTypes.bool,
-  /** Adds VideoJS's built-in playback rate control in the player's control-bar, which is hidden by default.
-   * This provides a menu with playback speed options 0.5x, 0.75x, 1x, 1.5x, and 2x. (**added in `@samvera/ramp@3.2.0`**) */
+  /** Adds VideoJS's built-in playback rate control in the player's control-bar. This provides a menu with playback speed
+   * options 0.5x, 0.75x, 1x, 1.5x, and 2x. (**added in `@samvera/ramp@3.2.0`**). */
   enablePlaybackRate: PropTypes.bool,
-  /** Adds a title bar to the video player linking to the active Canvas, which is hidden by default.
-   * The title bar displays a text `<Manifest label> - <Active Canvas label>` with an href attribute pointing to the active Canvas's URL. 
-   * This is a custom VideoJS component added to the VideoJS instance in Ramp. (**added in `@samvera/ramp@3.2.0`**) */
+  /** Adds a title bar to the video player linking to the active Canvas. The title bar displays a text
+   * `<Manifest label> - <Active Canvas label>` with an href attribute pointing to the active Canvas's URL. 
+   * This is a custom VideoJS component added to the VideoJS instance in Ramp (**added in `@samvera/ramp@3.2.0`**). */
   enableTitleLink: PropTypes.bool,
   /** Includes authentication/cookie headers with XHR requests for VideoJS streaming. This requires appropriate CORS headers on the server.
    * Setting this to `true` causes the VideoJS component to include any available `Authentication` and `Cookie` headers with 
@@ -261,12 +260,12 @@ MediaPlayer.propTypes = {
    * There are special server-side CORS requirements that go along with this option – specifically, the streaming server should
    * include an appropriate [`Access-Control-Allow-Credentials`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials)
    * header, and a non-wildcard [`Access-Control-Allow-Origin`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin)
-   * specifying the server originating the request. (**added in `@samvera/ramp@3.2.0`**) */
+   * specifying the server originating the request (**added in `@samvera/ramp@3.2.0`**). */
   withCredentials: PropTypes.bool,
   /** IANA language code for the translations of the player controls, which defaults to English (`'en'`).
    * Set the desired language as a [standard language code](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry).
    * If the given language code doesn't match with any of the existing language files in VideoJS, Ramp defaults to English language. This only provides
-   * the language for the in-built VideoJS player controls at the moment. (**added in `@samvera/ramp@3.3.0`**). */
+   * the language for the in-built VideoJS player controls at the moment (**added in `@samvera/ramp@3.3.0`**). */
   language: PropTypes.string,
   /** Saves and restores playback position per Manifest using localStorage, which is disabled by default.
    * When `resumeCache.enable`is set to `true`, the player saves and restores the playback position per Manifest using the browser's `localStorage`,
@@ -274,7 +273,7 @@ MediaPlayer.propTypes = {
    * The `ttlDays` property sets how many days a saved position is retained before expiring, and `maxItems` limits the number of Manifest entries
    * stored using an LRU eviction strategy.
    * When `resumeCache.enable` is set to `false`, any previously saved positions are cleared from storage. If the prop is initialized partially,
-   * Ramp applies default prop values to the rest of the properties. (**added in `@samvera/ramp@5.1.0`**) */
+   * Ramp applies default prop values to the rest of the properties (**added in `@samvera/ramp@5.1.0`**). */
   resumeCache: PropTypes.shape({
     enable: PropTypes.bool,
     ttlDays: PropTypes.number,

--- a/src/components/MediaPlayer/MediaPlayer.stories.jsx
+++ b/src/components/MediaPlayer/MediaPlayer.stories.jsx
@@ -30,7 +30,19 @@ const propControls = {
       labels: { ...videoJSLanguageOptions },
     },
     options: videoJSLanguageOptions ? Object.keys(videoJSLanguageOptions) : [],
-  }
+  },
+  // Resume cache settings
+  enable: {
+    control: { type: 'boolean' },
+    description: 'Enable/disable saving playback position in localStorage for the last partially played Canvas --omit saving playback times\
+    within the first and last 5 second range of the media-- in the current Manifest.',
+    table: { category: 'resumeCache' },
+  },
+  ttlDays: {
+    control: { type: 'number', min: 1 },
+    description: 'Number of days a saved Manifest entry is retained before it is removed from localStorage due to LRU eviction or expiration.',
+    table: { category: 'resumeCache' },
+  },
 };
 
 /* Default state for the MediaPlayer component */
@@ -39,6 +51,9 @@ const defaultState = {
   enablePlaybackRate: false,
   enableTitleLink: false,
   language: 'en',
+  enable: false,
+  ttlDays: 30,
+  maxItems: 200,
 };
 
 export const MultiCanvas = {
@@ -47,9 +62,9 @@ export const MultiCanvas = {
     ...propControls,
     enableFileDownload: { table: { disable: true } },
   },
-  render: ({ manifestUrl, ...args }) => (
-    <IIIFPlayer key={hashArgs({ manifestUrl, ...args })} manifestUrl={manifestUrl}>
-      <MediaPlayer {...args} />
+  render: ({ manifestUrl, enable, ttlDays, ...args }) => (
+    <IIIFPlayer key={hashArgs({ manifestUrl, enable, ttlDays, ...args })} manifestUrl={manifestUrl}>
+      <MediaPlayer {...args} resumeCache={{ enable, ttlDays }} />
     </IIIFPlayer>
   ),
   args: {
@@ -60,9 +75,9 @@ export const MultiCanvas = {
 
 export const SingleCanvas = {
   argTypes: { ...propControls },
-  render: ({ manifestUrl, ...args }) => (
-    <IIIFPlayer key={hashArgs({ manifestUrl, ...args })} manifestUrl={manifestUrl}>
-      <MediaPlayer {...args} />
+  render: ({ manifestUrl, enable, ttlDays, ...args }) => (
+    <IIIFPlayer key={hashArgs({ manifestUrl, enable, ttlDays, ...args })} manifestUrl={manifestUrl}>
+      <MediaPlayer {...args} resumeCache={{ enable, ttlDays }} />
       <StructuredNavigation />
     </IIIFPlayer>
   ),

--- a/src/components/MetadataDisplay/MetadataDisplay.js
+++ b/src/components/MetadataDisplay/MetadataDisplay.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { useManifestState } from '../../context/manifest-context';
 import { getMetadata } from '@Services/iiif-parser';
 import './MetadataDisplay.scss';
+import cx from 'classnames';
 
 /** 
  * Parse and display metadata, rights, and requiredStatement information
@@ -173,7 +174,10 @@ const MetadataDisplay = ({
       )}
       {hasMetadata
         ? (
-          <div className={`ramp--metadata-display-content${showHeading ? ' with-heading' : ''}`}>
+          <div className={cx(
+            'ramp--metadata-display-content',
+            showHeading && 'with-heading'
+          )}>
             {manifestMetadataBlock}
             {canvasMetadataBlock}
           </div>
@@ -181,7 +185,10 @@ const MetadataDisplay = ({
         : (
           <div
             data-testid='metadata-display-message'
-            className='ramp--metadata-display-message'>
+            className={cx(
+              'ramp--metadata-display-message',
+              showHeading && 'with-heading'
+            )}>
             <p>No valid Metadata is in the Manifest/Canvas(es)</p>
           </div>
         )
@@ -191,7 +198,7 @@ const MetadataDisplay = ({
 };
 
 MetadataDisplay.propTypes = {
-  /** Display only the active Canvas metadata instead of Manifest-level metadata. */
+  /** Display only the active Canvas metadata without Manifest-level metadata. */
   displayOnlyCanvasMetadata: PropTypes.bool,
   /** Display metadata for both the active Canvas and the Manifest. */
   displayAllMetadata: PropTypes.bool,

--- a/src/components/MetadataDisplay/MetadataDisplay.scss
+++ b/src/components/MetadataDisplay/MetadataDisplay.scss
@@ -10,7 +10,6 @@
   .ramp--metadata-display-title {
     border: 0.05rem solid vars.$primaryLight;
     border-radius: 0.25rem 0.25rem 0 0;
-    margin-bottom: 1rem;
     background: vars.$primaryLightest;
 
     h4 {
@@ -30,7 +29,12 @@
 
     &.with-heading {
       border: 0.05rem solid vars.$primaryLight;
+      border-top: none;
       padding: 1rem;
+      // Remove top margin when heading is displayed
+      >dl {
+        margin-top: 0;
+      }
     }
 
     >span {
@@ -62,5 +66,11 @@
     a {
       color: vars.$primaryGreenDark;
     }
+  }
+
+  .ramp--metadata-display-message.with-heading {
+    border: 0.05rem solid vars.$primaryLight;
+    border-top: none;
+    padding: 1rem;
   }
 }

--- a/src/components/MetadataDisplay/MetadataDisplay.stories.jsx
+++ b/src/components/MetadataDisplay/MetadataDisplay.stories.jsx
@@ -14,6 +14,16 @@ export default {
   },
 };
 
+/* Default state for the MetadataDisplay component */
+const defaultState = {
+  displayOnlyCanvasMetadata: false,
+  displayAllMetadata: false,
+  displayTitle: true,
+  showHeading: true,
+  itemHeading: 'Item Details',
+  sectionHeading: 'Section Details',
+};
+
 export const ManifestMetadata = {
   name: 'Manifest Metadata',
   argTypes: {
@@ -25,6 +35,7 @@ export const ManifestMetadata = {
     </IIIFPlayer>
   ),
   args: {
+    ...defaultState,
     manifestUrl: `${config.url}/storybook-manifests/${config.env}/lunchroom-manners.json`,
   },
 };
@@ -40,6 +51,7 @@ export const CanvasMetadata = {
     </IIIFPlayer>
   ),
   args: {
+    ...defaultState,
     manifestUrl: `${config.url}/storybook-manifests/${config.env}/playlist-manifest.json`,
   },
 };

--- a/src/components/StructuredNavigation/StructuredNavigation.js
+++ b/src/components/StructuredNavigation/StructuredNavigation.js
@@ -352,7 +352,7 @@ const StructuredNavigation = ({ showAllSectionsButton = false, sectionsHeading =
 
 StructuredNavigation.propTypes = {
   /** Show/hide a collapse/expand all sections button with a text heading (given as the value for the `sectionHeading` prop) above the structures.
-   * This is only visible when the Manifest has collapsible structures even when this prop is turned on (**added in `@samvera/ramp@3.3.0`**) */
+   * This is only visible when the Manifest has collapsible structures even when this prop is turned on (**added in `@samvera/ramp@3.3.0`**). */
   showAllSectionsButton: PropTypes.bool,
   /** Label shown next to the collapse/expand all sections button  (**added in `@samvera/ramp@3.3.0`**). */
   sectionsHeading: PropTypes.string,

--- a/src/components/Transcript/Transcript.js
+++ b/src/components/Transcript/Transcript.js
@@ -563,26 +563,26 @@ Transcript.propTypes = {
   playerID: PropTypes.string.isRequired,
   /** URL of the Manifest used with the player identified by `playerID` prop with `supplementing`
    * annotations. Either this or `transcripts` prop is required and when both props are defined,
-   * `transcripts` prop takes precedence. (**added in `@samvera/ramp@3.0.0`**) */
+   * `transcripts` prop takes precedence (**added in `@samvera/ramp@3.0.0`**). */
   manifestUrl: PropTypes.string,
   /** Show/hide embedded metadata as per the 
    * [FADGI guidelines](https://www.digitizationguidelines.gov/guidelines/FADGI_WebVTT_embed_guidelines_v0.1_2024-04-18.pdf)
-   * in the header of a given WebVTT file (**added in `@samvera/ramp@4.0.1`**) */
+   * in the header of a given WebVTT file (**added in `@samvera/ramp@4.0.1`**). */
   showMetadata: PropTypes.bool,
-  /** Show/hide NOTE comments from SRT/VTT timed-text files. (**added in `@samvera/ramp@3.2.0`**) */
+  /** Show/hide NOTE comments from SRT/VTT timed-text files (**added in `@samvera/ramp@3.2.0`**). */
   showNotes: PropTypes.bool,
   /** Truncate long cues to a given line count with a Show more/less toggle. When configured, it truncates
    * lengthy cues in the **timed transcripts** to only display the defined `textLineLimit` number of lines.
    * 
    * Partial initialization applies defaults for missing keys. _Since the words are not broken in the display,
-   * sometimes the lines shown could be +/- 1 of the given `textLineLimit` value_ (**added in @samvera/ramp@5.0.0**) */
+   * sometimes the lines shown could be +/- 1 of the given `textLineLimit` value_ (**added in @samvera/ramp@5.0.0**). */
   showMoreSettings: PropTypes.shape({
     enableShowMore: PropTypes.bool,
     textLineLimit: PropTypes.number
   }),
   /** Search configuration for transcript search feature. Pass `false` to disable search, or a key-value pair object
-   * to configure initial search query, show/hide markers, custom matcher/sorter callback function, and matchesOnly mode.
-   * (**added in @samvera/ramp@v3.2.0**) */
+   * to configure initial search query, show/hide markers, custom matcher/sorter callback function, and matchesOnly mode
+   * (**added in @samvera/ramp@v3.2.0**). */
   search: PropTypes.oneOf([
     PropTypes.bool,
     PropTypes.shape({

--- a/src/components/Transcript/Transcript.stories.jsx
+++ b/src/components/Transcript/Transcript.stories.jsx
@@ -21,31 +21,32 @@ const propControls = {
   playerID: { table: { disable: true } },
   showMoreSettings: { table: { disable: true } },
   search: { table: { disable: true } },
+  transcripts: { table: { disable: true } },
   // Show more settings for cues
   enableShowMore: {
     control: { type: 'boolean' },
-    description: 'Enable Show more/less toggle for long annotation texts',
+    description: 'Enable \'Show more/less\' toggle for longer cues.',
     table: { category: 'showMoreSettings' },
   },
   textLineLimit: {
     control: { type: 'number', min: 1 },
-    description: 'Number of lines in the cue to show before truncating',
+    description: 'Number of lines in the cue to show before truncating longer cues.',
     table: { category: 'showMoreSettings' },
   },
   // Search settings
   enableSearch: {
     control: { type: 'boolean' },
-    description: 'Enable/disable the transcript search feature',
+    description: 'Enable/disable the transcript search feature.',
     table: { category: 'search' },
   },
   showMarkers: {
     control: { type: 'boolean' },
-    description: 'Show/hide search hit markers',
+    description: 'Show/hide search hit markers in the player\'s progress-bar rail.',
     table: { category: 'search' },
   },
   matchesOnly: {
     control: { type: 'boolean' },
-    description: 'Only display transcript lines with search hits',
+    description: 'Only display cues with search hits for the current search query.',
     table: { category: 'search' },
   },
 };
@@ -176,13 +177,6 @@ const NonRampPlayer = ({ playerID, source }) => {
 export const DecoupledTranscripts = {
   tags: ['!dev'], // Remove this story from side-panel and only display in docs
   argTypes: { ...propControls },
-  parameters: {
-    docs: {
-      description: {
-        story: 'Use the primary button for the main call-to-action on a page.',
-      },
-    },
-  },
   render: (args) => (
     <div key={hashStoryArgs(args)}>
       <StubPlayer playerID={args.playerID} />
@@ -199,8 +193,6 @@ export const DecoupledManifestUrl = {
   name: 'With manifestUrl prop and Ramp player [decoupled]',
   argTypes: {
     ...propControls,
-    // Remove 'transcripts' prop from controls for this example
-    transcripts: { table: { disable: true } },
     // Remove showMarkers prop from controls because without Context providers search hit markers don't work
     showMarkers: { table: { disable: true } }
   },
@@ -227,32 +219,41 @@ export const WithExternalPlayer = {
     // Use a separate category to facilitate providing external media source URL for the non-Ramp player
     sourceUrl: {
       control: { type: 'text' },
-      description: 'Media file URL used to set up the non-Ramp player (not a Transcript prop)',
+      description: 'Media file URL to set as the `src` attribute of the non-Ramp player on the page (not a Transcript prop)',
       table: { category: 'external player' },
     },
     // Remove showMarkers prop from controls because without Context providers search hit markers don't work
-    showMarkers: { table: { disable: true } }
+    showMarkers: { table: { disable: true } },
+    transcripts: {
+      control: { type: 'object' },
+      description: 'Array of transcripts for the player in `[{ title: string, url: string }]` format. Since this instance with the\
+      external player has a single Canvas, the prop is set to accept only a list of transcripts.\
+      IIIF Manifests, Word documents (.docx), plain text files, WebVTT, and SRT can be given as transcripts. \
+      To identify machine generated transcripts type `Machine generated/machine-generated` in paranthesis after the title of\
+      the transcript. **Please edit the entire object at once using the edit icon next to the value.**',
+      table: { category: 'external player' },
+    }
   },
-  render: (args) => (
-    <div key={hashStoryArgs(args)}>
-      <NonRampPlayer
-        playerID={args.playerID}
-        source={args.sourceUrl}
-      />
-      <Transcript {...buildProps(args)} />
-    </div>
-  ),
+  render: ((args) => {
+    const { transcripts, ...rest } = args;
+    const transcriptProp = [{ canvasId: 0, items: transcripts }];
+    const storyArgs = { ...rest, transcripts: transcriptProp };
+    return (
+      <div key={hashStoryArgs(storyArgs)}>
+        <NonRampPlayer
+          playerID={storyArgs.playerID}
+          source={storyArgs.sourceUrl}
+        />
+        <Transcript {...buildProps(storyArgs)} />
+      </div>
+    );
+  }),
   args: {
     ...defaultState,
     transcripts: [
-      {
-        canvasId: 0,
-        items: [
-          { title: 'Structured JSON object list', url: `${config.url}/transcripts/lunchroom_base.json` },
-          { title: 'WebVTT Transcript (machine generated)', url: `${config.url}/lunchroom_manners/lunchroom_manners.vtt` },
-          { title: 'SRT Transcript', url: `${config.url}/lunchroom_manners/lunchroom_manners.srt` },
-        ]
-      }
+      { title: 'Structured JSON object list', url: `${config.url}/transcripts/lunchroom_base.json` },
+      { title: 'WebVTT Transcript (machine generated)', url: `${config.url}/lunchroom_manners/lunchroom_manners.vtt` },
+      { title: 'SRT Transcript', url: `${config.url}/lunchroom_manners/lunchroom_manners.srt` },
     ],
     sourceUrl: `${config.url}/lunchroom_manners/medium/lunchroom_manners_512kb.mp4`
   },
@@ -263,8 +264,6 @@ export const WithStateProviders = {
   argTypes: {
     ...propControls,
     manifestUrl: manifestUrlControl,
-    // Remove 'transcripts' prop from controls for this example
-    transcripts: { table: { disable: true } },
   },
   render: (args) => (
     <IIIFPlayer key={hashStoryArgs(args)} manifestUrl={args.manifestUrl}>


### PR DESCRIPTION
Related issue: #972 

Changes in this PR:
- enable prop descriptions in the prop controls panel using `parameters: { controls: { ..., expanded: true } }` in `preview.js`
- override some of the prop descriptions populated from the `.js` file's prop descriptions to simplify the role of the prop
- add a new style sheet for styling components and others in the Storybook docs site as needed

Additionally, I enabled `code` tab in the control panel using `docs: { codePanel: true }` in `preview.js`