### PR TITLE
Update circleCI to use node 26, add engines to package.json

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,12 @@ workflows:
   test-matrix:
     jobs:
       - node/test:
+          name: 'node-26'
+          pkg-manager: yarn
+          executor:
+            name: 'node/default'
+            tag: 26.0.0
+      - node/test:
           name: 'node-24'
           pkg-manager: yarn
           executor:
@@ -17,9 +23,3 @@ workflows:
           executor:
             name: 'node/default'
             tag: 22.22.0
-      - node/test:
-          name: 'node-20'
-          pkg-manager: yarn
-          executor:
-            name: 'node/default'
-            tag: 20.20.0

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   "files": [
     "/dist"
   ],
+  "engines": {
+    "node": "^20.19 || ^22.12 || >=24"
+  },
   "scripts": {
     "build": "npm run clean && NODE_ENV=production npm run bundle",
     "bundle": "vite build && PREACT=true vite build",


### PR DESCRIPTION
Changes in this PR:
- add Node 26 to the `CircleCI` test matrix and drop the Node 20
- add an `engines` field to `package.json` with supported Node versions as `^20.19 || ^22.12 || >=24`

Notes: the `engines` field in `package.json` only limits the Node version used in the build/test environments of the library.