### PR TITLE
Show/hide auth badge with video player controls during playback

### DIFF
--- a/src/components/MediaPlayer/VideoJS/AuthOverlay.js
+++ b/src/components/MediaPlayer/VideoJS/AuthOverlay.js
@@ -1,8 +1,10 @@
 import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
+import cx from 'classnames';
 import { getLabelValue, sanitizeHTML } from '@Services/utility-helpers';
 import { probeResource, requestLogout, requestTokenViaIframe } from '@Services/auth-service';
 import { SearchArrow, SignOutIcon, UserIcon } from '@Services/svg-icons';
+import { useIsUserInactive } from '@Services/ramp-hooks';
 import './VideoJSPlayer.scss';
 
 /**
@@ -20,14 +22,16 @@ import './VideoJSPlayer.scss';
  * @param {Object} props.authService
  * @param {String} props.authStatus
  * @param {Boolean} props.isVideo
+ * @param {Function} props.onBadgeFocus
  * @param {Function} props.onTokenReceived
  * @param {Function} props.onAuthStatus
  * @param {Function} props.onLogout
  */
-function AuthOverlay({ authService, authStatus, isVideo, onTokenReceived, onAuthStatus, onLogout }) {
+function AuthOverlay({ authService, authStatus, isVideo, onBadgeFocus, onTokenReceived, onAuthStatus, onLogout }) {
   const [errorMessage, setErrorMessage] = useState(null);
   const [isLoggingIn, setIsLoggingIn] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
+  const { isUserInactive } = useIsUserInactive();
 
   const loginTabRef = useRef(null);
   const pollIntervalRef = useRef(null);
@@ -94,6 +98,11 @@ function AuthOverlay({ authService, authStatus, isVideo, onTokenReceived, onAuth
       clearInterval(pollIntervalRef.current);
     };
   }, []);
+
+  // Close the menu when the badge is hidden due to user inactivity
+  useEffect(() => {
+    if (isUserInactive) setMenuOpen(false);
+  }, [isUserInactive]);
 
   /**
    * Acquire token via a hidden iframe using postMessage API, then save this token
@@ -214,10 +223,14 @@ function AuthOverlay({ authService, authStatus, isVideo, onTokenReceived, onAuth
     };
 
     return (
-      <div className='ramp--auth-overlay__badge-container' ref={badgeRef}>
+      <div
+        className={cx('ramp--auth-overlay__badge-container', isUserInactive && 'hidden')}
+        ref={badgeRef}
+      >
         <button
           className='ramp--auth-overlay__badge'
           onClick={() => setMenuOpen((mo) => !mo)}
+          onFocus={onBadgeFocus}
           aria-haspopup='true' aria-expanded={menuOpen}
           aria-label={`Account menu for sign-out`}
           data-testid='auth-badge'
@@ -307,6 +320,7 @@ AuthOverlay.propTypes = {
   }).isRequired,
   authStatus: PropTypes.string.isRequired,
   isVideo: PropTypes.bool,
+  onBadgeFocus: PropTypes.func.isRequired,
   onTokenReceived: PropTypes.func.isRequired,
   onAuthStatus: PropTypes.func.isRequired,
   onLogout: PropTypes.func,

--- a/src/components/MediaPlayer/VideoJS/AuthOverlay.test.js
+++ b/src/components/MediaPlayer/VideoJS/AuthOverlay.test.js
@@ -2,12 +2,18 @@ import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import AuthOverlay from './AuthOverlay';
 import * as authService from '@Services/auth-service';
+import * as hooks from '@Services/ramp-hooks';
 
 jest.mock('dompurify', () => ({ sanitize: (html) => html }));
 jest.mock('@Services/auth-service', () => ({
   probeResource: jest.fn(),
   requestTokenViaIframe: jest.fn(),
   requestLogout: jest.fn(),
+}));
+/* Mock the hook entirley so that, the test setup can control the return value instead of
+relying on the player, which needs to be mocked if the real hook is used. */
+jest.mock('@Services/ramp-hooks', () => ({
+  useIsUserInactive: jest.fn(() => false),
 }));
 
 const mockAccessService = {
@@ -421,6 +427,51 @@ describe('AuthOverlay', () => {
       fireEvent.mouseDown(document.body);
       expect(screen.queryByTestId('auth-badge-menu')).not.toBeInTheDocument();
       expect(screen.getByTestId('auth-badge')).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    describe('on user inactivity', () => {
+      // Re-set hook value after each test
+      afterEach(() => {
+        hooks.useIsUserInactive.mockReturnValue({ isUserInactive: false });
+      });
+
+      test('gets a hidden', () => {
+        hooks.useIsUserInactive.mockReturnValue({ isUserInactive: true });
+        render(<AuthOverlay {...authorizedProps} />);
+        const container = screen.getByTestId('auth-badge').closest('.ramp--auth-overlay__badge-container');
+        expect(container).toHaveClass('hidden');
+      });
+
+      test('stays in the tab order while hidden', () => {
+        hooks.useIsUserInactive.mockReturnValue({ isUserInactive: true });
+        render(<AuthOverlay {...authorizedProps} />);
+        expect(screen.getByTestId('auth-badge')).not.toHaveAttribute('tabIndex', '-1');
+      });
+
+      test('closes open logout menu when it gets hidden', () => {
+        hooks.useIsUserInactive.mockReturnValue({ isUserInactive: false });
+        const { rerender } = render(<AuthOverlay {...authorizedProps} />);
+
+        // Setup: open the logout menu
+        fireEvent.click(screen.getByTestId('auth-badge'));
+        expect(screen.getByTestId('auth-badge-menu')).toBeInTheDocument();
+
+        // Simulate 'userinactive' state in player and rerender component
+        hooks.useIsUserInactive.mockReturnValue({ isUserInactive: true });
+        rerender(<AuthOverlay {...authorizedProps} />);
+
+        expect(screen.queryByTestId('auth-badge-menu')).not.toBeInTheDocument();
+        expect(screen.getByTestId('auth-badge')).toHaveAttribute('aria-expanded', 'false');
+      });
+
+      test('calls "onBadgeFocus" when the badge receives keyboard focus', () => {
+        hooks.useIsUserInactive.mockReturnValue({ isUserInactive: true });
+        const onBadgeFocusMock = jest.fn();
+        render(<AuthOverlay {...authorizedProps} onBadgeFocus={onBadgeFocusMock} />);
+
+        fireEvent.focus(screen.getByTestId('auth-badge'));
+        expect(onBadgeFocusMock).toHaveBeenCalledTimes(1);
+      });
     });
   });
 });

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -1654,6 +1654,7 @@ function VideoJSPlayer({
           authToken={auth.token}
           authStatus={auth.status}
           isVideo={isVideo}
+          onBadgeFocus={() => playerRef.current?.reportUserActivity()}
           onTokenReceived={(token) => manifestDispatch({ token, type: 'setAuthToken' })}
           onAuthStatus={(status) => manifestDispatch({ status, type: 'setAuthStatus' })}
           onLogout={() => {

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.scss
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.scss
@@ -129,6 +129,14 @@
     z-index: 102;
     font-size: 1rem;
     color: #767676;
+    opacity: 1;
+    transition: opacity 0.3s;
+
+    &.hidden {
+      visibility: visible;
+      opacity: 0;
+      pointer-events: none;
+    }
   }
 
   &__badge {

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.test.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.test.js
@@ -546,6 +546,47 @@ describe('VideoJSPlayer component', () => {
           expect(aspectRatioSpy).toHaveBeenCalledWith('16:9');
           expect(player.hasClass('vjs-disabled')).toBe(true);
         });
+
+        test('hides the auth badge on player "userinactive" event', () => {
+          const badgeContainer = screen.getByTestId('auth-badge').closest('.ramp--auth-overlay__badge-container');
+          expect(badgeContainer).not.toHaveClass('hidden');
+
+          act(() => { player.trigger('userinactive'); });
+          expect(badgeContainer).toHaveClass('hidden');
+        });
+
+        test('shows the auth badge again on player "useractive" event', () => {
+          // Setup: hide the auth badge first
+          act(() => { player.trigger('userinactive'); });
+          const badgeContainer = screen.getByTestId('auth-badge').closest('.ramp--auth-overlay__badge-container');
+          expect(badgeContainer).toHaveClass('hidden');
+
+          // Simulate user activity
+          act(() => { player.trigger('useractive'); });
+
+          expect(badgeContainer).not.toHaveClass('hidden');
+        });
+
+        test('closes open logout menu on player "userinactive" event', () => {
+          // Setup: open the auth badge menu
+          fireEvent.click(screen.getByTestId('auth-badge'));
+          expect(screen.getByTestId('auth-badge-menu')).toBeInTheDocument();
+
+          // Simulate user inactivity
+          act(() => { player.trigger('userinactive'); });
+
+          expect(screen.queryByTestId('auth-badge-menu')).not.toBeInTheDocument();
+        });
+
+        test('triggers "reportUserActivity" when the badge receives focus while hidden', () => {
+          const reportUserActivitySpy = jest.spyOn(player, 'reportUserActivity');
+          // Setup: hide the auth badge first
+          act(() => { player.trigger('userinactive'); });
+
+          // Simulate focus event on the auth badge
+          act(() => { screen.getByTestId('auth-badge').focus(); });
+          expect(reportUserActivitySpy).toHaveBeenCalled();
+        });
       });
     });
 

