### PR TITLE
Parse presentation 4

### DIFF
--- a/public/manifests/dev/lunchroom-manners-v4.json
+++ b/public/manifests/dev/lunchroom-manners-v4.json
@@ -1,0 +1,394 @@
+{
+	"@context": "http://iiif.io/api/presentation/4/context.json",
+	"id": "http://localhost:3003/dev/lunchroom-manners-v4.json",
+	"type": "Manifest",
+	"label": {
+		"en": [
+			"Beginning Reponsibility: Lunchroom Manners [motion picture] Coronet Films"
+		]
+	},
+	"items": [
+		{
+			"id": "http://localhost:3003/dev/lunchroom-manners-4/canvas/1",
+			"type": "Canvas",
+			"height": 360,
+			"width": 480,
+			"duration": 572.034,
+			"timeMode": "trim",
+			"placeholderContainer": {
+				"id": "http://localhost:3003/dev/lunchroom-manners-4/placeholder",
+				"type": "Canvas",
+				"height": 728,
+				"width": 962,
+				"items": [
+					{
+						"id": "https://example.org/image/placeholder/annopage",
+						"type": "AnnotationPage",
+						"items": [
+							{
+								"id": "http://localhost:3003/dev/lunchroom-manners-4/placeholder/image",
+								"type": "Annotation",
+								"motivation": [
+									"painting"
+								],
+								"body": {
+									"id": "http://localhost:3003/lunchroom_manners/lunchroom_manners_poster.jpg",
+									"type": "Image",
+									"format": "image/png",
+									"height": 728,
+									"width": 962
+								},
+								"target": {
+									"id": "http://localhost:3003/dev/lunchroom-manners-4/placeholder",
+									"type": "Canvas"
+								}
+							}
+						]
+					}
+				]
+			},
+			"items": [
+				{
+					"id": "http://localhost:3003/dev/lunchroom-manners-4/annopage1",
+					"type": "AnnotationPage",
+					"items": [
+						{
+							"id": "http://localhost:3003/dev/lunchroom-manners-4/anno1",
+							"type": "Annotation",
+							"motivation": [
+								"painting"
+							],
+							"body": {
+								"type": "Choice",
+								"items": [
+									{
+										"id": "http://localhost:3003/lunchroom_manners/low/lunchroom_manners_256kb.mp4",
+										"type": "Video",
+										"label": {
+											"en": [
+												"Low"
+											]
+										},
+										"height": 360,
+										"width": 480,
+										"duration": 572.034,
+										"format": "video/mp4",
+										"fileSize": 78666676
+									},
+									{
+										"id": "http://localhost:3003/lunchroom_manners/high/lunchroom_manners_1024kb.mp4",
+										"type": "Video",
+										"label": {
+											"en": [
+												"High"
+											]
+										},
+										"height": 360,
+										"width": 480,
+										"duration": 572.034,
+										"format": "video/mp4",
+										"fileSize": 78666676
+									}
+								]
+							},
+							"target": {
+								"id": "http://localhost:3003/dev/lunchroom-manners-4/canvas",
+								"type": "Canvas"
+							}
+						}
+					]
+				}
+			],
+			"annotations": [
+				{
+					"id": "http://localhost:3003/dev/lunchroom-manners-4/subtitles",
+					"type": "AnnotationPage",
+					"items": [
+						{
+							"id": "http://localhost:3003/dev/lunchroom-manners-4/subtitles/anno",
+							"type": "Annotation",
+							"motivation": [
+								"supplementing"
+							],
+							"provides": [
+								"subtitles"
+							],
+							"body": {
+								"id": "http://localhost:3003/lunchroom_manners/lunchroom_manners.vtt",
+								"type": "Text",
+								"format": "text/vtt",
+								"label": {
+									"en": [
+										"Subtitles in WebVTT format"
+									]
+								},
+								"language": [
+									"en"
+								]
+							},
+							"target": {
+								"id": "http://localhost:3003/dev/lunchroom-manners-4/canvas",
+								"type": "Canvas"
+							}
+						}
+					]
+				}
+			]
+		}
+	],
+	"structures": [
+		{
+			"id": "http://localhost:3003/dev/lunchroom-manners-4/range/0",
+			"type": "Range",
+			"label": {
+				"en": [
+					"Table of Contents"
+				]
+			},
+			"items": [
+				{
+					"id": "http://localhost:3003/dev/lunchroom-manners-4/range/1",
+					"type": "Range",
+					"label": {
+						"en": [
+							"Lunchroom Manners"
+						]
+					},
+					"items": [
+						{
+							"id": "http://localhost:3003/dev/lunchroom-manners-4/range/1-1",
+							"type": "Range",
+							"label": {
+								"en": [
+									"Washing Hands"
+								]
+							},
+							"items": [
+								{
+									"id": "http://localhost:3003/dev/lunchroom-manners-4/range/1-1-1",
+									"type": "Range",
+									"label": {
+										"en": [
+											"Using Soap"
+										]
+									},
+									"items": [
+										{
+											"id": "http://localhost:3003/dev/lunchroom-manners-4/canvas/1#t=157,160",
+											"type": "Canvas"
+										}
+									]
+								},
+								{
+									"id": "http://localhost:3003/dev/lunchroom-manners-4/range/1-1-3",
+									"type": "Range",
+									"label": {
+										"en": [
+											"Rinsing Well"
+										]
+									},
+									"items": [
+										{
+											"id": "http://localhost:3003/dev/lunchroom-manners-4/canvas/1#t=165,170",
+											"type": "Canvas"
+										}
+									]
+								},
+								{
+									"id": "http://localhost:3003/dev/lunchroom-manners-4/range/1-2",
+									"type": "Range",
+									"label": {
+										"en": [
+											"After Washing Hands"
+										]
+									},
+									"items": [
+										{
+											"id": "http://localhost:3003/dev/lunchroom-manners-4/range/1-2-1",
+											"type": "Range",
+											"label": {
+												"en": [
+													"Drying Hands"
+												]
+											},
+											"items": [
+												{
+													"id": "http://localhost:3003/dev/lunchroom-manners-4/canvas/1#t=170,180",
+													"type": "Canvas"
+												}
+											]
+										},
+										{
+											"id": "http://localhost:3003/dev/lunchroom-manners-4/range/1-2-2",
+											"type": "Range",
+											"label": {
+												"en": [
+													"Getting Ready"
+												]
+											},
+											"items": [
+												{
+													"id": "http://localhost:3003/dev/lunchroom-manners-4/canvas/1#t=180,190",
+													"type": "Canvas"
+												}
+											]
+										}
+									]
+								}
+							]
+						},
+						{
+							"id": "http://localhost:3003/dev/lunchroom-manners-4/range/2",
+							"type": "Range",
+							"label": {
+								"en": [
+									"In the Lunchroom"
+								]
+							},
+							"items": [
+								{
+									"id": "http://localhost:3003/dev/lunchroom-manners-4/range/2-1",
+									"type": "Range",
+									"label": {
+										"en": [
+											"At the Counter"
+										]
+									},
+									"items": [
+										{
+											"id": "http://localhost:3003/dev/lunchroom-manners-4/range/2-1-1",
+											"type": "Range",
+											"label": {
+												"en": [
+													"Getting Tray"
+												]
+											},
+											"items": [
+												{
+													"id": "http://localhost:3003/dev/lunchroom-manners-4/canvas/1#t=227,245",
+													"type": "Canvas"
+												}
+											]
+										},
+										{
+											"id": "http://localhost:3003/dev/lunchroom-manners-4/range/2-1-2",
+											"type": "Range",
+											"label": {
+												"en": [
+													"Choosing Food"
+												]
+											},
+											"items": [
+												{
+													"id": "http://localhost:3003/dev/lunchroom-manners-4/canvas/1#t=258,288",
+													"type": "Canvas"
+												}
+											]
+										},
+										{
+											"id": "http://localhost:3003/dev/lunchroom-manners-4/range/2-1-3",
+											"type": "Range",
+											"label": {
+												"en": [
+													"There will be Cake"
+												]
+											},
+											"items": [
+												{
+													"id": "http://localhost:3003/dev/lunchroom-manners-4/canvas/1#t=301,308",
+													"type": "Canvas"
+												}
+											]
+										}
+									]
+								},
+								{
+									"id": "http://localhost:3003/dev/lunchroom-manners-4/range/2-2",
+									"type": "Range",
+									"label": {
+										"en": [
+											"At the Table"
+										]
+									},
+									"items": [
+										{
+											"id": "http://localhost:3003/dev/lunchroom-manners-4/range/2-2-1",
+											"type": "Range",
+											"label": {
+												"en": [
+													"Sitting Quietly"
+												]
+											},
+											"items": [
+												{
+													"id": "http://localhost:3003/dev/lunchroom-manners-4/canvas/1#t=323,333",
+													"type": "Canvas"
+												}
+											]
+										},
+										{
+											"id": "http://localhost:3003/dev/lunchroom-manners-4/range/2-2-2",
+											"type": "Range",
+											"label": {
+												"en": [
+													"Eating Neatly"
+												]
+											},
+											"items": [
+												{
+													"id": "http://localhost:3003/dev/lunchroom-manners-4/canvas/1#t=362,378",
+													"type": "Canvas"
+												}
+											]
+										}
+									]
+								},
+								{
+									"id": "http://localhost:3003/dev/lunchroom-manners-4/range/2-3",
+									"type": "Range",
+									"label": {
+										"en": [
+											"Leavning the Lunchroom"
+										]
+									},
+									"items": [
+										{
+											"id": "http://localhost:3003/dev/lunchroom-manners-4/range/2-3-1",
+											"type": "Range",
+											"label": {
+												"en": [
+													"Cleaning Up"
+												]
+											},
+											"items": [
+												{
+													"id": "http://localhost:3003/dev/lunchroom-manners-4/canvas/1#t=448,492",
+													"type": "Canvas"
+												}
+											]
+										},
+										{
+											"id": "http://localhost:3003/dev/lunchroom-manners-4/range/2-3-2",
+											"type": "Range",
+											"label": {
+												"en": [
+													"Putting Things Away"
+												]
+											},
+											"items": [
+												{
+													"id": "http://localhost:3003/dev/lunchroom-manners-4/canvas/1#t=573,600",
+													"type": "Canvas"
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			]
+		}
+	]
+}

--- a/public/manifests/prod/lunchroom-manners-v4.json
+++ b/public/manifests/prod/lunchroom-manners-v4.json
@@ -1,0 +1,394 @@
+{
+	"@context": "http://iiif.io/api/presentation/4/context.json",
+	"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-v4.json",
+	"type": "Manifest",
+	"label": {
+		"en": [
+			"Beginning Reponsibility: Lunchroom Manners [motion picture] Coronet Films"
+		]
+	},
+	"items": [
+		{
+			"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-4/canvas/1",
+			"type": "Canvas",
+			"height": 360,
+			"width": 480,
+			"duration": 572.034,
+			"timeMode": "trim",
+			"placeholderContainer": {
+				"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-4/placeholder",
+				"type": "Canvas",
+				"height": 728,
+				"width": 962,
+				"items": [
+					{
+						"id": "https://example.org/image/placeholder/annopage",
+						"type": "AnnotationPage",
+						"items": [
+							{
+								"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-4/placeholder/image",
+								"type": "Annotation",
+								"motivation": [
+									"painting"
+								],
+								"body": {
+									"id": "http://localhost:3003/lunchroom_manners/lunchroom_manners_poster.jpg",
+									"type": "Image",
+									"format": "image/png",
+									"height": 728,
+									"width": 962
+								},
+								"target": {
+									"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-4/placeholder",
+									"type": "Canvas"
+								}
+							}
+						]
+					}
+				]
+			},
+			"items": [
+				{
+					"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-4/annopage1",
+					"type": "AnnotationPage",
+					"items": [
+						{
+							"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-4/anno1",
+							"type": "Annotation",
+							"motivation": [
+								"painting"
+							],
+							"body": {
+								"type": "Choice",
+								"items": [
+									{
+										"id": "http://localhost:3003/lunchroom_manners/low/lunchroom_manners_256kb.mp4",
+										"type": "Video",
+										"label": {
+											"en": [
+												"Low"
+											]
+										},
+										"height": 360,
+										"width": 480,
+										"duration": 572.034,
+										"format": "video/mp4",
+										"fileSize": 78666676
+									},
+									{
+										"id": "http://localhost:3003/lunchroom_manners/high/lunchroom_manners_1024kb.mp4",
+										"type": "Video",
+										"label": {
+											"en": [
+												"High"
+											]
+										},
+										"height": 360,
+										"width": 480,
+										"duration": 572.034,
+										"format": "video/mp4",
+										"fileSize": 78666676
+									}
+								]
+							},
+							"target": {
+								"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-4/canvas",
+								"type": "Canvas"
+							}
+						}
+					]
+				}
+			],
+			"annotations": [
+				{
+					"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-4/subtitles",
+					"type": "AnnotationPage",
+					"items": [
+						{
+							"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-4/subtitles/anno",
+							"type": "Annotation",
+							"motivation": [
+								"supplementing"
+							],
+							"provides": [
+								"subtitles"
+							],
+							"body": {
+								"id": "http://localhost:3003/lunchroom_manners/lunchroom_manners.vtt",
+								"type": "Text",
+								"format": "text/vtt",
+								"label": {
+									"en": [
+										"Subtitles in WebVTT format"
+									]
+								},
+								"language": [
+									"en"
+								]
+							},
+							"target": {
+								"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-4/canvas",
+								"type": "Canvas"
+							}
+						}
+					]
+				}
+			]
+		}
+	],
+	"structures": [
+		{
+			"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-4/range/0",
+			"type": "Range",
+			"label": {
+				"en": [
+					"Table of Contents"
+				]
+			},
+			"items": [
+				{
+					"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-4/range/1",
+					"type": "Range",
+					"label": {
+						"en": [
+							"Lunchroom Manners"
+						]
+					},
+					"items": [
+						{
+							"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-4/range/1-1",
+							"type": "Range",
+							"label": {
+								"en": [
+									"Washing Hands"
+								]
+							},
+							"items": [
+								{
+									"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-4/range/1-1-1",
+									"type": "Range",
+									"label": {
+										"en": [
+											"Using Soap"
+										]
+									},
+									"items": [
+										{
+											"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-4/canvas/1#t=157,160",
+											"type": "Canvas"
+										}
+									]
+								},
+								{
+									"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-4/range/1-1-3",
+									"type": "Range",
+									"label": {
+										"en": [
+											"Rinsing Well"
+										]
+									},
+									"items": [
+										{
+											"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-4/canvas/1#t=165,170",
+											"type": "Canvas"
+										}
+									]
+								},
+								{
+									"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-4/range/1-2",
+									"type": "Range",
+									"label": {
+										"en": [
+											"After Washing Hands"
+										]
+									},
+									"items": [
+										{
+											"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-4/range/1-2-1",
+											"type": "Range",
+											"label": {
+												"en": [
+													"Drying Hands"
+												]
+											},
+											"items": [
+												{
+													"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-4/canvas/1#t=170,180",
+													"type": "Canvas"
+												}
+											]
+										},
+										{
+											"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-4/range/1-2-2",
+											"type": "Range",
+											"label": {
+												"en": [
+													"Getting Ready"
+												]
+											},
+											"items": [
+												{
+													"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-4/canvas/1#t=180,190",
+													"type": "Canvas"
+												}
+											]
+										}
+									]
+								}
+							]
+						},
+						{
+							"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-4/range/2",
+							"type": "Range",
+							"label": {
+								"en": [
+									"In the Lunchroom"
+								]
+							},
+							"items": [
+								{
+									"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-4/range/2-1",
+									"type": "Range",
+									"label": {
+										"en": [
+											"At the Counter"
+										]
+									},
+									"items": [
+										{
+											"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-4/range/2-1-1",
+											"type": "Range",
+											"label": {
+												"en": [
+													"Getting Tray"
+												]
+											},
+											"items": [
+												{
+													"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-4/canvas/1#t=227,245",
+													"type": "Canvas"
+												}
+											]
+										},
+										{
+											"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-4/range/2-1-2",
+											"type": "Range",
+											"label": {
+												"en": [
+													"Choosing Food"
+												]
+											},
+											"items": [
+												{
+													"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-4/canvas/1#t=258,288",
+													"type": "Canvas"
+												}
+											]
+										},
+										{
+											"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-4/range/2-1-3",
+											"type": "Range",
+											"label": {
+												"en": [
+													"There will be Cake"
+												]
+											},
+											"items": [
+												{
+													"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-4/canvas/1#t=301,308",
+													"type": "Canvas"
+												}
+											]
+										}
+									]
+								},
+								{
+									"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-4/range/2-2",
+									"type": "Range",
+									"label": {
+										"en": [
+											"At the Table"
+										]
+									},
+									"items": [
+										{
+											"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-4/range/2-2-1",
+											"type": "Range",
+											"label": {
+												"en": [
+													"Sitting Quietly"
+												]
+											},
+											"items": [
+												{
+													"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-4/canvas/1#t=323,333",
+													"type": "Canvas"
+												}
+											]
+										},
+										{
+											"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-4/range/2-2-2",
+											"type": "Range",
+											"label": {
+												"en": [
+													"Eating Neatly"
+												]
+											},
+											"items": [
+												{
+													"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-4/canvas/1#t=362,378",
+													"type": "Canvas"
+												}
+											]
+										}
+									]
+								},
+								{
+									"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-4/range/2-3",
+									"type": "Range",
+									"label": {
+										"en": [
+											"Leavning the Lunchroom"
+										]
+									},
+									"items": [
+										{
+											"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-4/range/2-3-1",
+											"type": "Range",
+											"label": {
+												"en": [
+													"Cleaning Up"
+												]
+											},
+											"items": [
+												{
+													"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-4/canvas/1#t=448,492",
+													"type": "Canvas"
+												}
+											]
+										},
+										{
+											"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-4/range/2-3-2",
+											"type": "Range",
+											"label": {
+												"en": [
+													"Putting Things Away"
+												]
+											},
+											"items": [
+												{
+													"id": "https://iiif-react-media-player.netlify.app/prod/lunchroom-manners-4/canvas/1#t=573,600",
+													"type": "Canvas"
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			]
+		}
+	]
+}

--- a/src/context/manifest-context.js
+++ b/src/context/manifest-context.js
@@ -1,6 +1,7 @@
 import { parseAnnotationSets } from '@Services/annotations-parser';
 import { canvasesInManifest, parseAutoAdvance } from '../services/iiif-parser';
 import { getAnnotationService, getIsPlaylist } from '@Services/playlist-parser';
+import { getIIIFAPIVersion } from '@Services/iiif-version-parser';
 import React, { createContext, useContext, useReducer } from 'react';
 
 export const ManifestStateContext = createContext();
@@ -11,6 +12,7 @@ export const ManifestDispatchContext = createContext();
  */
 const defaultState = {
   manifest: null,
+  iiifVersion: '3', // IIIF Presentation API version ('3' or '4')
   allCanvases: [],
   canvasIndex: 0, // index for active canvas
   currentNavItem: null,
@@ -69,6 +71,7 @@ function manifestReducer(state = defaultState, action) {
   switch (action.type) {
     case 'updateManifest': {
       const manifest = action.manifest;
+      const iiifVersion = getIIIFAPIVersion(manifest);
       const canvases = canvasesInManifest(manifest);
       const manifestBehavior = parseAutoAdvance(manifest.behavior);
       const isPlaylist = getIsPlaylist(manifest.label);
@@ -77,6 +80,7 @@ function manifestReducer(state = defaultState, action) {
       return {
         ...state,
         manifest: manifest,
+        iiifVersion: iiifVersion,
         allCanvases: canvases,
         autoAdvance: manifestBehavior,
         playlist: {

--- a/src/services/annotations-parser.js
+++ b/src/services/annotations-parser.js
@@ -6,7 +6,7 @@ import {
   parseTimeStrings, sortAnnotations,
   timeToHHmmss
 } from "./utility-helpers";
-import { resolveMotivation } from "./iiif-version-parser";
+import { hasMotivation, normalizeMotivation } from "./iiif-version-parser";
 
 // Global variable to store random tag colors for the current tags
 let TAG_COLORS = [];
@@ -138,7 +138,7 @@ function parseAnnotationPages(annotationPages, duration, manifestLabel = '') {
             // Parse linked resources as a single annotation set
             if (isExternalAnnotation(item.body)) {
               const { body, id, motivation, target } = item;
-              const annotationMotivation = resolveMotivation(motivation);
+              const annotationMotivation = normalizeMotivation(motivation);
               // Only add WebVTT, SRT, and JSON files as annotations
               const timeSynced = TIME_SYNCED_FORMATS.includes(body.format);
               const annotationInfo = parseAnnotationBody(body, annotationMotivation)[0];
@@ -155,7 +155,7 @@ function parseAnnotationPages(annotationPages, duration, manifestLabel = '') {
             } else {
               // Parse individual TextualBody annotation as an item/a marker in an annotation set
               const parsedAnnotation = parseAnnotationItem(item, duration);
-              if (resolveMotivation(item.motivation, 'highlighting')) {
+              if (hasMotivation(item.motivation, 'highlighting')) {
                 markers.push(convertAnnotationToMarker(parsedAnnotation));
               } else {
                 // Check if any of the annotations are with 'supplementing' motivation
@@ -236,7 +236,7 @@ export function parseAnnotationItem(annotation, duration) {
     canvasId = source.id;
     times = parseSelector(selector, duration);
   }
-  const motivations = resolveMotivation(annotation.motivation);
+  const motivations = normalizeMotivation(annotation.motivation);
   const item = {
     motivation: motivations,
     id: annotation.id,

--- a/src/services/annotations-parser.js
+++ b/src/services/annotations-parser.js
@@ -6,6 +6,7 @@ import {
   parseTimeStrings, sortAnnotations,
   timeToHHmmss
 } from "./utility-helpers";
+import { resolveMotivation } from "./iiif-version-parser";
 
 // Global variable to store random tag colors for the current tags
 let TAG_COLORS = [];
@@ -137,7 +138,7 @@ function parseAnnotationPages(annotationPages, duration, manifestLabel = '') {
             // Parse linked resources as a single annotation set
             if (isExternalAnnotation(item.body)) {
               const { body, id, motivation, target } = item;
-              const annotationMotivation = Array.isArray(motivation) ? motivation : [motivation];
+              const annotationMotivation = resolveMotivation(motivation);
               // Only add WebVTT, SRT, and JSON files as annotations
               const timeSynced = TIME_SYNCED_FORMATS.includes(body.format);
               const annotationInfo = parseAnnotationBody(body, annotationMotivation)[0];
@@ -154,7 +155,7 @@ function parseAnnotationPages(annotationPages, duration, manifestLabel = '') {
             } else {
               // Parse individual TextualBody annotation as an item/a marker in an annotation set
               const parsedAnnotation = parseAnnotationItem(item, duration);
-              if (item.motivation === 'highlighting') {
+              if (resolveMotivation(item.motivation, 'highlighting')) {
                 markers.push(convertAnnotationToMarker(parsedAnnotation));
               } else {
                 // Check if any of the annotations are with 'supplementing' motivation
@@ -235,8 +236,7 @@ export function parseAnnotationItem(annotation, duration) {
     canvasId = source.id;
     times = parseSelector(selector, duration);
   }
-  const motivations = Array.isArray(annotation.motivation)
-    ? annotation.motivation : [annotation.motivation];
+  const motivations = resolveMotivation(annotation.motivation);
   const item = {
     motivation: motivations,
     id: annotation.id,

--- a/src/services/iiif-parser.js
+++ b/src/services/iiif-parser.js
@@ -11,7 +11,7 @@ import {
   identifyMachineGen,
   sanitizeHTML,
 } from './utility-helpers';
-import { getPlaceholderProp, resolveMotivation } from './iiif-version-parser';
+import { getPlaceholderProp, hasMotivation } from './iiif-version-parser';
 
 // Do not build structures for the following 'Range' behaviors:
 // Reference: https://iiif.io/api/presentation/3.0/#behavior
@@ -261,7 +261,7 @@ export function getPlaceholderResource(annotation, isPoster = false, version = '
     if (placeholderResource && placeholderResource != undefined) {
       let items = placeholderResource.items[0].items;
       if (items?.length > 0 && items[0].body != undefined
-        && resolveMotivation(items[0].motivation, 'painting')) {
+        && hasMotivation(items[0].motivation, 'painting')) {
         const body = items[0].body;
         if (isPoster) {
           placeholder = body.id;

--- a/src/services/iiif-parser.js
+++ b/src/services/iiif-parser.js
@@ -1,4 +1,4 @@
-import { parseManifest, PropertyValue } from 'manifesto.js';
+import { parseManifest } from 'manifesto.js';
 import mimeTypes from 'mime-types';
 import {
   GENERIC_EMPTY_MANIFEST_MESSAGE,
@@ -35,7 +35,7 @@ export function canvasesInManifest(manifest) {
       canvases.map((canvas, index) => {
         let summary = undefined;
         if (canvas.summary && canvas.summary != undefined) {
-          summary = PropertyValue.parse(canvas.summary).getValue();
+          summary = getLabelValue(canvas.summary);
         }
         let homepage = undefined;
         if (canvas.homepage && canvas.homepage.length > 0) {
@@ -150,15 +150,17 @@ export function getMediaInfo({ manifest, canvasIndex, startTime, srcIndex = 0, i
     const duration = Number(canvas.duration);
 
     // Read painting resources from annotations
-    const {
-      resources, canvasTargets, isMultiSource, error, poster
-    } = parseResourceAnnotations(canvas, duration, 'painting', startTime, isPlaylist, version);
+    const { resources, canvasTargets, isMultiSource, error, poster } = parseResourceAnnotations({
+      annotation: canvas, duration, motivation: 'painting', start: startTime, isPlaylist, version
+    });
 
     // Set default src to auto
     sources = setDefaultSrc(resources, isMultiSource, srcIndex);
 
     // Read supplementing resources fom annotations
-    const supplementingRes = parseResourceAnnotations(annotations, duration, 'supplementing', 0, false, version);
+    const supplementingRes = parseResourceAnnotations({
+      annotation: annotations, duration, motivation: 'supplementing', version
+    });
 
     const allSupplementing = supplementingRes ? supplementingRes.resources : [];
     const audioDescTracks = allSupplementing.filter(t => t.kind === 'descriptions');
@@ -246,18 +248,18 @@ export function getCanvasId(uri) {
 
 /**
  * Get placeholderCanvas value for images and text messages
- * @function IIIFParser#getPlaceholderCanvas
+ * @function IIIFParser#getPlaceholderResource
  * @param {Object} annotation IIIF Annotation object
  * @param {Boolean} isPoster flag to indicate whether text/image
  * @param {String} version Presentation API version of the Manifest
  * @return {String}
  */
-export function getPlaceholderCanvas(annotation, isPoster = false, version = '3') {
+export function getPlaceholderResource(annotation, isPoster = false, version = '3') {
   let placeholder;
   try {
-    let placeholderCanvas = annotation[getPlaceholderProp(version)];
-    if (placeholderCanvas && placeholderCanvas != undefined) {
-      let items = placeholderCanvas.items[0].items;
+    let placeholderResource = annotation[getPlaceholderProp(version)];
+    if (placeholderResource && placeholderResource != undefined) {
+      let items = placeholderResource.items[0].items;
       if (items?.length > 0 && items[0].body != undefined
         && resolveMotivation(items[0].motivation, 'painting')) {
         const body = items[0].body;
@@ -265,13 +267,14 @@ export function getPlaceholderCanvas(annotation, isPoster = false, version = '3'
           placeholder = body.id;
         } else {
           placeholder = getLabelValue(body.label) || 'This item cannot be played.';
-          setCanvasMessageTimeout(placeholderCanvas.duration);
+          setCanvasMessageTimeout(placeholderResource.duration);
         }
         return placeholder;
       }
     } else if (!isPoster) {
+      const errMsgRes = version == '4' ? 'placeholderContainer' : 'placeholderCanvas';
       console.error(
-        'iiif-parser -> getPlaceholderCanvas() -> placeholderCanvas property not defined'
+        `iiif-parser -> getPlaceholderResource() -> ${errMsgRes} property not defined`
       );
       return 'This item cannot be played.';
     } else {

--- a/src/services/iiif-parser.js
+++ b/src/services/iiif-parser.js
@@ -11,6 +11,7 @@ import {
   identifyMachineGen,
   sanitizeHTML,
 } from './utility-helpers';
+import { getPlaceholderProp, resolveMotivation } from './iiif-version-parser';
 
 // Do not build structures for the following 'Range' behaviors:
 // Reference: https://iiif.io/api/presentation/3.0/#behavior
@@ -105,10 +106,11 @@ export function canvasesInManifest(manifest) {
  * @param {Number} obj.canvasIndex Index of the current canvas in manifest
  * @param {Number} obj.startTime Custom start time if exists, defaulted to 0
  * @param {Number} obj.srcIndex Index of the resource in active canvas
- * @param {Boolean} obj.isPlaylist 
+ * @param {Boolean} obj.isPlaylist
+ * @param {String} obj.version Presentation API version of the Manifest
  * @returns {Object} { sources, tracks, targets, isMultiSource, error, mediaType }
  */
-export function getMediaInfo({ manifest, canvasIndex, startTime, srcIndex = 0, isPlaylist = false }) {
+export function getMediaInfo({ manifest, canvasIndex, startTime, srcIndex = 0, isPlaylist = false, version = '3' }) {
   let canvas = null;
   let sources, tracks = [];
   let info = {
@@ -150,13 +152,13 @@ export function getMediaInfo({ manifest, canvasIndex, startTime, srcIndex = 0, i
     // Read painting resources from annotations
     const {
       resources, canvasTargets, isMultiSource, error, poster
-    } = parseResourceAnnotations(canvas, duration, 'painting', startTime, isPlaylist);
+    } = parseResourceAnnotations(canvas, duration, 'painting', startTime, isPlaylist, version);
 
     // Set default src to auto
     sources = setDefaultSrc(resources, isMultiSource, srcIndex);
 
     // Read supplementing resources fom annotations
-    const supplementingRes = parseResourceAnnotations(annotations, duration, 'supplementing');
+    const supplementingRes = parseResourceAnnotations(annotations, duration, 'supplementing', 0, false, version);
 
     const allSupplementing = supplementingRes ? supplementingRes.resources : [];
     const audioDescTracks = allSupplementing.filter(t => t.kind === 'descriptions');
@@ -245,18 +247,19 @@ export function getCanvasId(uri) {
 /**
  * Get placeholderCanvas value for images and text messages
  * @function IIIFParser#getPlaceholderCanvas
- * @param {Object} annotation
- * @param {Boolean} isPoster
- * @return {String} 
+ * @param {Object} annotation IIIF Annotation object
+ * @param {Boolean} isPoster flag to indicate whether text/image
+ * @param {String} version Presentation API version of the Manifest
+ * @return {String}
  */
-export function getPlaceholderCanvas(annotation, isPoster = false) {
+export function getPlaceholderCanvas(annotation, isPoster = false, version = '3') {
   let placeholder;
   try {
-    let placeholderCanvas = annotation.placeholderCanvas;
+    let placeholderCanvas = annotation[getPlaceholderProp(version)];
     if (placeholderCanvas && placeholderCanvas != undefined) {
       let items = placeholderCanvas.items[0].items;
       if (items?.length > 0 && items[0].body != undefined
-        && items[0].motivation === 'painting') {
+        && resolveMotivation(items[0].motivation, 'painting')) {
         const body = items[0].body;
         if (isPoster) {
           placeholder = body.id;

--- a/src/services/iiif-parser.test.js
+++ b/src/services/iiif-parser.test.js
@@ -7,6 +7,7 @@ import autoAdvanceManifest from '@TestData/multiple-canvas-auto-advance';
 import playlistManifest from '@TestData/playlist';
 import emptyManifest from '@TestData/empty-manifest';
 import singleCanvasManifest from '@TestData/single-canvas';
+import multiCanvasV4Manifest from '@TestData/multi-canvas-v4';
 import audiannotateTest from '@TestData/audiannotate-test';
 import adManifest from '@TestData/ad-annotation';
 import authManifest from '@TestData/auth-manifest';
@@ -139,7 +140,8 @@ describe('iiif-parser', () => {
     afterEach(() => {
       jest.restoreAllMocks();
     });
-    describe('with a valid canvasIndex', () => {
+
+    describe('with Presentation 3 Manifest', () => {
       it('returns sources, mediaType and parsing error (if any)', () => {
         const { sources, mediaType, error } = iiifParser.getMediaInfo({
           manifest: lunchroomManifest,
@@ -201,6 +203,93 @@ describe('iiif-parser', () => {
           startTime: 120.5
         });
         expect(sources[0].src).toEqual('https://example.com/manifest/high/lunchroom_manners_1024kb.mp4#t=120.5,660');
+      });
+    });
+
+    describe('with a Presentation 4 Manifest', () => {
+      let originalError;
+      beforeAll(() => {
+        originalError = console.error;
+        console.error = jest.fn();
+      });
+
+      afterAll(() => console.error = originalError);
+
+      it('returns sources, mediaType for a video resource with type="Canvas"', () => {
+        const { sources, mediaType, error } = iiifParser.getMediaInfo({
+          manifest: multiCanvasV4Manifest,
+          canvasIndex: 0, version: '4'
+        });
+        expect(sources).toHaveLength(1);
+        expect(mediaType).toBe('video');
+        expect(error).toBeNull();
+        expect(sources[0]).toEqual({
+          src: 'http://example.com/low.mp4', key: 'http://example.com/low.mp4',
+          type: 'video/mp4', label: 'Low', kind: 'Video', selected: true,
+        });
+      });
+
+      it('returns sources, mediaType for an audio resource with type="Timeline"', () => {
+        const { sources, mediaType, error } = iiifParser.getMediaInfo({
+          manifest: multiCanvasV4Manifest,
+          canvasIndex: 2, version: '4'
+        });
+        expect(sources).toHaveLength(1);
+        expect(mediaType).toBe('sound');
+        expect(error).toBeNull();
+        expect(sources[0]).toEqual({
+          src: 'http://example.com/audio-canvas.mp3', key: 'http://example.com/audio-canvas.mp3',
+          type: 'audio/mpeg', label: 'auto', kind: 'Sound', selected: true,
+        });
+      });
+
+      it('returns nothing for an image resource with type="Canvas"', () => {
+        const originalError = console.error;
+        console.error = jest.fn();
+        const { sources, mediaType, poster } = iiifParser.getMediaInfo({
+          manifest: multiCanvasV4Manifest,
+          canvasIndex: 1, version: '4'
+        });
+        expect(sources).toHaveLength(0);
+        // Media type defaults to video to show any error messages in the player container in UI
+        expect(mediaType).toBe('video');
+        expect(poster).toEqual('This item cannot be played.');
+        console.error = originalError;
+      });
+
+      it('resolves quality to auto, when not given', () => {
+        const { sources } = iiifParser.getMediaInfo({
+          manifest: multiCanvasV4Manifest,
+          canvasIndex: 3, version: '4'
+        });
+        expect(sources).toHaveLength(3);
+        expect(sources[2]).toEqual({
+          src: 'https://example.com/manifest/low/audio_256kb.mp3',
+          key: 'https://example.com/manifest/low/audio_256kb.mp3',
+          label: 'auto', type: 'audio/mpeg', selected: true, kind: 'Sound',
+        });
+        expect(sources[2].selected).toBeTruthy();
+      });
+
+      it('sets default source when not multisourced', () => {
+        const originalWarn = console.warn;
+        console.warn = jest.fn();
+        const { sources } = iiifParser.getMediaInfo({
+          manifest: multiCanvasV4Manifest,
+          canvasIndex: 0, version: '4'
+        });
+        expect(sources).toHaveLength(1);
+        expect(sources[0].src).toEqual('http://example.com/low.mp4');
+        console.warn = originalWarn;
+      });
+
+      it('appends start time to src when there is a custom start', () => {
+        const { sources } = iiifParser.getMediaInfo({
+          manifest: multiCanvasV4Manifest,
+          canvasIndex: 0, version: '4',
+          startTime: 120.5
+        });
+        expect(sources[0].src).toEqual('http://example.com/low.mp4#t=120.5,7278.422');
       });
     });
 
@@ -303,7 +392,7 @@ describe('iiif-parser', () => {
     ).toEqual('http://example.com/sample/transcript-annotation/canvas/1');
   });
 
-  describe('getPlaceholderCanvas()', () => {
+  describe('getPlaceholderResource()', () => {
     let originalError;
     beforeAll(() => {
       // Mock console.error function
@@ -314,40 +403,58 @@ describe('iiif-parser', () => {
       console.error = originalError;
     });
     it('returns url for video manifest', () => {
-      const posterUrl = iiifParser.getPlaceholderCanvas(lunchroomManifest.items[0], true);
+      const posterUrl = iiifParser.getPlaceholderResource(lunchroomManifest.items[0], true);
       expect(posterUrl).toEqual(
         'https://example.com/manifest/poster/lunchroom_manners_poster.jpg'
       );
     });
 
     it('returns null for audio manifest', () => {
-      const posterUrl = iiifParser.getPlaceholderCanvas(manifest.items[0], true);
+      const posterUrl = iiifParser.getPlaceholderResource(manifest.items[0], true);
       expect(posterUrl).toBeNull();
     });
 
     it('returns placeholderCanvas text and sets timer to given duration', () => {
-      const itemMessage = iiifParser.getPlaceholderCanvas(manifest.items[1]);
+      const itemMessage = iiifParser.getPlaceholderResource(manifest.items[1]);
       expect(itemMessage).toEqual('You do not have permission to playback this item. \nPlease contact support to report this error: <a href="mailto:admin-list@example.com">admin-list@example.com</a>.\n');
       expect(util.CANVAS_MESSAGE_TIMEOUT).toEqual(4000);
     });
 
     it('returns placeholderCanvas text and sets timer to default when duration is not defined', () => {
-      const itemMessage = iiifParser.getPlaceholderCanvas(playlistManifest.items[0]);
+      const itemMessage = iiifParser.getPlaceholderResource(playlistManifest.items[0]);
       expect(itemMessage).toEqual('You do not have permission to playback this item.');
       expect(util.CANVAS_MESSAGE_TIMEOUT).toEqual(10000);
     });
 
     it('returns hard coded text when placeholderCanvas has no text and sets timer to default', () => {
-      const itemMessage = iiifParser.getPlaceholderCanvas(lunchroomManifest.items[0]);
+      const itemMessage = iiifParser.getPlaceholderResource(lunchroomManifest.items[0]);
       expect(itemMessage).toEqual('This item cannot be played.');
       expect(util.CANVAS_MESSAGE_TIMEOUT).toEqual(10000);
     });
 
     it('returns default message when no placeholderCanvas is in the Canvas and sets timer to default', () => {
-      const itemMessage = iiifParser.getPlaceholderCanvas(singleSrcManifest.items[0]);
+      const itemMessage = iiifParser.getPlaceholderResource(singleSrcManifest.items[0]);
       expect(console.error).toBeCalledTimes(1);
       expect(itemMessage).toEqual('This item cannot be played.');
       expect(util.CANVAS_MESSAGE_TIMEOUT).toEqual(10000);
+    });
+
+    describe('with a Presentation 4 Canvas', () => {
+      it('returns url from placeholderContainer', () => {
+        const posterUrl = iiifParser.getPlaceholderResource(
+          multiCanvasV4Manifest.items[0], true, '4'
+        );
+        expect(posterUrl).toEqual(
+          'http://example.com/multi-canvas-manifest-v4/poster/poster.jpg'
+        );
+      });
+
+      it('does not find placeholderContainer when read as version "3"', () => {
+        const posterUrl = iiifParser.getPlaceholderResource(
+          multiCanvasV4Manifest.items[0], true, '3'
+        );
+        expect(posterUrl).toBeNull();
+      });
     });
   });
 

--- a/src/services/iiif-version-parser.js
+++ b/src/services/iiif-version-parser.js
@@ -1,0 +1,50 @@
+const PRESENTATION_4_CONTEXT = 'http://iiif.io/api/presentation/4/context.json';
+const PLACEHOLDER_PROP = { '3': 'placeholderCanvas', '4': 'placeholderContainer' };
+
+/**
+ * Determine the Presentation API version of a given Manifest from its
+ * '@context' property. Defaults to '3' when '@context' is missing or
+ * unrecognized. This is based on the fact that, Ramp initially only
+ * supported v3 without restrictions.
+ * @function VersionParser#getIIIFAPIVersion
+ * @param {Object} manifest IIIF Manifest
+ * @returns {String} IIIF Presentation API version ('3' or '4')
+ */
+export function getIIIFAPIVersion(manifest) {
+  const context = manifest?.['@context'];
+  const contexts = [].concat(context ?? []);
+  return contexts.includes(PRESENTATION_4_CONTEXT) ? '4' : '3';
+}
+
+/**
+ * Get the placeholder property name for a Canvas/Timeline or Annotation based on the
+ * IIIF Presentation API version of the given Manifest.
+ * - Presentation v3 -> 'placeholderCanvas'
+ * - Presentation v4 -> 'placeholderContainer'
+ * @function VersionParser#getPlaceholderProp
+ * @param {String} version Presentation API version, as returned by getIIIFAPIVersion
+ * @returns {String} 'placeholderCanvas' | 'placeholderContainer'
+ */
+export function getPlaceholderProp(version) {
+  return PLACEHOLDER_PROP[version] || PLACEHOLDER_PROP['3'];
+}
+
+/**
+ * Normalize an Annotation/AnnotationPage's 'motivation' to an array and if an expected
+ * motivation value is given check for its existence. Otherwise return the normalized
+ * motivation vlaues. This allows to read and parse 'motivation' values for both Presentations
+ * v3 and v4;
+ * - in Presentation v3 'motivation' is conventionally a single String (e.g. 'painting')
+ * - in Presentation v4 'motivation' is required to be an Array of strings (e.g. ['painting'])
+ * @function VersionParser#normalizeMotivation
+ * @param {String|Array} motivation 'motivation' value read off an Annotation
+ * @param {String|Null} expected given value to be checked whether it is included
+ * @returns {Array}
+ */
+export function resolveMotivation(motivation, expected = null) {
+  const motivations = [].concat(motivation ?? []);
+  if (expected != null) {
+    return motivations.includes(expected);
+  }
+  return motivations;
+}

--- a/src/services/iiif-version-parser.js
+++ b/src/services/iiif-version-parser.js
@@ -30,21 +30,26 @@ export function getPlaceholderProp(version) {
 }
 
 /**
- * Normalize an Annotation/AnnotationPage's 'motivation' to an array and if an expected
- * motivation value is given check for its existence. Otherwise return the normalized
- * motivation vlaues. This allows to read and parse 'motivation' values for both Presentations
- * v3 and v4;
- * - in Presentation v3 'motivation' is conventionally a single String (e.g. 'painting')
- * - in Presentation v4 'motivation' is required to be an Array of strings (e.g. ['painting'])
- * @function VersionParser#normalizeMotivation
+ * Check if a motivation string value is contained in the 'motivation' read from the
+ * IIIF resource in Manifest
+ * @function VersionParser#hasMotivation
  * @param {String|Array} motivation 'motivation' value read off an Annotation
- * @param {String|Null} expected given value to be checked whether it is included
+ * @param {String} expected given value to be checked whether it is included
  * @returns {Array}
  */
-export function resolveMotivation(motivation, expected = null) {
-  const motivations = [].concat(motivation ?? []);
-  if (expected != null) {
-    return motivations.includes(expected);
-  }
-  return motivations;
+export function hasMotivation(motivation, expected) {
+  const motivations = normalizeMotivation(motivation);
+  return motivations.includes(expected);
+}
+
+/**
+ * Normalize an Annotation/AnnotationPage 'motivation' to an array. This allows to read and parse
+ * 'motivation' values for both Presentation v3 and v4;
+ * - in Presentation v3 'motivation' is conventionally a single String (e.g. 'painting')
+ * @function VersionParser#normalizeMotivation
+ * @param {String|Array} motivation 'motivation' value read off an Annotation
+ * @returns {Array}
+ */
+export function normalizeMotivation(motivation) {
+  return [].concat(motivation ?? []);
 }

--- a/src/services/iiif-version-parser.test.js
+++ b/src/services/iiif-version-parser.test.js
@@ -1,0 +1,101 @@
+import { getIIIFAPIVersion, getPlaceholderProp, resolveMotivation } from './iiif-version-parser';
+
+describe('iiif-version-parser', () => {
+  describe('getIIIFAPIVersion()', () => {
+    describe('resutrns "3" when "@context"', () => {
+      test('is a Presentation 3 context', () => {
+        expect(getIIIFAPIVersion({
+          '@context': 'http://iiif.io/api/presentation/3/context.json',
+        })).toEqual('3');
+      });
+
+      test('is an array containing the Presentation 3 context', () => {
+        expect(getIIIFAPIVersion({
+          '@context': [
+            'http://iiif.io/api/presentation/3/context.json',
+            'http://example.com/extension/context.json',
+          ],
+        })).toEqual('3');
+      });
+
+      test('is missing', () => {
+        expect(getIIIFAPIVersion({})).toEqual('3');
+      });
+
+      test('is an unrecognized value', () => {
+        expect(getIIIFAPIVersion({
+          '@context': 'http://iiif.io/api/presentation/2/context.json',
+        })).toEqual('3');
+      });
+    });
+
+    describe('resutrns "4" when "@context"', () => {
+      test('is a Presentation 4 context', () => {
+        expect(getIIIFAPIVersion({
+          '@context': 'http://iiif.io/api/presentation/4/context.json',
+        })).toEqual('4');
+      });
+
+      test('is an array containing the Presentation 4 context', () => {
+        expect(getIIIFAPIVersion({
+          '@context': [
+            'http://iiif.io/api/presentation/4/context.json',
+            'http://example.com/extension/context.json',
+          ],
+        })).toEqual('4');
+      });
+    });
+  });
+
+  describe('getPlaceholderProp()', () => {
+    test('returns "placeholderCanvas" for version "3"', () => {
+      expect(getPlaceholderProp('3')).toEqual('placeholderCanvas');
+    });
+
+    test('returns "placeholderContainer" for version "4"', () => {
+      expect(getPlaceholderProp('4')).toEqual('placeholderContainer');
+    });
+
+    test('defaults to "placeholderCanvas" for an unrecognized version', () => {
+      expect(getPlaceholderProp('5')).toEqual('placeholderCanvas');
+    });
+  });
+
+  describe('resolveMotivation()', () => {
+    describe('when expected param is null', () => {
+      test('converts a string motivation into an array', () => {
+        expect(resolveMotivation('painting')).toEqual(['painting']);
+      });
+
+      test('returns an array-like motivation unchanged', () => {
+        expect(resolveMotivation(['painting'])).toEqual(['painting']);
+      });
+
+      test('returns an empty array when motivation is missing', () => {
+        expect(resolveMotivation(undefined)).toEqual([]);
+      });
+    });
+
+    describe('when expected param is provided', () => {
+      describe('and it is included in the given motivation', () => {
+        test('returns true for a string motivation', () => {
+          expect(resolveMotivation('painting', 'painting')).toBeTruthy();
+        });
+
+        test('returns true for an array-like motivation', () => {
+          expect(resolveMotivation(['painting', 'timeline'], 'painting')).toBeTruthy();
+        });
+      });
+
+      describe('and it is not included in the given motivation', () => {
+        test('returns false for a string motivation', () => {
+          expect(resolveMotivation('painting', 'commenting')).toBeFalsy();
+        });
+
+        test('returns false for an array-like motivation', () => {
+          expect(resolveMotivation(['painting', 'timeline'], 'commenting')).toBeFalsy();
+        });
+      });
+    });
+  });
+});

--- a/src/services/iiif-version-parser.test.js
+++ b/src/services/iiif-version-parser.test.js
@@ -1,4 +1,4 @@
-import { getIIIFAPIVersion, getPlaceholderProp, resolveMotivation } from './iiif-version-parser';
+import { getIIIFAPIVersion, getPlaceholderProp, hasMotivation, normalizeMotivation } from './iiif-version-parser';
 
 describe('iiif-version-parser', () => {
   describe('getIIIFAPIVersion()', () => {
@@ -61,41 +61,43 @@ describe('iiif-version-parser', () => {
     });
   });
 
-  describe('resolveMotivation()', () => {
-    describe('when expected param is null', () => {
-      test('converts a string motivation into an array', () => {
-        expect(resolveMotivation('painting')).toEqual(['painting']);
+  describe('hasMotivation()', () => {
+    describe('when the motivation is a string value', () => {
+      test('returns true when it is equal to expected value', () => {
+        expect(hasMotivation('painting', 'painting')).toBeTruthy();
       });
 
-      test('returns an array-like motivation unchanged', () => {
-        expect(resolveMotivation(['painting'])).toEqual(['painting']);
-      });
-
-      test('returns an empty array when motivation is missing', () => {
-        expect(resolveMotivation(undefined)).toEqual([]);
+      test('returns false when it is not equal to expected value', () => {
+        expect(hasMotivation('painting', 'commenting')).toBeFalsy();
       });
     });
 
-    describe('when expected param is provided', () => {
-      describe('and it is included in the given motivation', () => {
-        test('returns true for a string motivation', () => {
-          expect(resolveMotivation('painting', 'painting')).toBeTruthy();
-        });
-
-        test('returns true for an array-like motivation', () => {
-          expect(resolveMotivation(['painting', 'timeline'], 'painting')).toBeTruthy();
-        });
+    describe('when the motivation is an array value', () => {
+      test('returns true when expected value is included', () => {
+        expect(hasMotivation(['painting', 'timeline'], 'painting')).toBeTruthy();
       });
 
-      describe('and it is not included in the given motivation', () => {
-        test('returns false for a string motivation', () => {
-          expect(resolveMotivation('painting', 'commenting')).toBeFalsy();
-        });
-
-        test('returns false for an array-like motivation', () => {
-          expect(resolveMotivation(['painting', 'timeline'], 'commenting')).toBeFalsy();
-        });
+      test('returns true when expected value is not included', () => {
+        expect(hasMotivation(['painting', 'timeline'], 'commenting')).toBeFalsy();
       });
+    });
+  });
+
+  describe('normalizeMotivation()', () => {
+    test('converts a string motivation into an array', () => {
+      expect(normalizeMotivation('painting')).toEqual(['painting']);
+    });
+
+    test('returns an array motivation unchanged', () => {
+      expect(normalizeMotivation(['painting'])).toEqual(['painting']);
+    });
+
+    test('returns an empty array when motivation is undefined', () => {
+      expect(normalizeMotivation(undefined)).toEqual([]);
+    });
+
+    test('returns an empty array when motivation is null', () => {
+      expect(normalizeMotivation(null)).toEqual([]);
     });
   });
 });

--- a/src/services/ramp-hooks.js
+++ b/src/services/ramp-hooks.js
@@ -183,6 +183,7 @@ export const useSetupPlayer = ({
     customStart,
     manifest,
     playlist,
+    iiifVersion,
     renderings,
     srcIndex
   } = manifestState;
@@ -244,6 +245,7 @@ export const useSetupPlayer = ({
         ? customStart.startTime : 0,
       srcIndex,
       isPlaylist,
+      version: iiifVersion,
     });
 
     if (withCredentials) {
@@ -1108,6 +1110,10 @@ export const useTranscripts = ({
   const [cachedTranscripts, setCachedTranscripts] = useState([]);
   const [selectedTranscript, setSelectedTranscript] = useState({ url: '', isTimed: false });
 
+  // Read IIIF Presentation API version from manifestState or defaults to '3'
+  const iiifVersion = useMemo(() => {
+    return manifestState === undefined ? '3' : manifestState.iiifVersion;
+  }, [manifestState]);
   // Read annotations from ManifestState if it exists
   const annotations = useMemo(() => {
     return manifestState === undefined ? [] : manifestState.annotations;
@@ -1234,9 +1240,9 @@ export const useTranscripts = ({
   const loadTranscripts = async (transcripts) => {
     let allTranscripts = (transcripts?.length > 0)
       // transcripts prop is processed first if given
-      ? await sanitizeTranscripts(transcripts)
+      ? await sanitizeTranscripts(transcripts, iiifVersion)
       // Read supplementing annotations from the given manifest
-      : await readSupplementingAnnotations(manifestUrl, '', transcriptParseAbort.current.signal);
+      : await readSupplementingAnnotations(manifestUrl, '', transcriptParseAbort.current.signal, iiifVersion);
 
     // Do nothing if the transcript parsing was aborted
     if (transcriptParseAbort.current.signal.aborted) {

--- a/src/services/transcript-parser.js
+++ b/src/services/transcript-parser.js
@@ -58,10 +58,11 @@ export const TRANSCRIPT_MOTIVATION = 'supplementing';
  * @param {String} manifestURL IIIF Presentation 3.0 manifest URL
  * @param {String} title optional title given in the transcripts list in props
  * @param {AbortSignal} signal AbortSignal to cancel the fetch request
+ * @param {String} version Presentation API version of the Manifest
  * @returns {Array<Object>} array of supplementing annotations for transcripts for all
  * canvases in the Manifest
  */
-export async function readSupplementingAnnotations(manifestURL, title = '', signal) {
+export async function readSupplementingAnnotations(manifestURL, title = '', signal = null, version = '3') {
   if (manifestURL === undefined) {
     return [];
   }
@@ -77,14 +78,14 @@ export async function readSupplementingAnnotations(manifestURL, title = '', sign
       }
     }).then((manifest) => {
       // Parse supplementing annotations at Manifest level and display for each Canvas
-      const manifestAnnotations = getAnnotations(manifest.annotations, TRANSCRIPT_MOTIVATION) ?? [];
+      const manifestAnnotations = getAnnotations(manifest.annotations, TRANSCRIPT_MOTIVATION, version) ?? [];
       const manifestTranscripts =
         buildTranscriptAnnotation(manifestAnnotations, 0, manifestURL, manifest, title);
 
       let newTranscriptsList = [];
       if (manifest.items?.length > 0) {
         manifest.items.map((canvas, index) => {
-          let annotations = getAnnotations(canvas.annotations, TRANSCRIPT_MOTIVATION);
+          let annotations = getAnnotations(canvas.annotations, TRANSCRIPT_MOTIVATION, version);
           const canvasTranscripts =
             buildTranscriptAnnotation(annotations, index, manifestURL, canvas, title);
           newTranscriptsList.push({
@@ -176,11 +177,12 @@ function buildTranscriptAnnotation(annotations, index, manifestURL, resource, ti
  * in the given array process them to find supplementing annotations in the manifest and
  * them to the transcripts array to be displayed in the component.
  * @param {Array} transcripts list of transcripts from Transcript component's props
+ * @param {String} version Presentation API version of the Manifest
  * @returns {Array} a refined transcripts array for each canvas with the following json
  * structure;
  * { canvasId: <canvas index>, items: [{ title, filename, url, isMachineGen, id }]}
  */
-export async function sanitizeTranscripts(transcripts) {
+export async function sanitizeTranscripts(transcripts, version = '3') {
   // When transcripts list is empty in the props
   if (!transcripts || transcripts == undefined || transcripts.length == 0) {
     console.error('No transcripts given as input');
@@ -202,7 +204,7 @@ export async function sanitizeTranscripts(transcripts) {
             // For each item in the list check if it is a manifest and parse
             // the it to identify any supplementing annotations in the
             // manifest for each canvas
-            const manifestTranscripts = await readSupplementingAnnotations(url, title);
+            const manifestTranscripts = await readSupplementingAnnotations(url, title, null, version);
             let { isMachineGen, labelText } = identifyMachineGen(title);
             let manifestItems = [];
             if (manifestTranscripts?.length > 0) {

--- a/src/services/transcript-parser.test.js
+++ b/src/services/transcript-parser.test.js
@@ -286,7 +286,7 @@ describe('transcript-parser', () => {
 
         expect(fetchSpy).toHaveBeenCalledTimes(1);
         expect(fetchSpy).toHaveBeenCalledWith(
-          'https://example.com/volleyball-for-boys.json', { signal: undefined }
+          'https://example.com/volleyball-for-boys.json', { signal: null }
         );
         expect(transcripts).toHaveLength(1);
         expect(transcripts.filter(c => c.canvasId === 0)[0].items).toEqual([
@@ -323,7 +323,7 @@ describe('transcript-parser', () => {
 
         expect(fetchSpy).toHaveBeenCalledTimes(1);
         expect(fetchSpy).toHaveBeenCalledWith(
-          'https://example.com/transcript-canvas.json', { signal: undefined }
+          'https://example.com/transcript-canvas.json', { signal: null }
         );
         expect(transcripts).toHaveLength(2);
         expect(transcripts.filter(c => c.canvasId === 1)[0].items).toEqual([
@@ -360,7 +360,7 @@ describe('transcript-parser', () => {
 
         expect(fetchSpy).toHaveBeenCalledTimes(1);
         expect(fetchSpy).toHaveBeenCalledWith(
-          'https://example.com/transcript-canvas.json', { signal: undefined }
+          'https://example.com/transcript-canvas.json', { signal: null }
         );
         expect(transcripts).toHaveLength(2);
         expect(transcripts.filter(c => c.canvasId === 0)[0].items).toHaveLength(0);

--- a/src/services/utility-helpers.js
+++ b/src/services/utility-helpers.js
@@ -4,6 +4,7 @@ import mimeTypes from 'mime-types';
 import DOMPurify from 'dompurify';
 import { getPlaceholderCanvas } from './iiif-parser';
 import { IS_ANDROID, IS_MOBILE, IS_SAFARI } from '@Services/browser';
+import { resolveMotivation } from '@Services/iiif-version-parser';
 
 const S_ANNOTATION_TYPE = { transcript: 1, caption: 2, both: 3, audioDescription: 4 };
 // Number of decimal places for milliseconds used in time calculations. 
@@ -348,21 +349,34 @@ export function parseTimeStrings(fragment, duration = 0) {
  * @function Utils#getAnnotations
  * @param {Object/Array} annotation
  * @param {String} motivation
+ * @param {String} version Presentation API version of the Manifest
  * @returns {Array} array of AnnotationPage
  */
-export function getAnnotations(annotation, motivation = '') {
+export function getAnnotations(annotation, motivation = '', version = '3') {
   let content = [];
   if (!annotation) return content;
 
-  if (annotation.type === 'Canvas') {
+  /* In Presentation v4, 
+      - type='Canvas' is typically used for Image and Video content
+      - type='Timeline' is typically used for Audio content
+    To avoid parsing Image resources with type='Canvas' enforce a duration check for
+    Presentation v4 manifests.
+    In Presentation 3, Ramp never carried this ambiguity for type='Canvas', so it's accepted
+    unconditionally because it works without issues. */
+  const isPlayableCanvas = annotation.type === 'Canvas'
+    && (version !== '4' || annotation.duration != undefined);
+  if (isPlayableCanvas || annotation.type === 'Timeline') {
     content = annotation.items[0].items;
   } else if (Array.isArray(annotation) && annotation?.length > 0) {
     content = annotation[0].items;
   }
+
+  // Normalize 'motivation' to an array on each Annotation
+  content = content.map((a) => ({ ...a, motivation: resolveMotivation(a.motivation) }));
   // Filter the annotations if a motivation is given
   if (content && motivation != '') {
     const relevantAnnotations = content.filter(
-      (a) => a.motivation === motivation);
+      (a) => a.motivation.includes(motivation));
     content = relevantAnnotations;
   }
   return content;
@@ -377,9 +391,10 @@ export function getAnnotations(annotation, motivation = '') {
  * @param {String} motivation motivation type
  * @param {Number} start custom start time from props or Manifest's start property
  * @param {Boolean} isPlaylist
+ * @param {String} version Presentation API version of the Manifest
  * @returns {Object} { resources, canvasTargets, isMultiSource, poster, error }
  */
-export function parseResourceAnnotations(annotation, duration, motivation, start = 0, isPlaylist = false) {
+export function parseResourceAnnotations(annotation, duration, motivation, start = 0, isPlaylist = false, version = '3') {
   let resources = [],
     canvasTargets = [],
     isMultiSource = false,
@@ -401,18 +416,18 @@ export function parseResourceAnnotations(annotation, duration, motivation, start
   };
 
   if (annotation && annotation != undefined) {
-    const items = getAnnotations(annotation);
+    const items = getAnnotations(annotation, '', version);
     if (!items) { return { resources, canvasTargets, error }; }
     if (items.length === 0) {
       return {
         resources, canvasTargets, isMultiSource,
-        poster: getPlaceholderCanvas(annotation)
+        poster: getPlaceholderCanvas(annotation, false, version)
       };
     }
     // When multiple resources/annotations are in a single Canvas
     else if (items?.length > 1) {
       items.map((p, index) => {
-        if (p.motivation === motivation) {
+        if (resolveMotivation(p.motivation, motivation)) {
           parseAnnotation(p.body);
           if (motivation === 'painting') {
             isMultiSource = true;
@@ -423,16 +438,16 @@ export function parseResourceAnnotations(annotation, duration, motivation, start
       });
     }
     // When multiple qualities/sources are given for the resource in the Canvas => choice
-    else if (items[0].body.items?.length > 0 && items[0]?.motivation === motivation) {
+    else if (items[0].body.items?.length > 0 && resolveMotivation(items[0]?.motivation, motivation)) {
       items[0].body.items.map((p) => {
         parseAnnotation(p);
       });
     }
     // When a singe source is given for the resource in the Canvas
-    else if (!isEmpty(items[0].body) && items[0].body?.id != '' && items[0]?.motivation === motivation) {
+    else if (!isEmpty(items[0].body) && items[0].body?.id != '' && resolveMotivation(items[0]?.motivation, motivation)) {
       parseAnnotation(items[0].body);
     } else if (motivation === 'painting') {
-      return { resources, error, poster: getPlaceholderCanvas(annotation), canvasTargets };
+      return { resources, error, poster: getPlaceholderCanvas(annotation, false, version), canvasTargets };
     }
 
     // Set canvasTargets for non-multisource Canvases to use when building progressbar
@@ -454,7 +469,7 @@ export function parseResourceAnnotations(annotation, duration, motivation, start
     }
 
     // Read image placeholder
-    poster = getPlaceholderCanvas(annotation, true);
+    poster = getPlaceholderCanvas(annotation, true, version);
     return { canvasTargets, isMultiSource, resources, poster };
   } else {
     return { canvasTargets, isMultiSource, resources, poster, error };

--- a/src/services/utility-helpers.js
+++ b/src/services/utility-helpers.js
@@ -4,7 +4,7 @@ import mimeTypes from 'mime-types';
 import DOMPurify from 'dompurify';
 import { getPlaceholderResource } from './iiif-parser';
 import { IS_ANDROID, IS_MOBILE, IS_SAFARI } from '@Services/browser';
-import { resolveMotivation } from '@Services/iiif-version-parser';
+import { hasMotivation, normalizeMotivation } from '@Services/iiif-version-parser';
 
 const S_ANNOTATION_TYPE = { transcript: 1, caption: 2, both: 3, audioDescription: 4 };
 // Number of decimal places for milliseconds used in time calculations. 
@@ -373,7 +373,7 @@ export function getAnnotations(annotation, motivation = '', version = '3') {
   }
 
   // Normalize 'motivation' to an array on each Annotation
-  content = content.map((a) => ({ ...a, motivation: resolveMotivation(a.motivation) }));
+  content = content.map((a) => ({ ...a, motivation: normalizeMotivation(a.motivation) }));
   // Filter the annotations if a motivation is given
   if (content && motivation != '') {
     const relevantAnnotations = content.filter(
@@ -429,7 +429,7 @@ export function parseResourceAnnotations({ annotation, duration, motivation, ver
     // When multiple resources/annotations are in a single Canvas
     else if (items?.length > 1) {
       items.map((p, index) => {
-        if (resolveMotivation(p.motivation, motivation)) {
+        if (hasMotivation(p.motivation, motivation)) {
           parseAnnotation(p.body);
           if (motivation === 'painting') {
             isMultiSource = true;
@@ -440,13 +440,13 @@ export function parseResourceAnnotations({ annotation, duration, motivation, ver
       });
     }
     // When multiple qualities/sources are given for the resource in the Canvas => choice
-    else if (items[0].body.items?.length > 0 && resolveMotivation(items[0]?.motivation, motivation)) {
+    else if (items[0].body.items?.length > 0 && hasMotivation(items[0]?.motivation, motivation)) {
       items[0].body.items.map((p) => {
         parseAnnotation(p);
       });
     }
     // When a singe source is given for the resource in the Canvas
-    else if (!isEmpty(items[0].body) && items[0].body?.id != '' && resolveMotivation(items[0]?.motivation, motivation)) {
+    else if (!isEmpty(items[0].body) && items[0].body?.id != '' && hasMotivation(items[0]?.motivation, motivation)) {
       parseAnnotation(items[0].body);
     } else if (motivation === 'painting') {
       return { resources, error, poster: getPlaceholderResource(annotation, false, version), canvasTargets };

--- a/src/services/utility-helpers.js
+++ b/src/services/utility-helpers.js
@@ -2,7 +2,7 @@ import { decode } from 'html-entities';
 import isEmpty from 'lodash/isEmpty';
 import mimeTypes from 'mime-types';
 import DOMPurify from 'dompurify';
-import { getPlaceholderCanvas } from './iiif-parser';
+import { getPlaceholderResource } from './iiif-parser';
 import { IS_ANDROID, IS_MOBILE, IS_SAFARI } from '@Services/browser';
 import { resolveMotivation } from '@Services/iiif-version-parser';
 
@@ -365,6 +365,7 @@ export function getAnnotations(annotation, motivation = '', version = '3') {
     unconditionally because it works without issues. */
   const isPlayableCanvas = annotation.type === 'Canvas'
     && (version !== '4' || annotation.duration != undefined);
+
   if (isPlayableCanvas || annotation.type === 'Timeline') {
     content = annotation.items[0].items;
   } else if (Array.isArray(annotation) && annotation?.length > 0) {
@@ -386,15 +387,16 @@ export function getAnnotations(annotation, motivation = '', version = '3') {
  * Parse a list of annotations or a single annotation to extract information related to
  * a given Canvas. Assumes the annotation type as either 'painting' or 'supplementing'.
  * @function Utils#parseResourceAnnotations
- * @param {Array} annotation list of painting/supplementing annotations to be parsed
- * @param {Number} duration duration of the current canvas
- * @param {String} motivation motivation type
- * @param {Number} start custom start time from props or Manifest's start property
- * @param {Boolean} isPlaylist
- * @param {String} version Presentation API version of the Manifest
+ * @param {Object} obj
+ * @param {Array} obj.annotation list of painting/supplementing annotations to be parsed
+ * @param {Number} obj.duration duration of the current canvas
+ * @param {String} obj.motivation motivation type
+ * @param {String} obj.version Presentation API version of the Manifest
+ * @param {Number} obj.start custom start time from props or Manifest's start property
+ * @param {Boolean} obj.isPlaylist
  * @returns {Object} { resources, canvasTargets, isMultiSource, poster, error }
  */
-export function parseResourceAnnotations(annotation, duration, motivation, start = 0, isPlaylist = false, version = '3') {
+export function parseResourceAnnotations({ annotation, duration, motivation, version = '3', start = 0, isPlaylist = false }) {
   let resources = [],
     canvasTargets = [],
     isMultiSource = false,
@@ -421,7 +423,7 @@ export function parseResourceAnnotations(annotation, duration, motivation, start
     if (items.length === 0) {
       return {
         resources, canvasTargets, isMultiSource,
-        poster: getPlaceholderCanvas(annotation, false, version)
+        poster: getPlaceholderResource(annotation, false, version)
       };
     }
     // When multiple resources/annotations are in a single Canvas
@@ -447,7 +449,7 @@ export function parseResourceAnnotations(annotation, duration, motivation, start
     else if (!isEmpty(items[0].body) && items[0].body?.id != '' && resolveMotivation(items[0]?.motivation, motivation)) {
       parseAnnotation(items[0].body);
     } else if (motivation === 'painting') {
-      return { resources, error, poster: getPlaceholderCanvas(annotation, false, version), canvasTargets };
+      return { resources, error, poster: getPlaceholderResource(annotation, false, version), canvasTargets };
     }
 
     // Set canvasTargets for non-multisource Canvases to use when building progressbar
@@ -469,7 +471,7 @@ export function parseResourceAnnotations(annotation, duration, motivation, start
     }
 
     // Read image placeholder
-    poster = getPlaceholderCanvas(annotation, true, version);
+    poster = getPlaceholderResource(annotation, true, version);
     return { canvasTargets, isMultiSource, resources, poster };
   } else {
     return { canvasTargets, isMultiSource, resources, poster, error };

--- a/src/services/utility-helpers.test.js
+++ b/src/services/utility-helpers.test.js
@@ -171,7 +171,7 @@ describe('util helper', () => {
           };
           test('without a custom start', () => {
             const { resources, canvasTargets, isMultiSource } = util.parseResourceAnnotations(
-              annotations, 572.32, 'painting'
+              { annotation: annotations, duration: 572.32, motivation: 'painting' }
             );
             expect(resources).toHaveLength(2);
             expect(canvasTargets).toHaveLength(1);
@@ -191,7 +191,7 @@ describe('util helper', () => {
 
           test('with a custom start', () => {
             const { resources, canvasTargets, isMultiSource } = util.parseResourceAnnotations(
-              annotations, 572.32, 'painting', 120
+              { annotation: annotations, duration: 572.32, motivation: 'painting', start: 120 }
             );
             expect(resources).toHaveLength(2);
             expect(canvasTargets).toHaveLength(1);
@@ -245,7 +245,7 @@ describe('util helper', () => {
             ],
           };
           const { resources, canvasTargets, isMultiSource } = util.parseResourceAnnotations(
-            annotations, 572.32, 'painting'
+            { annotation: annotations, duration: 572.32, motivation: 'painting' }
           );
           expect(resources).toHaveLength(3);
           expect(canvasTargets).toHaveLength(1);
@@ -303,7 +303,7 @@ describe('util helper', () => {
               ],
             };
             const { resources, canvasTargets, isMultiSource } = util.parseResourceAnnotations(
-              annotations, 572.32, 'painting', 0, true
+              { annotation: annotations, duration: 572.32, motivation: 'painting', isPlaylist: true }
             );
             expect(resources).toHaveLength(2);
             expect(canvasTargets).toHaveLength(1);
@@ -356,7 +356,7 @@ describe('util helper', () => {
               ],
             };
             const { resources, canvasTargets, isMultiSource } = util.parseResourceAnnotations(
-              annotations, 572.32, 'painting', 0, true
+              { annotation: annotations, duration: 572.32, motivation: 'painting', isPlaylist: true }
             );
             expect(resources).toHaveLength(2);
             expect(canvasTargets).toHaveLength(1);
@@ -424,7 +424,7 @@ describe('util helper', () => {
           ],
         };
         const { resources, canvasTargets, isMultiSource } = util.parseResourceAnnotations(
-          annotations, 896.55, 'painting'
+          { annotation: annotations, duration: 896.55, motivation: 'painting' }
         );
         expect(resources).toHaveLength(2);
         expect(canvasTargets).toHaveLength(2);
@@ -491,7 +491,7 @@ describe('util helper', () => {
           }
         ],
       };
-      const { resources } = util.parseResourceAnnotations(annotations, 896.55, 'painting');
+      const { resources } = util.parseResourceAnnotations({ annotation: annotations, duration: 896.55, motivation: 'painting' });
       expect(resources).toHaveLength(0);
       jest.restoreAllMocks();
     });
@@ -531,7 +531,7 @@ describe('util helper', () => {
         }
       ];
       const { resources, _, isMultiResource } = util.parseResourceAnnotations(
-        annotations, 896.55, 'supplementing'
+        { annotation: annotations, duration: 896.55, motivation: 'supplementing' }
       );
       expect(resources).toHaveLength(2);
       expect(resources[0]).toEqual({
@@ -574,14 +574,14 @@ describe('util helper', () => {
           ]
         }
       ];
-      const { resources } = util.parseResourceAnnotations(annotations, 896.55, 'supplementing');
+      const { resources } = util.parseResourceAnnotations({ annotation: annotations, duration: 896.55, motivation: 'supplementing' });
       expect(resources).toHaveLength(1);
       expect(resources[0].label).toEqual('lunchroom_manners.vtt [forced]');
       expect(resources[0].forced).toBe(true);
     });
 
     test('with annotations undefined', () => {
-      expect(util.parseResourceAnnotations(undefined, 572.32, 'supplementing')).toEqual({
+      expect(util.parseResourceAnnotations({ annotation: undefined, duration: 572.32, motivation: 'supplementing' })).toEqual({
         resources: [], error: 'No resources found in Canvas', poster: '',
         canvasTargets: [], isMultiSource: false
       });
@@ -590,7 +590,7 @@ describe('util helper', () => {
     describe('for empty Canvas', () => {
       /** Use-case: Avalon's empty Canvas representation for restricted/deleted resources */
       test('with zero annotations', () => {
-        expect(util.parseResourceAnnotations([], NaN, 'painting')).toEqual({
+        expect(util.parseResourceAnnotations({ annotation: [], duration: NaN, motivation: 'painting' })).toEqual({
           resources: [],
           canvasTargets: [],
           isMultiSource: false,
@@ -625,7 +625,7 @@ describe('util helper', () => {
           ]
         };
         const { resources, canvasTargets, isMultiResource, poster } = util.parseResourceAnnotations(
-          annotations, 3204.0, 'painting'
+          { annotation: annotations, duration: 3204.0, motivation: 'painting' }
         );
         expect(resources).toHaveLength(0);
         expect(canvasTargets).toHaveLength(0);
@@ -1825,6 +1825,45 @@ describe('util helper', () => {
           util.playerHotKeys(mockEvent, player);
           expect(mockEvent.stopPropagation).toHaveBeenCalled();
         });
+      });
+    });
+  });
+  describe('getAnnotations()', () => {
+    describe('for a Presentation 3 Manifest, returns annotation content', () => {
+      test('with a motivation array for a painting annotation', () => {
+        const canvas = { type: 'Canvas', items: [{ items: [{ motivation: 'painting' }] }] };
+        expect(util.getAnnotations(canvas)).toEqual([{ motivation: ['painting'] }]);
+      });
+
+      test('with a motivation array for a supplementing annotation', () => {
+        const canvas = { type: 'Canvas', items: [{ items: [{ motivation: 'supplementing' }] }] };
+        expect(util.getAnnotations(canvas)).toEqual([{ motivation: ['supplementing'] }]);
+      });
+    });
+
+    describe('for a Presentation 4 Manifest, returns annotation content', () => {
+      test('for a painting timeline annotation', () => {
+        const timeline = { type: 'Timeline', items: [{ items: [{ motivation: ['painting'] }] }] };
+        const content = util.getAnnotations(timeline, 'painting', '4');
+        expect(content).toHaveLength(1);
+        expect(content[0].motivation).toEqual(['painting']);
+      });
+
+      test('for a painting canvas annotation with a duration (video)', () => {
+        const canvas = {
+          type: 'Canvas', width: 1920, height: 1080, duration: 572.034,
+          items: [{ items: [{ motivation: ['painting'] }] }]
+        };
+        const content = util.getAnnotations(canvas, 'painting', '4');
+        expect(content[0].motivation).toEqual(['painting']);
+      });
+
+      test('as an empty array for a painting canvas annotation without a duration (image)', () => {
+        const canvas = {
+          type: 'Canvas', width: 1920, height: 1080, items: [{ items: [{ motivation: ['painting'] }] }]
+        };
+        const content = util.getAnnotations(canvas, 'painting', '4');
+        expect(content).toEqual([]);
       });
     });
   });

--- a/src/test_data/multi-canvas-v4.js
+++ b/src/test_data/multi-canvas-v4.js
@@ -1,0 +1,159 @@
+export default {
+  '@context': "http://iiif.io/api/presentation/4/context.json",
+  id: "http://example.com/multi-canvas-manifest-v4/manifest.json",
+  type: "Manifest",
+  label: { en: ["Multi-Canvas V4 Manifest"], it: ["Manifeste Multi-Canvas V4"] },
+  items: [
+    {
+      id: "http://example.com/multi-canvas-manifest-v4/canvas/1",
+      type: "Canvas", width: 1920, height: 1080, duration: 7278.422,
+      placeholderContainer: {
+        id: "http://example.com/multi-canvas-manifest-v4/canvas/1/placeholder",
+        type: "Canvas", width: 640, height: 360,
+        items: [
+          {
+            id: "http://example.com/multi-canvas-manifest-v4/canvas/1/placeholder/1",
+            type: "AnnotationPage",
+            items: [
+              {
+                id: "http://example.com/multi-canvas-manifest-v4/canvas/1/placeholder/1-image",
+                type: "Annotation",
+                motivation: ["painting"],
+                body: {
+                  id: "http://example.com/multi-canvas-manifest-v4/poster/poster.jpg",
+                  type: "Image", format: "image/jpeg", width: 640, height: 360
+                },
+                target: { id: "http://example.com/multi-canvas-manifest-v4/canvas/1/placeholder", type: 'Canvas' }
+              }
+            ]
+          }
+        ]
+      },
+      items: [
+        {
+          id: "http://example.com/multi-canvas-manifest-v4/canvas/1/annotation_page/1",
+          type: "AnnotationPage",
+          items: [
+            {
+              id: "http://example.com/multi-canvas-manifest-v4/canvas/1/annotation_page/1/annotation/1",
+              type: "Annotation",
+              motivation: ["painting"],
+              target: { id: "http://example.com/multi-canvas-manifest-v4/canvas/1", type: 'Canvas' },
+              body: {
+                id: "http://example.com/low.mp4", type: "Video", format: "video/mp4",
+                height: 1080, width: 1920, duration: 7278.422, label: { en: ['Low'] },
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      id: "http://example.com/multi-canvas-manifest-v4/canvas/2",
+      type: "Canvas", width: 1920, height: 1080,
+      items: [
+        {
+          id: "http://example.com/multi-canvas-manifest-v4/canvas/2/annotation_page/1",
+          type: "AnnotationPage",
+          items: [
+            {
+              id: "http://example.com/multi-canvas-manifest-v4/canvas/2/annotation_page/1/annotation/1",
+              type: "Annotation",
+              motivation: ["painting"],
+              target: { id: "http://example.com/multi-canvas-manifest-v4/canvas/2", type: 'Canvas' },
+              body: {
+                id: "http://example.com/image.jpeg", type: "Image", format: "image/jpeg", height: 1080, width: 1920
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      id: "http://example.com/multi-canvas-manifest-v4/timeline/1",
+      type: "Timeline",
+      duration: 98.25,
+      items: [
+        {
+          id: "http://example.com/multi-canvas-manifest-v4/timeline/1/annotation_page/1",
+          type: "AnnotationPage",
+          items: [
+            {
+              id: "http://example.com/multi-canvas-manifest-v4/timeline/1/annotation_page/1/annotation/1",
+              type: "Annotation",
+              motivation: ["painting"],
+              target: { id: 'http://example.com/multi-canvas-manifest-v4/timeline/1', type: 'Timeline' },
+              body: {
+                id: "http://example.com/audio-canvas.mp3", type: "Sound", format: "audio/mpeg", duration: 98.25
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      id: 'http://example.com/multi-canvas-manifest-v4/timeline/2',
+      type: 'Timeline',
+      width: 480,
+      height: 360,
+      duration: 660,
+      label: { en: ['Multi-src Audio Timeline'] },
+      items: [
+        {
+          id: 'http://example.com/multi-canvas-manifest-v4/timeline/2/page',
+          type: 'AnnotationPage',
+          items: [
+            {
+              id: 'http://example.com/multi-canvas-manifest-v4/timeline/2/page/1',
+              type: 'Annotation',
+              motivation: ['painting'],
+              body: {
+                type: 'Choice',
+                choiceHint: 'user',
+                items: [
+                  {
+                    id: 'https://example.com/manifest/high/audio_1024kb.mp3',
+                    type: 'Sound', format: 'audio/mpeg', label: { en: ['High'] },
+                  },
+                  {
+                    id: 'https://example.com/manifest/medium/audio_512kb.mp3',
+                    type: 'Sound', format: 'audio/mpeg', label: { en: ['Medium'] },
+                  },
+                  {
+                    id: 'https://example.com/manifest/low/audio_256kb.mp3',
+                    type: 'Sound', format: 'audio/mpeg',
+                  },
+                ],
+              },
+              target: { id: 'http://example.com/multi-canvas-manifest-v4/timeline/2', type: 'Timeline' }
+            },
+          ]
+        },
+      ],
+      annotations: [
+        {
+          id: 'http://example.com/multi-canvas-manifest-v4/timeline/2/page/2',
+          type: 'AnnotationPage',
+          items: [
+            {
+              id: 'http://example.com/multi-canvas-manifest-v4/timeline/2/annotation/1',
+              type: 'Annotation',
+              motivation: ['supplementing'],
+              body: {
+                id: 'https://example.com/audio-transcript.vtt', type: 'Text', format: 'text/vtt', language: ['en'],
+                label: { en: ['Captions in WebVTT format'], none: ['audio-transcript.vtt'] }
+              },
+              target: { id: 'http://example.com/multi-canvas-manifest-v4/timeline/2', type: 'Timeline' }
+            }
+          ]
+        },
+      ],
+      rendering: [
+        {
+          id: 'https://example.com/lunchroom_manners/transcript.vtt',
+          type: 'Text', label: { en: ['Canvas - Supplement file'] }, format: 'text/vtt',
+        }
+      ],
+    },
+  ]
+};


### PR DESCRIPTION
Related issue: #980 

This PR adds support for parsing IIIF Presentation API v4 manifests with `manifesto.js`.

Changes in this PR:
- Add a new module named `iiif-version-parser.js` to do the following,
  - identify IIIF API version in a given Manifest. Parses the `@context` property in a given Manifest and defaults to 3 if the given context is not identified as 4
  - convert any given value for `motivation` property into an array, which is the accepted format for this property in v4. This was partially in-place for annotations parsing in Ramp
  - derive the placeholder IIIF resource property name based on the version. v3 --> `placeholderCanvas` and v4 --> `placeholderContainer`
- Add `type="Timeline"` support for parsing `items` in a given Manifest
- Add a condition to check the presence of `duration` property of a given Annotation with `type="Canvas"` to identify video resources against image resources
- Replace the use of `PropertyValue` class from `manifesto.js` with Ramp's function `getLabelValue()` which gives the same result