### PR TITLE
Logout UI for IIIF Auth

### DIFF
--- a/src/components/MediaPlayer/MediaPlayer.js
+++ b/src/components/MediaPlayer/MediaPlayer.js
@@ -8,6 +8,7 @@ import { useErrorBoundary } from 'react-error-boundary';
 import { IS_ANDROID, IS_IPAD, IS_IPHONE, IS_MOBILE, IS_SAFARI, IS_TOUCH_ONLY } from '@Services/browser';
 import { useMediaPlayer, useSetupPlayer } from '@Services/ramp-hooks';
 import { loadVideoJSLanguage } from '@Services/videojs-language-loader';
+import { requestLogout } from '@Services/auth-service';
 
 const PLAYER_ID = 'iiif-media-player';
 
@@ -50,7 +51,7 @@ const MediaPlayer = ({
   let videoJSLangMap = useRef('{}');
   const [languageLoaded, setLanguageLoaded] = useState(false);
 
-  const { canvasIsEmpty, canvasIndex, isMultiCanvased, lastCanvasIndex } = useMediaPlayer();
+  const { canvasIsEmpty, canvasIndex, isMultiCanvased, lastCanvasIndex, resetPlayerContainer } = useMediaPlayer();
   const authService = allCanvases[canvasIndex]?.authService ?? null;
 
   const {
@@ -176,7 +177,7 @@ const MediaPlayer = ({
             enablePlaybackRate ? 'playbackRateMenuButton' : '',
             enablePIP ? 'pictureInPictureToggle' : '',
             enableFileDownload ? 'videoJSFileDownload' : '',
-            auth.status === 'authorized' ? 'VideoJSAuthMenu' : '',
+            (auth.status === 'authorized' && !isVideo) ? 'VideoJSAuthMenu' : '',
             'fullscreenToggle',
             // 'vjsYo',             custom component
           ],
@@ -191,10 +192,14 @@ const MediaPlayer = ({
             controlText: 'Alternate resource download',
             files: renderingFiles,
           },
-          VideoJSAuthMenu: {
+          VideoJSAuthMenu: (auth.status === 'authorized' && !isVideo) && {
             title: 'Authenticated',
             label: authService?.logoutService?.label,
-            onLogout: () => manifestDispatch({ type: 'logout' }),
+            onLogout: () => {
+              resetPlayerContainer();
+              requestLogout(authService.logoutService.id);
+              manifestDispatch({ type: 'logout' });
+            },
           },
           videoJSPreviousButton: isMultiCanvased &&
             { canvasIndex, switchPlayer },

--- a/src/components/MediaPlayer/MediaPlayer.js
+++ b/src/components/MediaPlayer/MediaPlayer.js
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import VideoJSPlayer from '@Components/MediaPlayer/VideoJS/VideoJSPlayer';
 import { playerHotKeys } from '@Services/utility-helpers';
-import { useManifestState } from '../../context/manifest-context';
+import { useManifestState, useManifestDispatch } from '../../context/manifest-context';
 import { usePlayerState } from '../../context/player-context';
 import { useErrorBoundary } from 'react-error-boundary';
 import { IS_ANDROID, IS_IPAD, IS_IPHONE, IS_MOBILE, IS_SAFARI, IS_TOUCH_ONLY } from '@Services/browser';
@@ -36,6 +36,7 @@ const MediaPlayer = ({
   resumeCache = { enable: false, ttlDays: 30, maxItems: 200 },
 }) => {
   const manifestState = useManifestState();
+  const manifestDispatch = useManifestDispatch();
   const playerState = usePlayerState();
   const { showBoundary } = useErrorBoundary();
 
@@ -175,6 +176,7 @@ const MediaPlayer = ({
             enablePlaybackRate ? 'playbackRateMenuButton' : '',
             enablePIP ? 'pictureInPictureToggle' : '',
             enableFileDownload ? 'videoJSFileDownload' : '',
+            auth.status === 'authorized' ? 'VideoJSAuthMenu' : '',
             'fullscreenToggle',
             // 'vjsYo',             custom component
           ],
@@ -188,6 +190,11 @@ const MediaPlayer = ({
             title: 'Download Files',
             controlText: 'Alternate resource download',
             files: renderingFiles,
+          },
+          VideoJSAuthMenu: {
+            title: 'Authenticated',
+            label: authService?.logoutService?.label,
+            onLogout: () => manifestDispatch({ type: 'logout' }),
           },
           videoJSPreviousButton: isMultiCanvased &&
             { canvasIndex, switchPlayer },

--- a/src/components/MediaPlayer/VideoJS/AuthOverlay.js
+++ b/src/components/MediaPlayer/VideoJS/AuthOverlay.js
@@ -62,7 +62,7 @@ function AuthOverlay({ authService, authStatus, isVideo, onTokenReceived, onAuth
       });
   }, [authStatus]);
 
-  // Close the logout menu on outside click or Escape, and restore focus to the badge button
+  // Close the logout menu on outside click
   useEffect(() => {
     if (!menuOpen) return;
 
@@ -213,23 +213,25 @@ function AuthOverlay({ authService, authStatus, isVideo, onTokenReceived, onAuth
           onClick={() => setMenuOpen((mo) => !mo)}
           aria-haspopup='true' aria-expanded={menuOpen}
           aria-label={`Account menu for sign-out`}
+          data-testid='auth-badge'
         >
           <UserIcon />
           <span className='ramp--auth-overlay__badge-name'>Authenticated</span>
           <SearchArrow flip={menuOpen} />
         </button>
         {menuOpen && (
-          <div className='ramp--auth-overlay__badge-menu' role='menu'>
+          <div className='ramp--auth-overlay__badge-menu' role='menu' data-testid='auth-badge-menu'>
             {logoutService.label && (
-              <>
+              <div data-testid='auth-badge-labelitem'>
                 <p className='ramp--auth-overlay__badge-menu-name'>{logoutService.label}</p>
                 <div className='ramp--auth-overlay__badge-menu-divider' />
-              </>
+              </div>
             )}
             <button
               className='ramp--auth-overlay__badge-menu-logout'
               onClick={handleLogout}
               role='menuitem'
+              data-testid='auth-badge-logout-btn'
             >
               <SignOutIcon /> Log out
             </button>
@@ -259,7 +261,7 @@ function AuthOverlay({ authService, authStatus, isVideo, onTokenReceived, onAuth
         ) : (
           <>
             {heading && (
-              <div className='ramp--auth-overlay__header' data-testid='auth-overlay-heading'>
+              <div className='ramp--auth-overlay__header'>
                 <span dangerouslySetInnerHTML={{ __html: sanitizeHTML(heading) }} />
               </div>
             )}

--- a/src/components/MediaPlayer/VideoJS/AuthOverlay.js
+++ b/src/components/MediaPlayer/VideoJS/AuthOverlay.js
@@ -206,6 +206,13 @@ function AuthOverlay({ authService, authStatus, isVideo, onTokenReceived, onAuth
       onLogout();
     };
 
+    const handleLogoutKeyDown = (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        handleLogout();
+      }
+    };
+
     return (
       <div className='ramp--auth-overlay__badge-container' ref={badgeRef}>
         <button
@@ -214,6 +221,7 @@ function AuthOverlay({ authService, authStatus, isVideo, onTokenReceived, onAuth
           aria-haspopup='true' aria-expanded={menuOpen}
           aria-label={`Account menu for sign-out`}
           data-testid='auth-badge'
+          role='button'
         >
           <UserIcon />
           <span className='ramp--auth-overlay__badge-name'>Authenticated</span>
@@ -230,8 +238,9 @@ function AuthOverlay({ authService, authStatus, isVideo, onTokenReceived, onAuth
             <button
               className='ramp--auth-overlay__badge-menu-logout'
               onClick={handleLogout}
+              onKeyDown={handleLogoutKeyDown}
               role='menuitem'
-              data-testid='auth-badge-logout-btn'
+              data-testid='auth-badge-logout-button'
             >
               <SignOutIcon /> Log out
             </button>

--- a/src/components/MediaPlayer/VideoJS/AuthOverlay.js
+++ b/src/components/MediaPlayer/VideoJS/AuthOverlay.js
@@ -201,11 +201,9 @@ function AuthOverlay({ authService, authStatus, isVideo, onTokenReceived, onAuth
 
     const handleLogout = () => {
       setMenuOpen(false);
-      requestLogout(logoutService.id)
-        .catch(() => { })
-        .finally(() => {
-          onLogout();
-        });
+      // Requires requestLogout to be called here for the new tab to open
+      requestLogout(logoutService.id);
+      onLogout();
     };
 
     return (

--- a/src/components/MediaPlayer/VideoJS/AuthOverlay.js
+++ b/src/components/MediaPlayer/VideoJS/AuthOverlay.js
@@ -1,30 +1,39 @@
 import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { getLabelValue, sanitizeHTML } from '@Services/utility-helpers';
-import { probeResource, requestTokenViaIframe } from '@Services/auth-service';
+import { probeResource, requestLogout, requestTokenViaIframe } from '@Services/auth-service';
+import { SearchArrow, SignOutIcon, UserIcon } from '@Services/svg-icons';
 import './VideoJSPlayer.scss';
 
 /**
  * Display authentication dialog and handle login interaction for IIIF resources
- * protected by IIIF Auth 2.0 spec. 
+ * protected by IIIF Auth 2.0 spec.
  * It is rendered over the VideoJS player when a Canvas has an AuthProbeService2 defined.
  * The flow is as follows;
  * 1. On page load: probe the resource without a token to determine if login is required
  * 2. Login: performs the authnentication flow based on the access service profile and gets a token
  * 3. On token received: re-probe with token to confirm authorization, or show error if probe fails
+ * 4. On authorized: shows a persistent authenticated badge for video players with 'Log out' option when
+ * there is a logout service with type='AuthLogoutService2'. Audio players show an equivalent control
+ * in the player's contro-bar instead (see VideoJSAuthMenu custom component).
  * @param {Object} props
  * @param {Object} props.authService
  * @param {String} props.authStatus
+ * @param {Boolean} props.isVideo
  * @param {Function} props.onTokenReceived
  * @param {Function} props.onAuthStatus
+ * @param {Function} props.onLogout
  */
-function AuthOverlay({ authService, authStatus, onTokenReceived, onAuthStatus }) {
+function AuthOverlay({ authService, authStatus, isVideo, onTokenReceived, onAuthStatus, onLogout }) {
   const [errorMessage, setErrorMessage] = useState(null);
   const [isLoggingIn, setIsLoggingIn] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+
   const loginTabRef = useRef(null);
   const pollIntervalRef = useRef(null);
+  const badgeRef = useRef(null);
 
-  const { probe, accessService, tokenService, restricted } = authService;
+  const { probe, accessService, tokenService, logoutService, restricted } = authService;
 
   useEffect(() => {
     /* When the resource access is restricted without required access services, update auth status to 'error' in state and
@@ -36,7 +45,8 @@ function AuthOverlay({ authService, authStatus, onTokenReceived, onAuthStatus })
       setErrorMessage({ heading: restrictedHeading, note: restrictedNote });
       return;
     }
-    // Otherwise, probe without token on page load to determine if login is required
+    // Otherwise, probe without token on page load and again after logout resets status to
+    // 'idle' to determine whether login is required
     if (authStatus !== 'idle') return;
     onAuthStatus('probing');
     probeResource(probe.id, null)
@@ -50,7 +60,33 @@ function AuthOverlay({ authService, authStatus, onTokenReceived, onAuthStatus })
       .catch(() => {
         onAuthStatus('login-required');
       });
-  }, []);
+  }, [authStatus]);
+
+  // Close the logout menu on outside click or Escape, and restore focus to the badge button
+  useEffect(() => {
+    if (!menuOpen) return;
+
+    const handleClickOutside = (e) => {
+      if (badgeRef.current && !badgeRef.current.contains(e.target)) {
+        setMenuOpen(false);
+      }
+    };
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape') {
+        setMenuOpen(false);
+        badgeRef.current?.querySelector('button')?.focus();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleKeyDown);
+
+    // Cleanup the event handlers
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [menuOpen]);
 
   // Cleanup login tab pollin interval on unmount
   useEffect(() => {
@@ -78,10 +114,8 @@ function AuthOverlay({ authService, authStatus, onTokenReceived, onAuthStatus })
           onTokenReceived(accessToken);
           onAuthStatus('authorized');
         } else {
-          const probeErrorHeading = getLabelValue(probe?.errorHeading) || 'Something went wrong';
-          const errHeading = getLabelValue(heading) || probeErrorHeading;
-          const probeErrorNote = getLabelValue(probe?.errorNote) || 'Could not confirm authorization with token.';
-          const errNote = getLabelValue(note) || probeErrorNote;
+          const errHeading = getLabelValue(heading) || probe.errorHeading;
+          const errNote = getLabelValue(note) || probe.errorNote;
           setErrorMessage({ heading: errHeading, note: errNote });
           onAuthStatus('error');
           setIsLoggingIn(false);
@@ -89,8 +123,7 @@ function AuthOverlay({ authService, authStatus, onTokenReceived, onAuthStatus })
       })
       .catch(() => {
         setErrorMessage({
-          heading: getLabelValue(tokenService.errorHeading) || 'Authentication failed',
-          note: getLabelValue(tokenService.errorNote) || 'Could not obtain an access token.',
+          heading: tokenService.errorHeading, note: tokenService.errorNote,
         });
         onAuthStatus('error');
         setIsLoggingIn(false);
@@ -151,18 +184,66 @@ function AuthOverlay({ authService, authStatus, onTokenReceived, onAuthStatus })
     onAuthStatus('cancelled');
   };
 
-  const confirmLabel = getLabelValue(accessService?.confirmLabel) || 'Log in';
-  const loginLabel = getLabelValue(accessService?.label) || 'Login';
-  const headingText = getLabelValue(accessService?.heading) ?? null;
-  const noteText = getLabelValue(accessService?.note) ?? null;
-
   // Do not show the auth overlay when auth status doesn't indicate that login is required
-  if (authStatus === 'authorized' || authStatus === 'idle' || authStatus === 'probing' || authStatus === 'cancelled') {
+  if (authStatus === 'idle' || authStatus === 'probing' || authStatus === 'cancelled') {
     return null;
   }
 
+  if (authStatus === 'authorized') {
+    /* When authenticated; display a persistent authenticated badge with a logout menu.
+    Skip this if,
+     - the current player is audio-only, as they show an equivalent control in the control-bar
+     - the logoutService is undefined
+    */
+    if (!isVideo || !logoutService) {
+      return null;
+    }
+
+    const handleLogout = () => {
+      setMenuOpen(false);
+      requestLogout(logoutService.id)
+        .catch(() => { })
+        .finally(() => {
+          onLogout();
+        });
+    };
+
+    return (
+      <div className='ramp--auth-overlay__badge-container' ref={badgeRef}>
+        <button
+          className='ramp--auth-overlay__badge'
+          onClick={() => setMenuOpen((mo) => !mo)}
+          aria-haspopup='true' aria-expanded={menuOpen}
+          aria-label={`Account menu for sign-out`}
+        >
+          <UserIcon />
+          <span className='ramp--auth-overlay__badge-name'>Authenticated</span>
+          <SearchArrow flip={menuOpen} />
+        </button>
+        {menuOpen && (
+          <div className='ramp--auth-overlay__badge-menu' role='menu'>
+            {logoutService.label && (
+              <>
+                <p className='ramp--auth-overlay__badge-menu-name'>{logoutService.label}</p>
+                <div className='ramp--auth-overlay__badge-menu-divider' />
+              </>
+            )}
+            <button
+              className='ramp--auth-overlay__badge-menu-logout'
+              onClick={handleLogout}
+              role='menuitem'
+            >
+              <SignOutIcon /> Log out
+            </button>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  const { confirmLabel, label, heading, note } = accessService;
   return (
-    <div className='ramp--auth-overlay' data-testid='auth-overlay' role='region' aria-label={loginLabel}>
+    <div className='ramp--auth-overlay' data-testid='auth-overlay' role='region' aria-label={label}>
       <div className='ramp--auth-overlay__content'>
         {errorMessage ? (
           <>
@@ -179,15 +260,15 @@ function AuthOverlay({ authService, authStatus, onTokenReceived, onAuthStatus })
           </>
         ) : (
           <>
-            {headingText && (
+            {heading && (
               <div className='ramp--auth-overlay__header' data-testid='auth-overlay-heading'>
-                <span dangerouslySetInnerHTML={{ __html: sanitizeHTML(headingText) }} />
+                <span dangerouslySetInnerHTML={{ __html: sanitizeHTML(heading) }} />
               </div>
             )}
             <div className='ramp--auth-overlay__body'>
-              <p className='ramp--auth-overlay__label' dangerouslySetInnerHTML={{ __html: sanitizeHTML(loginLabel) }} />
-              {noteText && (
-                <p className='ramp--auth-overlay__note' data-testid='auth-overlay-note' dangerouslySetInnerHTML={{ __html: sanitizeHTML(noteText) }} />
+              <p className='ramp--auth-overlay__label' dangerouslySetInnerHTML={{ __html: sanitizeHTML(label) }} />
+              {note && (
+                <p className='ramp--auth-overlay__note' data-testid='auth-overlay-note' dangerouslySetInnerHTML={{ __html: sanitizeHTML(note) }} />
               )}
             </div>
           </>
@@ -212,11 +293,14 @@ AuthOverlay.propTypes = {
     probe: PropTypes.object.isRequired,
     accessService: PropTypes.object,
     tokenService: PropTypes.object,
+    logoutService: PropTypes.object,
     restricted: PropTypes.bool.isRequired,
   }).isRequired,
   authStatus: PropTypes.string.isRequired,
+  isVideo: PropTypes.bool,
   onTokenReceived: PropTypes.func.isRequired,
   onAuthStatus: PropTypes.func.isRequired,
+  onLogout: PropTypes.func,
 };
 
 export default AuthOverlay;

--- a/src/components/MediaPlayer/VideoJS/AuthOverlay.test.js
+++ b/src/components/MediaPlayer/VideoJS/AuthOverlay.test.js
@@ -367,7 +367,7 @@ describe('AuthOverlay', () => {
         fireEvent.click(screen.getByTestId('auth-badge'));
 
         expect(screen.getByTestId('auth-badge-labelitem')).toBeInTheDocument();
-        expect(screen.getByTestId('auth-badge-logout-btn')).toHaveTextContent('Log out');
+        expect(screen.getByTestId('auth-badge-logout-button')).toHaveTextContent('Log out');
       });
 
       test('without a logout label when logoutService doesn\'t have a label', () => {
@@ -377,14 +377,14 @@ describe('AuthOverlay', () => {
         fireEvent.click(screen.getByTestId('auth-badge'));
 
         expect(screen.queryByTestId('auth-badge-labelitem')).not.toBeInTheDocument();
-        expect(screen.getByTestId('auth-badge-logout-btn')).toHaveTextContent('Log out');
+        expect(screen.getByTestId('auth-badge-logout-button')).toHaveTextContent('Log out');
       });
 
       describe('with a logout button that,', () => {
         test('calls requestLogout and onLogout when clicked', () => {
           render(<AuthOverlay {...authorizedProps} />);
           fireEvent.click(screen.getByTestId('auth-badge'));
-          fireEvent.click(screen.getByTestId('auth-badge-logout-btn'));
+          fireEvent.click(screen.getByTestId('auth-badge-logout-button'));
 
           expect(authService.requestLogout).toHaveBeenCalledWith(logoutServiceId);
           expect(onLogoutMock).toHaveBeenCalledTimes(1);
@@ -399,6 +399,15 @@ describe('AuthOverlay', () => {
       const badge = screen.getByTestId('auth-badge');
       fireEvent.click(badge);
       fireEvent.click(badge);
+      expect(screen.queryByTestId('auth-badge-menu')).not.toBeInTheDocument();
+      expect(screen.getByTestId('auth-badge')).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    test('closes the menu when "Escape" key is pressed', () => {
+      render(<AuthOverlay {...authorizedProps} />);
+      const badge = screen.getByTestId('auth-badge');
+      fireEvent.click(badge);
+      fireEvent.keyDown(badge, { key: 'Escape', keyCode: 47 });
       expect(screen.queryByTestId('auth-badge-menu')).not.toBeInTheDocument();
       expect(screen.getByTestId('auth-badge')).toHaveAttribute('aria-expanded', 'false');
     });

--- a/src/components/MediaPlayer/VideoJS/AuthOverlay.test.js
+++ b/src/components/MediaPlayer/VideoJS/AuthOverlay.test.js
@@ -7,28 +7,29 @@ jest.mock('dompurify', () => ({ sanitize: (html) => html }));
 jest.mock('@Services/auth-service', () => ({
   probeResource: jest.fn(),
   requestTokenViaIframe: jest.fn(),
+  requestLogout: jest.fn(),
 }));
 
 const mockAccessService = {
   id: 'http://example.com/auth/login',
   profile: 'active',
-  label: { en: ['Login Required'] },
-  heading: { en: ['Please Log In'] },
-  note: { en: ['This application requires that you log in with your account to view this content.'] },
-  confirmLabel: { en: ['Log In'] },
+  label: 'Login Required',
+  heading: 'Please Log In',
+  note: 'This application requires that you log in with your account to view this content.',
+  confirmLabel: 'Log In',
 };
 
 const defaultAuthService = {
   probe: {
     id: 'http://example.com/auth/probe',
-    errorHeading: { en: ['No access'] },
-    errorNote: { en: ['You do not have permission'] },
+    errorHeading: 'No access',
+    errorNote: 'You do not have permission',
   },
   accessService: mockAccessService,
   tokenService: {
     id: 'http://example.com/auth/token',
-    errorHeading: { en: ['Something went wrong'] },
-    errorNote: { en: ['Could not get a token.'] },
+    errorHeading: 'Something went wrong',
+    errorNote: 'Could not get a token.',
   },
   restricted: false,
 };
@@ -57,22 +58,59 @@ describe('AuthOverlay', () => {
   });
 
   describe('does not render', () => {
-    test('when authStatus=\'authorized\'', () => {
-      render(<AuthOverlay {...props} authStatus='authorized' />);
-      expect(screen.queryByTestId('auth-overlay')).not.toBeInTheDocument();
+    describe('login overlay when', () => {
+      describe('authStatus="authorized"', () => {
+        test('with a logoutService in a video player', () => {
+          render(<AuthOverlay {...props} authStatus='authorized' isVideo={true}
+            authService={{
+              ...defaultAuthService,
+              logoutService: { id: 'http://example.com/auth/logout' }
+            }}
+          />);
+          expect(screen.queryByTestId('auth-overlay')).not.toBeInTheDocument();
+        });
+
+        test('without a logoutService in a video player', () => {
+          render(<AuthOverlay {...props} authStatus='authorized' isVideo={true} />);
+          expect(screen.queryByTestId('auth-overlay')).not.toBeInTheDocument();
+        });
+
+        test('with a logoutService in an audio-only player', () => {
+          render(<AuthOverlay {...props} authStatus='authorized' isVideo={false} />);
+          expect(screen.queryByTestId('auth-overlay')).not.toBeInTheDocument();
+        });
+      });
+
+      test('authStatus="idle" with probeResource returning 200', () => {
+        /* Mock probeResource to return 200, so that auth overlay is not
+         displayed with authStatus='authorized' */
+        authService.probeResource.mockResolvedValue({ status: 200 });
+        render(<AuthOverlay {...props} authStatus='idle' />);
+        expect(screen.queryByTestId('auth-overlay')).not.toBeInTheDocument();
+      });
+
+      test('authStatus="probing"', () => {
+        render(<AuthOverlay {...props} authStatus='probing' />);
+        expect(screen.queryByTestId('auth-overlay')).not.toBeInTheDocument();
+      });
+
+      test('authStatus="cancelled"', () => {
+        render(<AuthOverlay {...props} authStatus='cancelled' />);
+        expect(screen.queryByTestId('auth-overlay')).not.toBeInTheDocument();
+      });
     });
 
-    test('when authStatus=\'idle\'', () => {
-      /* Mock probeResource to return 200, so that auth overlay is not
-       displayed with authStatus='authorizd' */
-      authService.probeResource.mockResolvedValue({ status: 200 });
-      render(<AuthOverlay {...props} authStatus='idle' />);
-      expect(screen.queryByTestId('auth-overlay')).not.toBeInTheDocument();
-    });
+    describe('authenticated badge when authStatus="authorized" for', () => {
+      test('an audio-only player', () => {
+        render(<AuthOverlay {...props} authStatus='authorized' isVideo={false}
+          authService={{ ...defaultAuthService, logoutService: { id: 'http://example.com/auth/logout' } }} />);
+        expect(screen.queryByTestId('auth-badge')).not.toBeInTheDocument();
+      });
 
-    test('when authStatus=\'probing\'', () => {
-      render(<AuthOverlay {...props} authStatus='probing' />);
-      expect(screen.queryByTestId('auth-overlay')).not.toBeInTheDocument();
+      test('a video player when logoutService is undefined', () => {
+        render(<AuthOverlay {...props} authStatus='authorized' isVideo={true} authService={defaultAuthService} />);
+        expect(screen.queryByTestId('auth-badge')).not.toBeInTheDocument();
+      });
     });
   });
 
@@ -101,9 +139,13 @@ describe('AuthOverlay', () => {
     });
 
     describe('restricted overlay (no login/cancel buttons) when', () => {
+      // Null accessService without id
+      const nullAccessService = {
+        heading: 'No access', note: 'You do not have permission'
+      };
       test('accessService is missing; shows probe errorHeading and errorNote', () => {
         render(<AuthOverlay {...props} authStatus='login-required'
-          authService={{ ...defaultAuthService, accessService: null, restricted: true }} />);
+          authService={{ ...defaultAuthService, accessService: nullAccessService, restricted: true }} />);
 
         expect(screen.getByText('No access')).toBeInTheDocument();
         expect(screen.getByText('You do not have permission')).toBeInTheDocument();
@@ -125,7 +167,7 @@ describe('AuthOverlay', () => {
         render(<AuthOverlay {...props} authStatus='login-required'
           authService={{
             probe: { id: 'http://example.com/auth/probe' },
-            accessService: null, tokenService: null, restricted: true
+            accessService: nullAccessService, tokenService: null, restricted: true
           }} />);
 
         expect(screen.getByText('Restricted content')).toBeInTheDocument();
@@ -281,6 +323,95 @@ describe('AuthOverlay', () => {
     test('does not render the overlay when authStatus=\'cancelled\'', () => {
       render(<AuthOverlay {...props} authStatus='cancelled' />);
       expect(screen.queryByTestId('auth-overlay')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('authenticated badge', () => {
+    const onLogoutMock = jest.fn();
+    const logoutServiceId = 'http://example.com/auth/logout';
+    const authorizedProps = {
+      ...props,
+      authStatus: 'authorized',
+      authService: {
+        ...defaultAuthService,
+        logoutService: { id: logoutServiceId, label: 'Log out from Avalon' }
+      },
+      isVideo: true,
+      onLogout: onLogoutMock,
+    };
+
+    afterEach(() => onLogoutMock.mockClear());
+
+    test('renders with an "Authenticated" label', () => {
+      render(<AuthOverlay {...authorizedProps} />);
+      const badge = screen.getByTestId('auth-badge');
+      expect(badge).toBeInTheDocument();
+      expect(badge).toHaveTextContent('Authenticated');
+    });
+
+    test('has the logout menu closed by default', () => {
+      render(<AuthOverlay {...authorizedProps} />);
+      expect(screen.queryByTestId('auth-badge-menu')).not.toBeInTheDocument();
+    });
+
+    describe('opens a logout menu', () => {
+      test('when clicked on the authenticated badge', () => {
+        render(<AuthOverlay {...authorizedProps} />);
+        fireEvent.click(screen.getByTestId('auth-badge'));
+        expect(screen.getByTestId('auth-badge-menu')).toBeInTheDocument();
+        expect(screen.getByTestId('auth-badge')).toHaveAttribute('aria-expanded', 'true');
+      });
+
+      test('with a logout label and a button when logoutService has a label', () => {
+        render(<AuthOverlay {...authorizedProps} />);
+        fireEvent.click(screen.getByTestId('auth-badge'));
+
+        expect(screen.getByTestId('auth-badge-labelitem')).toBeInTheDocument();
+        expect(screen.getByTestId('auth-badge-logout-btn')).toHaveTextContent('Log out');
+      });
+
+      test('without a logout label when logoutService doesn\'t have a label', () => {
+        render(<AuthOverlay {...authorizedProps}
+          authService={{ ...defaultAuthService, logoutService: { id: logoutServiceId } }} />);
+
+        fireEvent.click(screen.getByTestId('auth-badge'));
+
+        expect(screen.queryByTestId('auth-badge-labelitem')).not.toBeInTheDocument();
+        expect(screen.getByTestId('auth-badge-logout-btn')).toHaveTextContent('Log out');
+      });
+
+      describe('with a logout button that,', () => {
+        test('calls requestLogout and onLogout when clicked', () => {
+          render(<AuthOverlay {...authorizedProps} />);
+          fireEvent.click(screen.getByTestId('auth-badge'));
+          fireEvent.click(screen.getByTestId('auth-badge-logout-btn'));
+
+          expect(authService.requestLogout).toHaveBeenCalledWith(logoutServiceId);
+          expect(onLogoutMock).toHaveBeenCalledTimes(1);
+          expect(screen.queryByTestId('auth-badge-menu')).not.toBeInTheDocument();
+          expect(screen.getByTestId('auth-badge')).toHaveAttribute('aria-expanded', 'false');
+        });
+      });
+    });
+
+    test('closes the menu when clicked again', () => {
+      render(<AuthOverlay {...authorizedProps} />);
+      const badge = screen.getByTestId('auth-badge');
+      fireEvent.click(badge);
+      fireEvent.click(badge);
+      expect(screen.queryByTestId('auth-badge-menu')).not.toBeInTheDocument();
+      expect(screen.getByTestId('auth-badge')).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    test('closes the menu when clicked outside', () => {
+      render(<AuthOverlay {...authorizedProps} />);
+      fireEvent.click(screen.getByTestId('auth-badge'));
+      expect(screen.getByTestId('auth-badge-menu')).toBeInTheDocument();
+      expect(screen.getByTestId('auth-badge')).toHaveAttribute('aria-expanded', 'true');
+
+      fireEvent.mouseDown(document.body);
+      expect(screen.queryByTestId('auth-badge-menu')).not.toBeInTheDocument();
+      expect(screen.getByTestId('auth-badge')).toHaveAttribute('aria-expanded', 'false');
     });
   });
 });

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -1648,6 +1648,20 @@ function VideoJSPlayer({
 
   return (
     <div style={{ position: 'relative' }}>
+      {authService && (
+        <AuthOverlay
+          authService={authService}
+          authToken={auth.token}
+          authStatus={auth.status}
+          isVideo={isVideo}
+          onTokenReceived={(token) => manifestDispatch({ token, type: 'setAuthToken' })}
+          onAuthStatus={(status) => manifestDispatch({ status, type: 'setAuthStatus' })}
+          onLogout={() => {
+            resetPlayerContainer();
+            manifestDispatch({ type: 'logout' });
+          }}
+        />
+      )}
       <div data-vjs-player data-canvasindex={cIndexRef.current}>
         {canvasIsEmptyRef.current && (
           <div data-testid="inaccessible-message-display"
@@ -1713,20 +1727,6 @@ function VideoJSPlayer({
         >
         </video>
       </div>
-      {authService && (
-        <AuthOverlay
-          authService={authService}
-          authToken={auth.token}
-          authStatus={auth.status}
-          isVideo={isVideo}
-          onTokenReceived={(token) => manifestDispatch({ token, type: 'setAuthToken' })}
-          onAuthStatus={(status) => manifestDispatch({ status, type: 'setAuthStatus' })}
-          onLogout={() => {
-            resetPlayerContainer();
-            manifestDispatch({ type: 'logout' });
-          }}
-        />
-      )}
       {(hasStructure || isPlaylist) &&
         (<div className="vjs-track-scrubber-container hidden" ref={trackScrubberRef} id="track_scrubber">
           <p className="vjs-time track-currenttime" role="presentation"></p>

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -18,6 +18,7 @@ import {
 } from '@Services/browser';
 import { useLocalStorage } from '@Services/local-storage';
 import { usePlaybackPositions } from '@Services/save-playback-positions';
+import { requestLogout } from '@Services/auth-service';
 import { showResumeModal } from './VideoJSResumeModal';
 import { showErrorModal } from './components/js/VideoJSErrorModal';
 import AuthOverlay from './AuthOverlay';
@@ -113,7 +114,7 @@ function VideoJSPlayer({
   const resumeModalRef = useRef(null);
   const vjsErrorModalRef = useRef(null);
 
-  const { canvasIndex, canvasIsEmpty, isMultiCanvased, lastCanvasIndex } = useMediaPlayer();
+  const { canvasIndex, canvasIsEmpty, isMultiCanvased, lastCanvasIndex, resetPlayerContainer } = useMediaPlayer();
   const authService = allCanvases[canvasIndex]?.authService ?? null;
 
   const { isPlaylist, renderingFiles, srcIndex, switchPlayer }
@@ -818,7 +819,7 @@ function VideoJSPlayer({
         - appearance of the player: big play button and aspect ratio of the player
         based on media type
         - file download menu
-        - logout menu for authenticated resources
+        - auth menu for authenticated resources
     */
     if (player.getChild('controlBar') != null && !canvasIsEmpty) {
       const controlBar = player.getChild('controlBar');
@@ -913,11 +914,14 @@ function VideoJSPlayer({
           // Index of the full-screen toggle in the player's control bar
           const fullscreenIndex = controlBar.children()
             .findIndex((c) => c.name_ == 'FullscreenToggle');
-          console.log(authService?.logoutService?.label);
           controlBar.addChild('VideoJSAuthMenu', {
             title: 'Authenticated',
             label: authService?.logoutService?.label,
-            onLogout: () => manifestDispatch({ type: 'logout' }),
+            onLogout: () => {
+              resetPlayerContainer();
+              requestLogout(authService.logoutService.id);
+              manifestDispatch({ type: 'logout' });
+            },
           }, fullscreenIndex);
         } else {
           controlBar.removeChild('VideoJSAuthMenu');
@@ -1717,7 +1721,10 @@ function VideoJSPlayer({
           isVideo={isVideo}
           onTokenReceived={(token) => manifestDispatch({ token, type: 'setAuthToken' })}
           onAuthStatus={(status) => manifestDispatch({ status, type: 'setAuthStatus' })}
-          onLogout={() => manifestDispatch({ type: 'logout' })}
+          onLogout={() => {
+            resetPlayerContainer();
+            manifestDispatch({ type: 'logout' });
+          }}
         />
       )}
       {(hasStructure || isPlaylist) &&

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -37,6 +37,7 @@ import VideoJSPreviousButton from './components/js/VideoJSPreviousButton';
 import VideoJSTitleLink from './components/js/VideoJSTitleLink';
 import VideoJSTrackScrubber from './components/js/VideoJSTrackScrubber';
 import VideoJSADButton from './components/js/VideoJSADButton';
+import VideoJSAuthMenu from './components/js/VideoJSAuthMenu';
 
 /**
  * Module to setup VideoJS instance on initial page load and update
@@ -817,6 +818,7 @@ function VideoJSPlayer({
         - appearance of the player: big play button and aspect ratio of the player
         based on media type
         - file download menu
+        - logout menu for authenticated resources
     */
     if (player.getChild('controlBar') != null && !canvasIsEmpty) {
       const controlBar = player.getChild('controlBar');
@@ -903,6 +905,22 @@ function VideoJSPlayer({
           controlBar.addChild('videoJSFileDownload', { ...fileOptions },
             fileDownloadIndex
           );
+        }
+      }
+
+      if (authService?.logoutService && auth.status === 'authorized') {
+        if (!isVideo) {
+          // Index of the full-screen toggle in the player's control bar
+          const fullscreenIndex = controlBar.children()
+            .findIndex((c) => c.name_ == 'FullscreenToggle');
+          console.log(authService?.logoutService?.label);
+          controlBar.addChild('VideoJSAuthMenu', {
+            title: 'Authenticated',
+            label: authService?.logoutService?.label,
+            onLogout: () => manifestDispatch({ type: 'logout' }),
+          }, fullscreenIndex);
+        } else {
+          controlBar.removeChild('VideoJSAuthMenu');
         }
       }
     }
@@ -1691,13 +1709,15 @@ function VideoJSPlayer({
         >
         </video>
       </div>
-      {authService && auth?.status !== 'authorized' && (
+      {authService && (
         <AuthOverlay
           authService={authService}
           authToken={auth.token}
           authStatus={auth.status}
+          isVideo={isVideo}
           onTokenReceived={(token) => manifestDispatch({ token, type: 'setAuthToken' })}
           onAuthStatus={(status) => manifestDispatch({ status, type: 'setAuthStatus' })}
+          onLogout={() => manifestDispatch({ type: 'logout' })}
         />
       )}
       {(hasStructure || isPlaylist) &&

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.scss
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.scss
@@ -119,4 +119,68 @@
       background-color: vars.$primaryGreenDarker;
     }
   }
+
+  /* Styles for persistent authenticated badge in Video players 
+  for authenticated resources */
+  &__badge-container {
+    position: absolute;
+    top: 0.5em;
+    right: 0.5em;
+    z-index: 102;
+    font-size: 1rem;
+  }
+
+  &__badge {
+    display: flex;
+    align-items: center;
+    gap: 0.4em;
+    border: none;
+    padding: 0.3em 0.6em;
+    background-color: transparent;
+    font-size: 0.8em;
+    font-weight: bold;
+    cursor: pointer;
+  }
+
+  &__badge-name {
+    max-width: 10em;
+    color: vars.$primaryLightest;
+    white-space: nowrap;
+  }
+
+  &__badge-menu {
+    min-width: 11em;
+    border: 1px solid vars.$primaryDark;
+    border-radius: 0.4em;
+    background-color: vars.$primaryDarker;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  &__badge-menu-name {
+    margin: 0;
+    padding: 0.6em;
+    color: vars.$primaryLightest;
+    font-size: 0.85em;
+    max-width: 11em;
+  }
+
+  &__badge-menu-divider {
+    border-top: 1px solid vars.$primaryDark;
+  }
+
+  &__badge-menu-logout {
+    display: flex;
+    border: none;
+    background: transparent;
+    color: vars.$primaryLightest;
+    width: 100%;
+    padding: 0.6em;
+    font-size: 0.85em;
+    cursor: pointer;
+
+    &:hover {
+      background-color: rgba(255, 255, 255, 0.08);
+    }
+  }
 }

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.scss
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.scss
@@ -128,6 +128,7 @@
     right: 0.5em;
     z-index: 102;
     font-size: 1rem;
+    color: #767676;
   }
 
   &__badge {

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.test.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.test.js
@@ -3,9 +3,17 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { ErrorBoundary } from 'react-error-boundary';
 import MediaPlayer from '@Components/MediaPlayer/MediaPlayer';
 import { withManifestAndPlayerProvider, manifestState } from '@Services/testing-helpers';
+import * as authService from '@Services/auth-service';
 import videoManifest from '@TestData/lunchroom-manners';
 import playlistManifest from '@TestData/playlist';
 import singleCanvasManifest from '@TestData/single-canvas';
+import authManifest from '@TestData/auth-manifest';
+
+// Mock 'requestLogout' from auth-service module
+jest.mock('@Services/auth-service', () => ({
+  ...jest.requireActual('@Services/auth-service'),
+  requestLogout: jest.fn(),
+}));
 
 describe('VideoJSPlayer component', () => {
   const MANIFEST_URL = 'https://example.com/manifest/lunchroom_manners';
@@ -52,11 +60,11 @@ describe('VideoJSPlayer component', () => {
   };
 
   // Helper function to trigger 'loadedmetadata' event on the video element
-  const triggerLoadedMetadata = async () => {
+  const triggerLoadedMetadata = async (testid) => {
     await waitFor(() => {
-      expect(screen.getAllByTestId('videojs-video-element').length).toBeGreaterThan(0);
+      expect(screen.getAllByTestId(testid).length).toBeGreaterThan(0);
     });
-    const player = screen.getAllByTestId('videojs-video-element')[0].player;
+    const player = screen.getAllByTestId(testid)[0].player;
     // Wait for player 'ready' to fire, i.e. player.canvasIndex is set
     await waitFor(() => {
       expect(player.canvasIndex).toBeDefined();
@@ -71,7 +79,7 @@ describe('VideoJSPlayer component', () => {
       manifest = videoManifest, canvasIndex = 0, manifestOverrides = {},
       props = { resumeCache: { enable: true } } } = {}) => {
       await renderPlayer({ manifest, canvasIndex, manifestOverrides, props });
-      await triggerLoadedMetadata();
+      await triggerLoadedMetadata('videojs-video-element');
     };
 
     test('doesn\'t render resume modal with default props', async () => {
@@ -320,7 +328,7 @@ describe('VideoJSPlayer component', () => {
     describe('when all sources of a single-source Canvas fail', () => {
       beforeEach(async () => {
         await renderPlayer({ manifest: singleCanvasManifest, canvasIndex: 0 });
-        player = await triggerLoadedMetadata();
+        player = await triggerLoadedMetadata('videojs-video-element');
         // Mark the source as failed to trigger error modal
         player.failedSources = player.currentSources().map((s) => s.src);
         // Fire the 'error' event by setting player.error(err)
@@ -346,7 +354,7 @@ describe('VideoJSPlayer component', () => {
     describe('when all multi-source segments of a Canvas fail', () => {
       beforeEach(async () => {
         await renderPlayer({ manifest: singleCanvasManifest, canvasIndex: 0 });
-        player = await triggerLoadedMetadata();
+        player = await triggerLoadedMetadata('videojs-video-element');
         // Set player.targets to simulate a multi-source Canvas
         player.targets = [
           { start: 0, end: 330, altStart: 0, duration: 330 },
@@ -377,7 +385,7 @@ describe('VideoJSPlayer component', () => {
     describe('when a CORS error exhausts HLS playlist retries', () => {
       test('renders the error display modal with the default message', async () => {
         await renderPlayer({ manifest: singleCanvasManifest, canvasIndex: 0 });
-        const player = await triggerLoadedMetadata();
+        const player = await triggerLoadedMetadata('videojs-video-element');
         const mockVHSTech = {
           vhs: {
             playlistController_: {
@@ -480,4 +488,125 @@ describe('VideoJSPlayer component', () => {
     });
   });
 
+  describe('feature: IIIF Auth logout UI', () => {
+    describe('for video player', () => {
+      test('when not authorized; doesn\'t render auth badge inside the player', async () => {
+        await renderPlayer({
+          manifest: authManifest,
+          canvasIndex: 0,
+          manifestOverrides: { auth: { token: null, status: 'idle' } },
+        });
+        /* No need to call triggerLoadedMetadata() to mimic the player events, as this instance doesn't
+        create the VideoJS instance yet */
+
+        expect(screen.getAllByTestId('videojs-video-element').length).toBeGreaterThan(0);
+        expect(screen.queryByTestId('videojs-auth-menu')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('auth-badge')).not.toBeInTheDocument();
+      });
+
+      describe('when authorized', () => {
+        let player;
+        beforeEach(async () => {
+          await renderPlayer({
+            manifest: authManifest,
+            canvasIndex: 0,
+            manifestOverrides: { auth: { token: 'valid-token', status: 'authorized' } },
+          });
+          player = await triggerLoadedMetadata('videojs-video-element');
+        });
+
+        test('renders auth badge inside the player', async () => {
+          expect(screen.getAllByTestId('videojs-video-element').length).toBeGreaterThan(0);
+          expect(screen.getByTestId('auth-badge')).toBeInTheDocument();
+        });
+
+        test('doesn\'t render auth menu control in the control-bar', () => {
+          expect(screen.getAllByTestId('videojs-video-element').length).toBeGreaterThan(0);
+          expect(screen.queryByTestId('videojs-auth-menu')).not.toBeInTheDocument();
+        });
+
+        test('renders a logout button that calls "requestLogout" when clicked', async () => {
+          expect(screen.getByTestId('auth-badge')).toBeInTheDocument();
+
+          // Open the auth menu and click log out button
+          fireEvent.click(screen.getByTestId('auth-badge'));
+          fireEvent.click(screen.getByTestId('auth-badge-logout-button'));
+
+          expect(authService.requestLogout).toHaveBeenCalledWith('http://example.com/auth/logout');
+        });
+
+        test('disables player and restores aspect-ratio on logout', async () => {
+          const aspectRatioSpy = jest.spyOn(player, 'aspectRatio');
+
+          // Open the auth menu and click log out button
+          fireEvent.click(screen.getByTestId('auth-badge'));
+          fireEvent.click(screen.getByTestId('auth-badge-logout-button'));
+
+          expect(player.hasClass('vjs-audio-only-mode')).toBeFalsy();
+          expect(aspectRatioSpy).toHaveBeenCalledWith('16:9');
+          expect(player.hasClass('vjs-disabled')).toBe(true);
+        });
+      });
+    });
+
+    describe('for audio player', () => {
+      test('when not authorized; doesn\'t render auth menu control in the control-bar', async () => {
+        await renderPlayer({
+          manifest: authManifest,
+          canvasIndex: 2,
+          manifestOverrides: { auth: { token: null, status: 'idle' } },
+        });
+        /* No need to call triggerLoadedMetadata() to mimic the player events, as this instance doesn't
+        create the VideoJS instance yet */
+
+        expect(screen.getAllByTestId('videojs-audio-element').length).toBeGreaterThan(0);
+        expect(screen.queryByTestId('videojs-auth-menu')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('auth-badge')).not.toBeInTheDocument();
+      });
+
+      describe('when authorized', () => {
+        let player;
+        beforeEach(async () => {
+          await renderPlayer({
+            manifest: authManifest,
+            canvasIndex: 2,
+            manifestOverrides: { auth: { token: 'valid-token', status: 'authorized' } },
+          });
+          player = await triggerLoadedMetadata('videojs-audio-element');
+        });
+
+        test('renders auth menu control in the control-bar', async () => {
+          expect(screen.getAllByTestId('videojs-audio-element').length).toBeGreaterThan(0);
+          expect(screen.getByTestId('videojs-auth-menu')).toBeInTheDocument();
+        });
+
+        test('doesn\'t render auth badge', async () => {
+          expect(screen.getAllByTestId('videojs-audio-element').length).toBeGreaterThan(0);
+          expect(screen.queryByTestId('auth-badge')).not.toBeInTheDocument();
+        });
+
+        test('renders a logout button that calls "requestLogout" when clicked', async () => {
+          expect(screen.getByTestId('videojs-auth-menu')).toBeInTheDocument();
+
+          // Open auth menu and click log out button
+          fireEvent.click(screen.getByTestId('videojs-auth-menu'));
+          fireEvent.click(screen.getByTestId('videojs-auth-logout-button'));
+
+          expect(authService.requestLogout).toHaveBeenCalledWith('http://example.com/auth/logout');
+        });
+
+        test('disables player and restores aspect-ratio on logout', async () => {
+          const aspectRatioSpy = jest.spyOn(player, 'aspectRatio');
+
+          // Open auth menu and click log out button
+          fireEvent.click(screen.getByTestId('videojs-auth-menu'));
+          fireEvent.click(screen.getByTestId('videojs-auth-logout-button'));
+
+          expect(player.hasClass('vjs-audio-only-mode')).toBeFalsy();
+          expect(aspectRatioSpy).toHaveBeenCalledWith('16:9');
+          expect(player.hasClass('vjs-disabled')).toBe(true);
+        });
+      });
+    });
+  });
 });

--- a/src/components/MediaPlayer/VideoJS/components/js/VideoJSAuthMenu.js
+++ b/src/components/MediaPlayer/VideoJS/components/js/VideoJSAuthMenu.js
@@ -76,6 +76,7 @@ class VideoJSAuthMenu extends MenuButton {
     }
 
     const logOutBtn = new MenuItem(player_, { label: 'Log out', selectable: false });
+    logOutBtn.controlText('Log out');
     logOutBtn.el().insertAdjacentHTML('afterbegin', `
       <svg class="vjs-logout-icon" role="presentation">
         <use xlink:href="#log-out"></use>

--- a/src/components/MediaPlayer/VideoJS/components/js/VideoJSAuthMenu.js
+++ b/src/components/MediaPlayer/VideoJS/components/js/VideoJSAuthMenu.js
@@ -54,8 +54,8 @@ const MenuItem = videojs.getComponent('MenuItem');
 class VideoJSAuthMenu extends MenuButton {
   constructor(player, options) {
     super(player, options);
-    this.addClass('vjs-play-control vjs-control vjs-logout-menu');
-    this.setAttribute('data-testid', 'videojs-auth-icon');
+    this.addClass('vjs-play-control vjs-control vjs-auth-menu');
+    this.setAttribute('data-testid', 'videojs-auth-menu');
     this.controlText('Logout menu');
     this.el().firstChild.innerHTML = `
       <svg class="vjs-user-icon" role="presentation">
@@ -77,6 +77,7 @@ class VideoJSAuthMenu extends MenuButton {
 
     const logOutBtn = new MenuItem(player_, { label: 'Log out', selectable: false });
     logOutBtn.controlText('Log out');
+    logOutBtn.setAttribute('data-testid', 'videojs-auth-logout-button');
     logOutBtn.el().insertAdjacentHTML('afterbegin', `
       <svg class="vjs-logout-icon" role="presentation">
         <use xlink:href="#log-out"></use>

--- a/src/components/MediaPlayer/VideoJS/components/js/VideoJSAuthMenu.js
+++ b/src/components/MediaPlayer/VideoJS/components/js/VideoJSAuthMenu.js
@@ -1,0 +1,95 @@
+import videojs from 'video.js';
+import '../styles/VideoJSAuthMenu.scss';
+
+const userSVGSymbol = `
+ <symbol id="user" viewBox="0 0 20 20">
+  <g id="SVGRepo_bgCarrier" stroke-width="0"></g>
+  <g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g>
+  <g id="SVGRepo_iconCarrier">
+    <path d="M5 21C5 17.134 8.13401 14 12 14C15.866 14 19 17.134 19 21M16 7C16
+      9.20914 14.2091 11 12 11C9.79086 11 8 9.20914 8 7C8 4.79086 9.79086 3 12 3C14.2091 3 16 4.79086 16 7Z"
+      stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    </path>
+  </g>
+ </symbol>`;
+
+const logOutSVGSymbol = `
+  <symbol id="log-out" viewBox="0 0 20 20">
+    <g id="SVGRepo_bgCarrier" stroke-width="0"></g>
+    <g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g>
+    <g id="SVGRepo_iconCarrier">
+      <path d="M11 4V7L5 7V9H11V12H12L16 8L12 4L11 4Z" fill="#ffffff"></path>
+      <path d="M0 1L3.41715e-07 15H8V13H2L2 3H8L8 1L0 1Z" fill="#ffffff"></path>
+    </g>
+  </symbol>
+`;
+
+// Function to inject SVGs into the DOM
+function injectSVGIcons() {
+  const svgContainer = document.createElement('div');
+  svgContainer.style.display = 'none';
+  svgContainer.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg">${userSVGSymbol}${logOutSVGSymbol}</svg>`;
+  document.body.appendChild(svgContainer);
+}
+
+// Call the function to inject SVG icons
+injectSVGIcons();
+
+const MenuButton = videojs.getComponent('MenuButton');
+const MenuItem = videojs.getComponent('MenuItem');
+
+/**
+ * Custom control button for the IIIF Auth 2.0 logout UI on audio players. This is hidden until the
+ * user is authenticated; once visible, clicking the menu button brings up a popup menu with a default
+ * 'Authenticated' title and a 'Log out' action.
+ * This control is added only when the auth service defines a logout service with type 'AuthLogoutService2'
+ * and the player is in audio-only mode. If the defined logout service has a label then it is displayed as
+ * a logout item.
+ * @param {Object} props
+ * @param {Object} props.player VideoJS player instance
+ * @param {Object} props.options
+ * @param {String} props.options.label label to display in the menu from log out service
+ * @param {Function} props.options.onLogout callback invoked when 'Log out' is clicked
+ */
+class VideoJSAuthMenu extends MenuButton {
+  constructor(player, options) {
+    super(player, options);
+    this.addClass('vjs-play-control vjs-control vjs-logout-menu');
+    this.setAttribute('data-testid', 'videojs-auth-icon');
+    this.controlText('Logout menu');
+    this.el().firstChild.innerHTML = `
+      <svg class="vjs-user-icon" role="presentation">
+        <use xlink:href="#user"></use>
+      </svg>`;
+  }
+
+  createItems() {
+    const { options_, player_ } = this;
+    const { label, onLogout } = options_;
+
+    const items = [];
+    // Add label item if it exists
+    if (label) {
+      const logoutLabel = new MenuItem(player_, { label, selectable: false });
+      logoutLabel.addClass('vjs-auth-label');
+      items.push(logoutLabel);
+    }
+
+    const logOutBtn = new MenuItem(player_, { label: 'Log out', selectable: false });
+    logOutBtn.el().insertAdjacentHTML('afterbegin', `
+      <svg class="vjs-logout-icon" role="presentation">
+        <use xlink:href="#log-out"></use>
+      </svg>`);
+
+    logOutBtn.handleClick = () => {
+      if (typeof onLogout === 'function') onLogout();
+    };
+    items.push(logOutBtn);
+
+    return items;
+  }
+}
+
+videojs.registerComponent('VideoJSAuthMenu', VideoJSAuthMenu);
+
+export default VideoJSAuthMenu;

--- a/src/components/MediaPlayer/VideoJS/components/styles/VideoJSAuthMenu.scss
+++ b/src/components/MediaPlayer/VideoJS/components/styles/VideoJSAuthMenu.scss
@@ -1,4 +1,4 @@
-.vjs-logout-menu {
+.vjs-auth-menu {
   cursor: pointer;
 
   .vjs-user-icon,
@@ -26,10 +26,10 @@
       padding-left: 0.5em;
     }
   }
-}
 
-.vjs-auth-label {
-  cursor: default;
-  opacity: 0.7;
-  pointer-events: none;
+  .vjs-auth-label {
+    cursor: default;
+    opacity: 0.7;
+    pointer-events: none;
+  }
 }

--- a/src/components/MediaPlayer/VideoJS/components/styles/VideoJSAuthMenu.scss
+++ b/src/components/MediaPlayer/VideoJS/components/styles/VideoJSAuthMenu.scss
@@ -19,6 +19,12 @@
   .vjs-menu {
     left: unset;
     right: 0;
+
+    li {
+      text-transform: none;
+      text-align: initial;
+      padding-left: 0.5em;
+    }
   }
 }
 

--- a/src/components/MediaPlayer/VideoJS/components/styles/VideoJSAuthMenu.scss
+++ b/src/components/MediaPlayer/VideoJS/components/styles/VideoJSAuthMenu.scss
@@ -1,0 +1,29 @@
+.vjs-logout-menu {
+  cursor: pointer;
+
+  .vjs-user-icon,
+  .vjs-logout-icon {
+    height: 1.25em;
+    width: 1.25em;
+    scale: 1.15;
+
+    &:hover {
+      filter: drop-shadow(0 0 0.25em #fff);
+    }
+  }
+  .vjs-logout-icon {
+    margin-top: 0.25rem;
+  }
+
+  // Align the right edge of the menu with the player
+  .vjs-menu {
+    left: unset;
+    right: 0;
+  }
+}
+
+.vjs-auth-label {
+  cursor: default;
+  opacity: 0.7;
+  pointer-events: none;
+}

--- a/src/context/manifest-context.js
+++ b/src/context/manifest-context.js
@@ -270,6 +270,12 @@ function manifestReducer(state = defaultState, action) {
         auth: { ...state.auth, status: action.status },
       };
     }
+    case 'logout': {
+      return {
+        ...state,
+        auth: { token: null, status: 'idle' },
+      };
+    }
     default: {
       throw new Error(`Unhandled action type: ${action.type}`);
     }

--- a/src/services/auth-service.js
+++ b/src/services/auth-service.js
@@ -92,6 +92,20 @@ export function requestTokenViaIframe(tokenServiceUrl, origin) {
 }
 
 /**
+ * Request logout from the logout service with type='AuthLogoutService2'
+ * @param {String} logoutServiceId URL of the AuthLogoutService2
+ * @returns {Promise<void>}
+ */
+export function requestLogout(logoutServiceId) {
+  return new Promise((resolve) => {
+    fetch(logoutServiceId, { mode: 'no-cors', credentials: 'include' })
+      .catch(() => { })
+      .finally(resolve);
+    return;
+  });
+}
+
+/**
  * Generate a random message ID for correlating postMessage responses
  * @returns {String} randomly generated, 36 character long v4 UUID
  */

--- a/src/services/auth-service.js
+++ b/src/services/auth-service.js
@@ -92,17 +92,14 @@ export function requestTokenViaIframe(tokenServiceUrl, origin) {
 }
 
 /**
- * Request logout from the logout service with type='AuthLogoutService2'
+ * Request logout from the logout service with type='AuthLogoutService2'.
+ * According to the IIIF Auth 2.0 spec, the logout action presents the results of a
+ * GET request on the logout service’s URI in a separate tab/window with an address bar.
+ * https://iiif.io/api/auth/2.0/#logout-interaction
  * @param {String} logoutServiceId URL of the AuthLogoutService2
- * @returns {Promise<void>}
  */
 export function requestLogout(logoutServiceId) {
-  return new Promise((resolve) => {
-    fetch(logoutServiceId, { mode: 'no-cors', credentials: 'include' })
-      .catch(() => { })
-      .finally(resolve);
-    return;
-  });
+  window.open(logoutServiceId, '_blank');
 }
 
 /**

--- a/src/services/auth-service.test.js
+++ b/src/services/auth-service.test.js
@@ -1,4 +1,4 @@
-import { probeResource, requestTokenViaIframe } from './auth-service';
+import { probeResource, requestLogout, requestTokenViaIframe } from './auth-service';
 
 describe('auth-service', () => {
   afterEach(() => {
@@ -133,6 +133,19 @@ describe('auth-service', () => {
         const result = await probeResource('http://example.com/probe', null);
         expect(result.status).toBe(401);
       });
+    });
+  });
+
+  describe('requestLogout()', () => {
+    test('opens the logout service URI in a new tab', () => {
+      const logoutServiceId = 'http://example.com/logout';
+      const originalWindowOpen = window.open;
+      window.open = jest.fn();
+
+      requestLogout(logoutServiceId);
+
+      expect(window.open).toHaveBeenCalledWith(logoutServiceId, '_blank');
+      window.open = originalWindowOpen;
     });
   });
 });

--- a/src/services/iiif-parser.js
+++ b/src/services/iiif-parser.js
@@ -722,6 +722,11 @@ export function getSearchService(resource) {
  * tokenService: Object, logoutService: Object, restricted: Boolean }
  */
 export function getAuthService(canvas) {
+  /* Check if a given access service has an 'id' and the required service 'type' */
+  const validAccessService = (service, serviceType) => {
+    return service?.id != undefined && service?.type === serviceType;
+  };
+
   try {
     const body = canvas?.items?.[0]?.items?.[0]?.body;
     /* For Canvas 'body' with choice, parse auth service from within the an item
@@ -736,34 +741,41 @@ export function getAuthService(canvas) {
     const services = serviceArray.flatMap(s => Array.isArray(s) ? s : [s]);
 
     // Find and parse service type="AuthProbeService2"
-    const probe = services.find(s => s.type === 'AuthProbeService2');
+    const probe = services.find(s => validAccessService(s, 'AuthProbeService2'));
+    console.log(probe);
     if (probe) {
       // Read probe services as an array
       const probeServicesRaw = probe.service ?? [];
       const probeServices = Array.isArray(probeServicesRaw) ? probeServicesRaw : [probeServicesRaw];
       const accessService = probeServices.find(
-        s => s.type === 'AuthAccessService2' && ['active', 'kiosk'].includes(s.profile)
-      ) ?? {};
+        s => validAccessService(s, 'AuthAccessService2') && ['active', 'kiosk'].includes(s.profile)
+      ) ?? null;
 
       probe.errorHeading = getLabelValue(probe?.errorHeading) || 'Something went wrong';
       probe.errorNote = getLabelValue(probe?.errorNote) || 'Could not confirm authorization with token.';
 
-      accessService.confirmLabel = getLabelValue(accessService?.confirmLabel) || 'Log in';
-      accessService.label = getLabelValue(accessService?.label) || 'Login';
-      accessService.heading = getLabelValue(accessService?.heading) ?? null;
-      accessService.note = getLabelValue(accessService?.note) ?? null;
+      if (accessService) {
+        accessService.confirmLabel = getLabelValue(accessService?.confirmLabel) || 'Log in';
+        accessService.label = getLabelValue(accessService?.label) || 'Login';
+        accessService.heading = getLabelValue(accessService?.heading) ?? null;
+        accessService.note = getLabelValue(accessService?.note) ?? null;
+      }
 
       // Parse access, token, and logout services if they exist
       const accessServices = Array.isArray(accessService?.service)
         ? accessService.service
         : accessService?.service ? [accessService.service] : [];
       const tokenService = accessServices.find(s => s.type === 'AuthAccessTokenService2') ?? null;
-      tokenService.heading = getLabelValue(tokenService?.errorHeading) || 'Authentication failed';
-      tokenService.note = getLabelValue(tokenService?.errorNote) || 'Could not obtain an access token.';
+      if (tokenService) {
+        tokenService.heading = getLabelValue(tokenService?.errorHeading) || 'Authentication failed';
+        tokenService.note = getLabelValue(tokenService?.errorNote) || 'Could not obtain an access token.';
+      }
 
-      const logoutService = accessServices.find(s => s.type === 'AuthLogoutService2') ?? null;
+      const logoutService = accessServices.find(s => validAccessService(s, 'AuthLogoutService2')) ?? null;
       // Do not set default value, because the logout menu UI is changed based on its existence
-      logoutService.label = getLabelValue(logoutService?.label);
+      if (logoutService) {
+        logoutService.label = getLabelValue(logoutService?.label);
+      }
       const restricted = !accessService || !tokenService;
 
       return { version: 2, probe, accessService, tokenService, logoutService, restricted };

--- a/src/services/iiif-parser.js
+++ b/src/services/iiif-parser.js
@@ -743,14 +743,27 @@ export function getAuthService(canvas) {
       const probeServices = Array.isArray(probeServicesRaw) ? probeServicesRaw : [probeServicesRaw];
       const accessService = probeServices.find(
         s => s.type === 'AuthAccessService2' && ['active', 'kiosk'].includes(s.profile)
-      ) ?? null;
+      ) ?? {};
+
+      probe.errorHeading = getLabelValue(probe?.errorHeading) || 'Something went wrong';
+      probe.errorNote = getLabelValue(probe?.errorNote) || 'Could not confirm authorization with token.';
+
+      accessService.confirmLabel = getLabelValue(accessService?.confirmLabel) || 'Log in';
+      accessService.label = getLabelValue(accessService?.label) || 'Login';
+      accessService.heading = getLabelValue(accessService?.heading) ?? null;
+      accessService.note = getLabelValue(accessService?.note) ?? null;
 
       // Parse access, token, and logout services if they exist
       const accessServices = Array.isArray(accessService?.service)
         ? accessService.service
         : accessService?.service ? [accessService.service] : [];
       const tokenService = accessServices.find(s => s.type === 'AuthAccessTokenService2') ?? null;
+      tokenService.heading = getLabelValue(tokenService?.errorHeading) || 'Authentication failed';
+      tokenService.note = getLabelValue(tokenService?.errorNote) || 'Could not obtain an access token.';
+
       const logoutService = accessServices.find(s => s.type === 'AuthLogoutService2') ?? null;
+      // Do not set default value, because the logout menu UI is changed based on its existence
+      logoutService.label = getLabelValue(logoutService?.label);
       const restricted = !accessService || !tokenService;
 
       return { version: 2, probe, accessService, tokenService, logoutService, restricted };

--- a/src/services/iiif-parser.js
+++ b/src/services/iiif-parser.js
@@ -742,7 +742,6 @@ export function getAuthService(canvas) {
 
     // Find and parse service type="AuthProbeService2"
     const probe = services.find(s => validAccessService(s, 'AuthProbeService2'));
-    console.log(probe);
     if (probe) {
       // Read probe services as an array
       const probeServicesRaw = probe.service ?? [];

--- a/src/services/iiif-parser.test.js
+++ b/src/services/iiif-parser.test.js
@@ -886,6 +886,12 @@ describe('iiif-parser', () => {
       expect(result.tokenService.type).toBe('AuthAccessTokenService2');
     });
 
+    test('returns auth service from the body object when Annotation body type in not "Choice"', () => {
+      const result = iiifParser.getAuthService(authManifest.items[0]);
+      expect(result).not.toBeNull();
+      expect(result.probe.type).toBe('AuthProbeService2');
+    });
+
     describe('returns restricted=true when', () => {
       test('auth service has no access service', () => {
         const result = iiifParser.getAuthService(authManifest.items[3]);
@@ -901,5 +907,72 @@ describe('iiif-parser', () => {
         expect(result.tokenService).toBeNull();
       });
     });
+
+    test('returns null when no service with type="AuthProbeService2" is in services', () => {
+      const result = iiifParser.getAuthService(authManifest.items[6]);
+      expect(result).toBeNull();
+    });
+
+    test('returns logoutService=null when no service with type="AuthLogoutService2" is in services', () => {
+      const result = iiifParser.getAuthService(authManifest.items[3]);
+      expect(result.logoutService).toBeNull();
+    });
+
+    describe('parses descriptive properties', () => {
+      test('for errorHeading and errorNote from probe when provided', () => {
+        const result = iiifParser.getAuthService(authManifest.items[0]);
+        expect(result.probe.errorHeading).toBe('No access');
+        expect(result.probe.errorNote).toBe('You do not have permission to access this resource');
+      });
+
+      test('for heading, note, confirmLable, and label from accessService when provided', () => {
+        const result = iiifParser.getAuthService(authManifest.items[0]);
+        expect(result.accessService.heading).toBe('Authentication Required');
+        expect(result.accessService.note).toBe('Please log in with your institution credentials');
+        expect(result.accessService.confirmLabel).toBe('Log in');
+        expect(result.accessService.label).toBe('Login to access restricted content');
+      });
+
+      test('for heading and note from tokenService when provided', () => {
+        const result = iiifParser.getAuthService(authManifest.items[0]);
+        expect(result.tokenService.heading).toBe('Something went wrong with the token service');
+        expect(result.tokenService.note).toBe('Could not get a token. Please contact support.');
+      });
+
+      test('for label from logoutService when provided', () => {
+        const result = iiifParser.getAuthService(authManifest.items[0]);
+        expect(result.logoutService.label).toBe('Log out from service');
+      });
+    });
+
+    describe('uses hard-coded default values for descriptive properties', () => {
+      test('for probe when not provided', () => {
+        const result = iiifParser.getAuthService(authManifest.items[4]);
+        expect(result.probe.errorHeading).toBe('Something went wrong');
+        expect(result.probe.errorNote).toBe('Could not confirm authorization with token.');
+      });
+
+      test('for accessService when not provided', () => {
+        const result = iiifParser.getAuthService(authManifest.items[4]);
+        expect(result.accessService.confirmLabel).toBe('Log in');
+        expect(result.accessService.label).toBe('Login');
+        expect(result.accessService.heading).toBe('');
+        expect(result.accessService.note).toBe('');
+      });
+
+      test('for tokenService when not provided', () => {
+        const result = iiifParser.getAuthService(authManifest.items[2]);
+        expect(result.tokenService.heading).toBe('Authentication failed');
+        expect(result.tokenService.note).toBe('Could not obtain an access token.');
+      });
+
+      test('for logoutService when not provided', () => {
+        const result = iiifParser.getAuthService(authManifest.items[2]);
+        /* For logoutService, no default values are assigned for label, because the UI is
+        conditionally rendered based on the existence of this value */
+        expect(result.logoutService.label).toBe('');
+      });
+    });
+
   });
 });

--- a/src/services/ramp-hooks.js
+++ b/src/services/ramp-hooks.js
@@ -56,6 +56,7 @@ export const useMarkers = () => {
  * lastCanvasIndex: number,
  * player: object 
  * getCurrentTime: func, 
+ * resetPlayerContainer: func,
  * }
  */
 export const useMediaPlayer = () => {
@@ -112,6 +113,32 @@ export const useMediaPlayer = () => {
     }
   }, [manifestState]);
 
+  /**
+   * Reset the player to Video player's aspect ratio (16:9) on logout from IIIF Auth.
+   * This restores the player container to a 16:9 aspect ratio before the 'AuthOverlay'
+   * re-renders after auth state transition from 'authorized' -> 'idle'.
+   * At the same time; it resets the player so that, the previously authorized
+   * resource is no longer available for playback after logout.
+   */
+  const resetPlayerContainer = useCallback(() => {
+    const player = playerRef.current;
+
+    if (player) {
+      // Remove the VideoJSAuthMenu control from the control-bar
+      const controlBar = player.getChild('controlBar');
+      controlBar.removeChild('VideoJSAuthMenu');
+      // Restore original 16:9 aspect ratio and remove audio-only-mode
+      player.audioOnlyMode(false);
+      player.removeClass('vjs-audio-only-mode');
+      player.aspectRatio('16:9');
+      // Disable and reset player to remove authenticated resource
+      player.addClass('vjs-disabled');
+      player.src('');
+      player.tech().el().load();
+    }
+  }, [playerRef.current]);
+
+
   return {
     canvasIndex,
     canvasIsEmpty,
@@ -120,6 +147,7 @@ export const useMediaPlayer = () => {
     lastCanvasIndex,
     player,
     getCurrentTime,
+    resetPlayerContainer,
   };
 };
 

--- a/src/services/ramp-hooks.js
+++ b/src/services/ramp-hooks.js
@@ -138,7 +138,6 @@ export const useMediaPlayer = () => {
     }
   }, [playerRef.current]);
 
-
   return {
     canvasIndex,
     canvasIsEmpty,

--- a/src/services/svg-icons.js
+++ b/src/services/svg-icons.js
@@ -171,3 +171,33 @@ export const FileDownloadIcon = () => {
     </svg>
   );
 };
+
+export const SignOutIcon = () => {
+  return (
+    <svg viewBox="0 0 24 24" fill="#fffff" xmlns="http://www.w3.org/2000/svg"
+      style={{ fill: 'none', height: '1.25rem', width: '1.25rem', marginTop: '0.25rem' }}>
+      <g id="SVGRepo_bgCarrier" strokeWidth="0"></g>
+      <g id="SVGRepo_tracerCarrier" strokeLinecap="round" strokeLinejoin="round"></g>
+      <g id="SVGRepo_iconCarrier">
+        <path d="M11 4V7L5 7V9H11V12H12L16 8L12 4L11 4Z" fill="#ffffff"></path>
+        <path d="M0 1L3.41715e-07 15H8V13H2L2 3H8L8 1L0 1Z" fill="#ffffff"></path>
+      </g>
+    </svg>
+  );
+};
+
+export const UserIcon = () => {
+  return (
+    <svg viewBox="0 0 24 24" fill="#fffff" xmlns="http://www.w3.org/2000/svg"
+      style={{ fill: 'none', height: '1.25rem', width: '1.25rem' }}>
+      <g id="SVGRepo_bgCarrier" strokeWidth="0"></g>
+      <g id="SVGRepo_tracerCarrier" strokeLinecap="round" strokeLinejoin="round"></g>
+      <g id="SVGRepo_iconCarrier">
+        <path d="M5 21C5 17.134 8.13401 14 12 14C15.866 14 19 17.134 19 21M16 7C16 9.20914 14.2091 11 12 11C9.79086
+     11 8 9.20914 8 7C8 4.79086 9.79086 3 12 3C14.2091 3 16 4.79086 16 7Z" stroke="#ffffff" strokeWidth="2"
+          strokeLinecap="round" strokeLinejoin="round">
+        </path>
+      </g>
+    </svg>
+  );
+};

--- a/src/services/svg-icons.js
+++ b/src/services/svg-icons.js
@@ -143,7 +143,10 @@ export const LockedSVGIcon = () => {
 export const SearchArrow = ({ flip = false }) => {
   return (
     <svg viewBox="0 0 1024 1024" fill="#ffffff" xmlns="http://www.w3.org/2000/svg"
-      style={{ height: '1rem', width: '1rem', scale: 0.8, transform: flip ? 'rotate(180deg)' : 'rotate(0)' }}>
+      style={{
+        height: '1rem', width: '1rem', scale: 0.8, transform: flip ? 'rotate(180deg)' : 'rotate(0)',
+        transition: 'transform 0.4s ease-in-out'
+      }}>
       <g id="SVGRepo_bgCarrier" strokeWidth="0"></g>
       <g id="SVGRepo_tracerCarrier" strokeLinecap="round" strokeLinejoin="round"></g>
       <g id="SVGRepo_iconCarrier">

--- a/src/services/utility-helpers.js
+++ b/src/services/utility-helpers.js
@@ -727,7 +727,8 @@ export function playerHotKeys(event, player, canvasIsEmpty = false) {
     'ramp--structured-nav__item-link', 'ramp--structured-nav__collapse-all-btn',
     'ramp--annotations__multi-select-header', 'ramp--annotations__show-more-tags',
     'ramp--annotations__show-more-less', 'ramp--annotations__annotation-row-time-tags',
-    'ramp--transcript__show-more-less', 'placeholder-previous-button', 'placeholder-next-button'
+    'ramp--transcript__show-more-less', 'placeholder-previous-button', 'placeholder-next-button',
+    'ramp--auth-overlay__badge', 'ramp--auth-overlay__badge-menu-logout'
   ];
 
   // Check if the activeElement is an anchor tag inside a annotation/cue text
@@ -740,7 +741,7 @@ export function playerHotKeys(event, player, canvasIsEmpty = false) {
 
   // Determine the focused element and pressed key combination needs to be skipped
   let skipActionWithButtonFocus = linkInText || (
-    activeElement?.role === 'button'
+    (activeElement?.role === 'button' || activeElement.tagName === 'BUTTON')
     && (
       (
         buttonClassesToCheck.some(c => activeElement?.classList?.contains(c))

--- a/src/test_data/auth-manifest.js
+++ b/src/test_data/auth-manifest.js
@@ -47,13 +47,13 @@ export default {
                           {
                             id: 'http://example.com/auth/token',
                             type: 'AuthAccessTokenService2',
-                            errorHeading: { en: ['Something went wrong'] },
-                            errorNote: { en: ['Could not get a token.'] }
+                            errorHeading: { en: ['Something went wrong with the token service'] },
+                            errorNote: { en: ['Could not get a token. Please contact support.'] }
                           },
                           {
                             id: 'http://example.com/auth/logout',
                             type: 'AuthLogoutService2',
-                            label: { en: ['Log out'] }
+                            label: { en: ['Log out from service'] }
                           }
                         ]
                       }
@@ -133,17 +133,8 @@ export default {
                             note: { en: ['Please log in with your institution credentials'] },
                             confirmLabel: { en: ['Log in'] },
                             service: [
-                              {
-                                id: 'http://example.com/auth/token',
-                                type: 'AuthAccessTokenService2',
-                                errorHeading: { en: ['Something went wrong'] },
-                                errorNote: { en: ['Could not get a token.'] }
-                              },
-                              {
-                                id: 'http://example.com/auth/logout',
-                                type: 'AuthLogoutService2',
-                                label: { en: ['Log out'] }
-                              }
+                              { id: 'http://example.com/auth/token', type: 'AuthAccessTokenService2' },
+                              { id: 'http://example.com/auth/logout', type: 'AuthLogoutService2' }
                             ]
                           }
                         ]
@@ -172,17 +163,8 @@ export default {
                             note: { en: ['Please log in with your institution credentials'] },
                             confirmLabel: { en: ['Log in'] },
                             service: [
-                              {
-                                id: 'http://example.com/auth/token',
-                                type: 'AuthAccessTokenService2',
-                                errorHeading: { en: ['Something went wrong'] },
-                                errorNote: { en: ['Could not get a token.'] }
-                              },
-                              {
-                                id: 'http://example.com/auth/logout',
-                                type: 'AuthLogoutService2',
-                                label: { en: ['Log out'] }
-                              }
+                              { id: 'http://example.com/auth/token', type: 'AuthAccessTokenService2' },
+                              { id: 'http://example.com/auth/logout', type: 'AuthLogoutService2' }
                             ]
                           }
                         ]
@@ -276,6 +258,33 @@ export default {
           ]
         }
       ]
-    }
+    },
+    {
+      id: 'http://example.com/auth-manifest/canvas/6',
+      type: 'Canvas',
+      duration: 56.6,
+      label: { en: ['Other Service Canvas'] },
+      items: [
+        {
+          id: 'http://example.com/auth-manifest/canvas/6/page/1',
+          type: 'AnnotationPage',
+          items: [
+            {
+              id: 'http://example.com/auth-manifest/canvas/6/page/1/annotation/1',
+              type: 'Annotation',
+              motivation: 'painting',
+              target: 'http://example.com/auth-manifest/canvas/6',
+              body: {
+                id: 'http://example.com/auth-manifest/video/other.mp4',
+                type: 'Video',
+                format: 'video/mp4',
+                duration: 56.6,
+                service: [{ id: 'http://example.com/other', type: 'OtherService' }]
+              }
+            }
+          ]
+        }
+      ]
+    },
   ]
 };

--- a/src/test_data/auth-manifest.js
+++ b/src/test_data/auth-manifest.js
@@ -96,7 +96,7 @@ export default {
       id: 'http://example.com/auth-manifest/canvas/3',
       type: 'Canvas',
       duration: 120,
-      label: { en: ['Multi Quality Video'] },
+      label: { en: ['Multi Quality Audio'] },
       items: [
         {
           id: 'http://example.com/auth-manifest/canvas/3/page/1',
@@ -112,14 +112,14 @@ export default {
                 choiceHint: 'user',
                 items: [
                   {
-                    id: 'http://example.com/auth-manifest/video/high.mp4',
-                    type: 'Video',
-                    format: 'video/mp4',
+                    id: 'http://example.com/auth-manifest/audio/high.mp3',
+                    type: 'Sound',
+                    format: 'audio/mp3',
                     duration: 300,
                     label: { en: ['High Quality'] },
                     service: [
                       {
-                        id: 'http://example.com/auth/probe?id=high.mp4',
+                        id: 'http://example.com/auth/probe?id=high.mp3',
                         type: 'AuthProbeService2',
                         errorHeading: { en: ['No access'] },
                         errorNote: { en: ['You do not have permission to access this resource'] },
@@ -142,14 +142,14 @@ export default {
                     ]
                   },
                   {
-                    id: 'http://example.com/auth-manifest/video/medium.mp4',
-                    type: 'Video',
-                    format: 'video/mp4',
+                    id: 'http://example.com/auth-manifest/audio/medium.mp3',
+                    type: 'Sound',
+                    format: 'audio/mp3',
                     duration: 300,
                     label: { en: ['Medium Quality'] },
                     service: [
                       {
-                        id: 'http://example.com/auth/probe?id=medium.mp4',
+                        id: 'http://example.com/auth/probe?id=medium.mp3',
                         type: 'AuthProbeService2',
                         errorHeading: { en: ['No access'] },
                         errorNote: { en: ['You do not have permission to access this resource'] },


### PR DESCRIPTION
Related issue: #958

Changes in this PR:
- add a logout UI,
  - for audio players: a `VideoJSAuthMenu` custom VideoJS `MenuButton` component. This is added to the control-bar before the `fullscreen` toggle when authenticated, showing a user icon that opens a popup with an optional label and a 'Log out' action button.
  - for video players: a persistent authenticated badge as a button with a popup menu with an optional label and a 'Log out' action button to the `AuthOverlay` component. This is shown once the user is authorized.
- both 'Log out' actions take the user to a new tab that presents the results of the HTTP GET request on the logout service’s URI, and clears the auth token and status in Context providers state
- once the user is logged out the player is cleaned up and disabled, so that authenticated media is removed from the player instance. And player aspect-ratio is reset to `16:9` to accommodate the display of the login modal in `AuthOverlay` component.

Additionally;
- move label parsing for all auth-related services into the parser function in `iiif-parser`, to cleanup the imports across UI components
- add relevant DOM-selectors to the `playerHotKeys()` in `utility-helpers.js` to enable keyboard accessibility for the new UI

<img width="1638" height="213" alt="Screenshot 2026-07-01 at 4 27 58 PM" src="https://github.com/user-attachments/assets/01775719-5e5d-41fa-957c-1158e7af4b7d" />
<img width="1638" height="931" alt="Screenshot 2026-07-01 at 4 28 22 PM" src="https://github.com/user-attachments/assets/ae144170-2169-48b6-a72a-98716166cdb5" />