--- a/src/services/ramp-hooks.js
+++ b/src/services/ramp-hooks.js
@@ -725,6 +725,39 @@ export const useVideoJSPlayer = ({
 };
 
 /**
+ * Track user (in)activity in the VideoJS player instance based on the 'useractive' and
+ * 'userinactive' events emitted by VideoJS.
+ * This hook isolates the state updates based on these events to avoid re-rendering the
+ * whole VideoJSPlayer component tree on each user-interaction.
+ * @returns {
+ *  isUserInactive: Boolean
+ * }
+ */
+export const useIsUserInactive = () => {
+  const playerState = useContext(PlayerStateContext);
+  const { player } = playerState;
+
+  const [isUserInactive, setIsUserInactive] = useState(false);
+
+  useEffect(() => {
+    if (!player) return;
+
+    const handleActive = () => setIsUserInactive(false);
+    const handleInactive = () => setIsUserInactive(true);
+
+    player.on('useractive', handleActive);
+    player.on('userinactive', handleInactive);
+
+    return () => {
+      player.off('useractive', handleActive);
+      player.off('userinactive', handleInactive);
+    };
+  }, [player]);
+
+  return { isUserInactive };
+};
+
+/**
  * Handle display of inaccessible message timer and interval for
  * countdown
  * @param {Object} obj

--- a/src/services/ramp-hooks.test.js
+++ b/src/services/ramp-hooks.test.js
@@ -1,7 +1,7 @@
 import React, { act, useEffect } from 'react';
 import { render } from "@testing-library/react";
 import * as hooks from "./ramp-hooks";
-import { manifestState, withManifestAndPlayerProvider } from "./testing-helpers";
+import { manifestState, withManifestAndPlayerProvider, withPlayerProvider } from "./testing-helpers";
 import playlist from "@TestData/playlist";
 import singleCanvas from '@TestData/single-canvas';
 import multiSourceManifest from '@TestData/multi-source-manifest';
@@ -221,6 +221,58 @@ describe('useSetupPlayer', () => {
     expect(resultRef.current.playerConfig.error)
       .toEqual('You do not have permission to playback this item.');
     expect(resultRef.current.playerConfig.sources).toEqual([]);
+  });
+});
+
+describe('useIsUserInactive', () => {
+  // not a real ref because react throws warning if we use outside a component
+  const resultRef = { current: null };
+  let UIComponent, player;
+  beforeEach(() => {
+    resultRef.current = null;
+
+    // Player instance with minimal event handling required for testing the hook
+    const handlers = {};
+    player = {
+      on: jest.fn((event, handler) => { handlers[event] = handler; }),
+      off: jest.fn((event) => { delete handlers[event]; }),
+      trigger: (event) => handlers[event]?.(),
+    };
+
+    UIComponent = () => {
+      const isUserInactive = hooks.useIsUserInactive();
+      useEffect(() => {
+        resultRef.current = isUserInactive;
+      }, [isUserInactive]);
+      return (<div></div>);
+    };
+  });
+
+  test('returns false when there is no player', () => {
+    const CustomComponent = withPlayerProvider(UIComponent, { initialState: {} });
+    render(<CustomComponent />);
+    expect(resultRef.current.isUserInactive).toBeFalsy();
+  });
+
+  test('returns true after player emits "userinactive", and false again after "useractive"', () => {
+    const CustomComponent = withPlayerProvider(UIComponent, { initialState: { player } });
+    render(<CustomComponent />);
+
+    act(() => player.trigger('userinactive'));
+    expect(resultRef.current.isUserInactive).toBeTruthy();
+
+    act(() => player.trigger('useractive'));
+    expect(resultRef.current.isUserInactive).toBeFalsy();
+  });
+
+  test('unregisters event listeners on unmount', () => {
+    const CustomComponent = withPlayerProvider(UIComponent, { initialState: { player } });
+    const { unmount } = render(<CustomComponent />);
+
+    unmount();
+
+    expect(player.off).toHaveBeenCalledWith('useractive', expect.any(Function));
+    expect(player.off).toHaveBeenCalledWith('userinactive', expect.any(Function));
   });
 });
 


### PR DESCRIPTION
Related issue: #983 

Use VideoJS's `'useractive'` and `'userinactive'` events to track the user (in)activity in the player instance. Using a custom hook to keep track of this in `ramp-hooks.js` avoids unnecessary re-renders to the `VideoJSPlayer` component tree and scopes the updates to `AuthOverlay` component.
Attaching VideoJS's `reportUserActivity()` function in the auth badge button's `onFocus` event handler triggers the `'useractive'` event to show player controls and auth badge when user tabs into the player from the top (because the first focus-able element inside the player is the auth badge from this direction).