### PR TITLE
Refactor playerHotKeys() to be generic

### DIFF
--- a/src/services/utility-helpers.js
+++ b/src/services/utility-helpers.js
@@ -712,7 +712,15 @@ export function playerHotKeys(event, player, canvasIsEmpty = false) {
   let playerInst = player?.player();
   let output = '';
 
-  let inputs = ['input', 'textarea', 'select'];
+  /* Selector matching any interactive element that should suppress player hotkeys when focused.
+    Add values to this as needed in the future.  */
+  const HOTKEY_INTERACTIVE_SELECTORS = [
+    'button', 'a[href]', 'input', 'textarea', 'select',
+    '[role="tab"]', '[role="switch"]', '[role="option"]', '[role="slider"]',
+    '[role="spinbutton"]', '[role="combobox"]', '[role="menuitem"]',
+    '[tabindex]:not([tabindex="-1"])',
+  ].join(',');
+
   let activeElement = document.activeElement;
   // Check if the active element is within the player
   let focusedWithinPlayer = activeElement.className.includes('vjs') || activeElement.className.includes('videojs');
@@ -722,71 +730,12 @@ export function playerHotKeys(event, player, canvasIsEmpty = false) {
   // Check if ctrl/cmd/alt/shift keys are pressed when using key combinations
   let isCombKeyPress = event.ctrlKey || event.metaKey || event.altKey || event.shiftKey;
 
-  // CSS classes of active buttons to skip
-  let buttonClassesToCheck = ['ramp--transcript_time', 'ramp--structured-nav__section-title',
-    'ramp--structured-nav__item-link', 'ramp--structured-nav__collapse-all-btn',
-    'ramp--annotations__multi-select-header', 'ramp--annotations__show-more-tags',
-    'ramp--annotations__show-more-less', 'ramp--annotations__annotation-row-time-tags',
-    'ramp--transcript__show-more-less', 'placeholder-previous-button', 'placeholder-next-button',
-    'ramp--auth-overlay__badge', 'ramp--auth-overlay__badge-menu-logout'
-  ];
+  /* Suppress hotkeys when focus is on any interactive element outside the player.
+   This covers buttons, links, inputs, specific ARIA role elements etc. */
+  let focusedOnInteractive = activeElement?.matches(HOTKEY_INTERACTIVE_SELECTORS);
 
-  // Check if the activeElement is an anchor tag inside a annotation/cue text
-  let linkInText = false;
-  if (activeElement.tagName == 'A') {
-    let anchorTagsInText = ['ramp--annotations__annotation-text', 'ramp--transcript_text'];
-    const textClassName = activeElement.parentElement?.className;
-    linkInText = anchorTagsInText.includes(textClassName);
-  }
-
-  // Determine the focused element and pressed key combination needs to be skipped
-  let skipActionWithButtonFocus = linkInText || (
-    (activeElement?.role === 'button' || activeElement.tagName === 'BUTTON')
-    && (
-      (
-        buttonClassesToCheck.some(c => activeElement?.classList?.contains(c))
-        && (pressedKey === 38 || pressedKey === 40 || pressedKey === 32 || pressedKey === 13)
-      ) // Skip hot-keys when focused on transcript item/structure item/annotation row for ArrowUp/ArrowDown/Space/Enter keys
-      || (
-        ((
-          activeElement?.classList?.contains('ramp--structured-nav__section-title')
-          || activeElement?.classList?.contains('ramp--structured-nav__collapse-all-btn')
-        )
-          && (pressedKey === 37 || pressedKey === 39)
-        ) // Skip hot-keys when focused on a section or close/expand button for ArrowLeft/ArrowRight keys 
-      )
-    )
-  ) || (
-      (activeElement?.role === 'button' && activeElement?.classList?.contains('ramp--annotations__multi-select-header'))
-      || (activeElement?.role === 'option' && activeElement?.classList?.contains('annotations-dropdown-item'))
-      // Skip hot-keys when focused on annotation set dropdown/item, since it allows printable characters for keyboard navigation
-    );
-
-  /*
-    Avoid player hotkey activation when;
-    - keyboard focus in on some element on the page
-      - AND it is an input, textarea field, or a select element on the page
-          - OR a tab element AND the key pressed is left/right arrow keys as
-            this specific combination is avoided to allow keyboard navigation between 
-            tabbed UI components
-          - OR a switch element AND the key pressed is enter/space as this combination is avoided
-            to allow keyboard activation of a switch (toggle)
-          - OR a transcript cue element or a clickable structure item
-      - AND is not focused within the player, to avoid activation of player toolbar buttons
-    - OR key combinations are not in use with a key associated with hotkeys
-    - OR current Canvas is empty
-  */
   if (
-    (activeElement
-      && (
-        inputs.indexOf(activeElement.tagName.toLowerCase()) !== -1
-        || (activeElement.role === 'tab' && (pressedKey === 37 || pressedKey === 39))
-        || (activeElement.role === 'switch' && (pressedKey === 13 || pressedKey === 32))
-        || (activeElement?.classList?.contains('transcript_content') && (pressedKey === 38 || pressedKey === 40))
-        || (activeElement?.classList?.contains('ramp--transcript_item')) && (pressedKey === 38 || pressedKey === 40)
-        || skipActionWithButtonFocus
-      )
-      && !focusedWithinPlayer)
+    (!focusedWithinPlayer && focusedOnInteractive)
     || isCombKeyPress || canvasIsEmpty
   ) {
     return;

--- a/src/services/utility-helpers.test.js
+++ b/src/services/utility-helpers.test.js
@@ -1518,4 +1518,314 @@ describe('util helper', () => {
       });
     });
   });
+
+  describe('playerHotKeys()', () => {
+    let player, playerInst, mockEvent;
+
+    beforeEach(() => {
+      playerInst = {
+        paused: jest.fn(),
+        play: jest.fn(),
+        pause: jest.fn(),
+        isFullscreen: jest.fn(),
+        audioOnlyMode: jest.fn().mockReturnValue(false),
+        requestFullscreen: jest.fn(),
+        exitFullscreen: jest.fn(),
+        volume: jest.fn(),
+        lastVolume_: jest.fn(),
+        muted: jest.fn(),
+        currentTime: jest.fn(),
+      };
+      player = { player: jest.fn().mockReturnValue(playerInst) };
+      mockEvent = {
+        which: 0,
+        ctrlKey: false,
+        metaKey: false,
+        altKey: false,
+        shiftKey: false,
+        preventDefault: jest.fn(),
+        stopPropagation: jest.fn(),
+      };
+
+      // Set the activeElement to be the player by default
+      Object.defineProperty(document, 'activeElement', {
+        value: {
+          className: 'video-js vjs-big-play-centered vjs-theme-ramp',
+          matches: jest.fn().mockReturnValue(false),
+          tagName: 'DIV'
+        },
+        configurable: true,
+      });
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    describe('returns undefined without triggering hotkeys', () => {
+      test('when Canvas is empty', () => {
+        mockEvent.which = 32;
+        const result = util.playerHotKeys(mockEvent, player, true);
+        expect(result).toBeUndefined();
+        expect(playerInst.play).not.toHaveBeenCalled();
+      });
+
+      test('when player instance is null', () => {
+        player.player = jest.fn().mockReturnValue(null);
+        mockEvent.which = 32;
+        const result = util.playerHotKeys(mockEvent, player);
+        expect(result).toBeUndefined();
+        expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+      });
+
+      test('when player instance is undefined', () => {
+        player.player = jest.fn().mockReturnValue(undefined);
+        mockEvent.which = 32;
+        const result = util.playerHotKeys(mockEvent, player);
+        expect(result).toBeUndefined();
+      });
+
+      describe('when modifier key', () => {
+        test('"ctrl" is pressed', () => {
+          mockEvent.which = 32;
+          mockEvent.ctrlKey = true;
+          const result = util.playerHotKeys(mockEvent, player);
+          expect(result).toBeUndefined();
+          expect(playerInst.play).not.toHaveBeenCalled();
+        });
+
+        test('"meta" is pressed', () => {
+          mockEvent.which = 32;
+          mockEvent.metaKey = true;
+          const result = util.playerHotKeys(mockEvent, player);
+          expect(result).toBeUndefined();
+        });
+
+        test('"alt" is pressed', () => {
+          mockEvent.which = 32;
+          mockEvent.altKey = true;
+          const result = util.playerHotKeys(mockEvent, player);
+          expect(result).toBeUndefined();
+        });
+
+        test('"shift" is pressed', () => {
+          mockEvent.which = 32;
+          mockEvent.shiftKey = true;
+          const result = util.playerHotKeys(mockEvent, player);
+          expect(result).toBeUndefined();
+        });
+      });
+
+      test('when focus is on an interactive element outside the player', () => {
+        Object.defineProperty(document, 'activeElement', {
+          value: { className: 'some-button', matches: jest.fn().mockReturnValue(true), tagName: 'INPUT' },
+          configurable: true,
+        });
+        mockEvent.which = 32;
+        const result = util.playerHotKeys(mockEvent, player);
+        expect(result).toBeUndefined();
+        expect(playerInst.play).not.toHaveBeenCalled();
+      });
+
+      test('when a unrecognized key is pressed', () => {
+        // 'a' key -> does nothing
+        mockEvent.which = 65;
+        const result = util.playerHotKeys(mockEvent, player);
+        expect(result).toBeUndefined();
+        expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+      });
+    });
+
+    test('returns hotkeys action when focus is on an interactive element inside player', () => {
+      Object.defineProperty(document, 'activeElement', {
+        value: {
+          className: 'vjs-play-button',
+          matches: jest.fn().mockReturnValue(true),
+          tagName: 'BUTTON'
+        },
+        configurable: true,
+      });
+      playerInst.paused.mockReturnValue(true);
+      mockEvent.which = 32;
+      const result = util.playerHotKeys(mockEvent, player);
+      expect(result).toBe(util.HOTKEY_ACTION_OUTPUT.play);
+    });
+
+    describe('when space key (32) is pressed', () => {
+      test('returns play action when player is paused', () => {
+        playerInst.paused.mockReturnValue(true);
+        mockEvent.which = 32;
+        const result = util.playerHotKeys(mockEvent, player);
+        expect(mockEvent.preventDefault).toHaveBeenCalled();
+        expect(playerInst.play).toHaveBeenCalled();
+        expect(result).toBe(util.HOTKEY_ACTION_OUTPUT.play);
+        expect(mockEvent.stopPropagation).toHaveBeenCalled();
+      });
+
+      test('returns pause action when player is playing', () => {
+        playerInst.paused.mockReturnValue(false);
+        mockEvent.which = 32;
+        const result = util.playerHotKeys(mockEvent, player);
+        expect(mockEvent.preventDefault).toHaveBeenCalled();
+        expect(playerInst.pause).toHaveBeenCalled();
+        expect(result).toBe(util.HOTKEY_ACTION_OUTPUT.pause);
+      });
+    });
+
+    describe('when k key (75) is pressed', () => {
+      test('returns play action when player is paused', () => {
+        playerInst.paused.mockReturnValue(true);
+        mockEvent.which = 75;
+        const result = util.playerHotKeys(mockEvent, player);
+        expect(mockEvent.preventDefault).toHaveBeenCalled();
+        expect(playerInst.play).toHaveBeenCalled();
+        expect(result).toBe(util.HOTKEY_ACTION_OUTPUT.play);
+      });
+
+      test('returns pause action when player is playing', () => {
+        playerInst.paused.mockReturnValue(false);
+        mockEvent.which = 75;
+        const result = util.playerHotKeys(mockEvent, player);
+        expect(playerInst.pause).toHaveBeenCalled();
+        expect(result).toBe(util.HOTKEY_ACTION_OUTPUT.pause);
+      });
+    });
+
+    describe('when f key (70) is pressed', () => {
+      test('returns enterFullscreen action for video when not in fullscreen', () => {
+        playerInst.isFullscreen.mockReturnValue(false);
+        mockEvent.which = 70;
+        const result = util.playerHotKeys(mockEvent, player);
+        expect(mockEvent.preventDefault).toHaveBeenCalled();
+        expect(playerInst.requestFullscreen).toHaveBeenCalled();
+        expect(result).toBe(util.HOTKEY_ACTION_OUTPUT.enterFullscreen);
+      });
+
+      test('returns exitFullscreen action when already in fullscreen', () => {
+        playerInst.isFullscreen.mockReturnValue(true);
+        mockEvent.which = 70;
+        const result = util.playerHotKeys(mockEvent, player);
+        expect(playerInst.exitFullscreen).toHaveBeenCalled();
+        expect(result).toBe(util.HOTKEY_ACTION_OUTPUT.exitFullscreen);
+      });
+
+      test('doesn\'t return an action for audio-only mode', () => {
+        playerInst.audioOnlyMode.mockReturnValue(true);
+        mockEvent.which = 70;
+        const result = util.playerHotKeys(mockEvent, player);
+        expect(mockEvent.preventDefault).toHaveBeenCalled();
+        expect(playerInst.requestFullscreen).not.toHaveBeenCalled();
+        expect(playerInst.exitFullscreen).not.toHaveBeenCalled();
+
+        expect(result).toBe('');
+        expect(mockEvent.stopPropagation).toHaveBeenCalled();
+      });
+    });
+
+    describe('when m key (77) is pressed', () => {
+      test('returns mute action when volume is above 0', () => {
+        playerInst.volume.mockReturnValue(0.5);
+        playerInst.muted.mockReturnValue(false);
+        mockEvent.which = 77;
+        const result = util.playerHotKeys(mockEvent, player);
+        expect(mockEvent.preventDefault).toHaveBeenCalled();
+        expect(playerInst.muted).toHaveBeenCalledWith(true);
+        expect(result).toBe(util.HOTKEY_ACTION_OUTPUT.mute);
+      });
+
+      test('returns unmute action and restores volume when volume is 0 and lastVolume >= 0.1', () => {
+        playerInst.volume.mockReturnValue(0);
+        playerInst.lastVolume_.mockReturnValue(0.5);
+        mockEvent.which = 77;
+        const result = util.playerHotKeys(mockEvent, player);
+        expect(playerInst.volume).toHaveBeenCalledWith(0.5);
+        expect(playerInst.muted).toHaveBeenCalledWith(false);
+        expect(result).toBe(util.HOTKEY_ACTION_OUTPUT.unmute);
+      });
+
+      test('returns unmute action and sets volume to 0.1 when lastVolume was below 0.1', () => {
+        playerInst.volume.mockReturnValue(0);
+        playerInst.lastVolume_.mockReturnValue(0.05);
+        mockEvent.which = 77;
+        const result = util.playerHotKeys(mockEvent, player);
+        expect(playerInst.volume).toHaveBeenCalledWith(0.1);
+        expect(playerInst.muted).toHaveBeenCalledWith(false);
+        expect(result).toBe(util.HOTKEY_ACTION_OUTPUT.unmute);
+      });
+    });
+
+    test('when left arrow key (37) is pressed; returns leftArrow action to seek 5 seconds backward', () => {
+      playerInst.currentTime.mockReturnValue(30);
+      mockEvent.which = 37;
+      const result = util.playerHotKeys(mockEvent, player);
+      expect(mockEvent.preventDefault).toHaveBeenCalled();
+      expect(playerInst.currentTime).toHaveBeenCalledWith(25);
+      expect(result).toBe(util.HOTKEY_ACTION_OUTPUT.leftArrow);
+      expect(mockEvent.stopPropagation).toHaveBeenCalled();
+    });
+
+    test('when right arrow key (39) is pressed; returns rightArrow action to seek 5 seconds forward', () => {
+      playerInst.currentTime.mockReturnValue(30);
+      mockEvent.which = 39;
+      const result = util.playerHotKeys(mockEvent, player);
+      expect(mockEvent.preventDefault).toHaveBeenCalled();
+      expect(playerInst.currentTime).toHaveBeenCalledWith(35);
+      expect(result).toBe(util.HOTKEY_ACTION_OUTPUT.rightArrow);
+    });
+
+    describe('when up arrow key (38) is pressed', () => {
+      test('returns upArrow to increase volume by 0.1', () => {
+        playerInst.volume.mockReturnValue(0.5);
+        playerInst.muted.mockReturnValue(false);
+        mockEvent.which = 38;
+        const result = util.playerHotKeys(mockEvent, player);
+        expect(mockEvent.preventDefault).toHaveBeenCalled();
+        expect(playerInst.volume).toHaveBeenCalledWith(0.6);
+        expect(result).toBe(util.HOTKEY_ACTION_OUTPUT.upArrow);
+      });
+
+      test('when player was muted, returns upArrow to increase volume and unmutes the player', () => {
+        playerInst.volume.mockReturnValue(0.5);
+        playerInst.muted.mockReturnValue(true);
+        mockEvent.which = 38;
+        const result = util.playerHotKeys(mockEvent, player);
+        expect(playerInst.muted).toHaveBeenCalledWith(false);
+        expect(playerInst.volume).toHaveBeenCalledWith(0.6);
+        expect(result).toBe(util.HOTKEY_ACTION_OUTPUT.upArrow);
+      });
+    });
+
+    describe('when down arrow key (40) is pressed', () => {
+      test('returns downArrow action to decrease volume by 0.1', () => {
+        playerInst.volume.mockReturnValue(0.5);
+        mockEvent.which = 40;
+        const result = util.playerHotKeys(mockEvent, player);
+        expect(mockEvent.preventDefault).toHaveBeenCalled();
+        expect(playerInst.volume).toHaveBeenCalledWith(0.4);
+        expect(result).toBe(util.HOTKEY_ACTION_OUTPUT.downArrow);
+      });
+
+      test('when volume is at minimum (0.1), returns downArrow action to set volume to 0 and mutes the player', () => {
+        playerInst.volume.mockReturnValue(0.1);
+        playerInst.muted.mockReturnValue(false);
+        mockEvent.which = 40;
+        const result = util.playerHotKeys(mockEvent, player);
+        expect(mockEvent.preventDefault).toHaveBeenCalled();
+        expect(result).toBe(util.HOTKEY_ACTION_OUTPUT.downArrow);
+        expect(playerInst.volume).toHaveBeenCalledWith(0);
+        playerInst.muted.mockReturnValue(true);
+      });
+    });
+
+    describe('stopPropagation is called for all valid hotkeys', () => {
+      const validKeys = [32, 75, 70, 77, 37, 39, 38, 40];
+      validKeys.forEach((keyCode) => {
+        test(`stopPropagation called for key ${keyCode}`, () => {
+          mockEvent.which = keyCode;
+          util.playerHotKeys(mockEvent, player);
+          expect(mockEvent.stopPropagation).toHaveBeenCalled();
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
This PR is to refactor the `playerHotKeys()`function in `utility-helpers.js` to use a set of generic selectors to identify active interactive elements outside the player.
Previously the function maintained a hard-coded list of specific classNames and ARIA roles to determine when the player hotkeys should be suppressed.
To ensure, the existing functionality is preserved after the refactor without doing manual testing, I added unit-tests for the function and followed a TDD approach.

With this changes, hotkeys are now suppressed based on the *type* of an active element rather than specific component classNames, so new interactive UI components are covered automatically without needing updates to this function.