### PR TITLE
Cleanup duplicated SVG symbols in VideoJS custom components

### DIFF
--- a/src/components/MediaPlayer/VideoJS/components/js/VideoJSAuthMenu.js
+++ b/src/components/MediaPlayer/VideoJS/components/js/VideoJSAuthMenu.js
@@ -1,31 +1,12 @@
 import videojs from 'video.js';
+import { svgIconToSymbol, SignOutIcon, UserIcon } from '@Services/svg-icons';
 import '../styles/VideoJSAuthMenu.scss';
-
-const userSVGSymbol = `
- <symbol id="user" viewBox="0 0 20 20">
-  <g id="SVGRepo_bgCarrier" stroke-width="0"></g>
-  <g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g>
-  <g id="SVGRepo_iconCarrier">
-    <path d="M5 21C5 17.134 8.13401 14 12 14C15.866 14 19 17.134 19 21M16 7C16
-      9.20914 14.2091 11 12 11C9.79086 11 8 9.20914 8 7C8 4.79086 9.79086 3 12 3C14.2091 3 16 4.79086 16 7Z"
-      stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-    </path>
-  </g>
- </symbol>`;
-
-const logOutSVGSymbol = `
-  <symbol id="log-out" viewBox="0 0 20 20">
-    <g id="SVGRepo_bgCarrier" stroke-width="0"></g>
-    <g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g>
-    <g id="SVGRepo_iconCarrier">
-      <path d="M11 4V7L5 7V9H11V12H12L16 8L12 4L11 4Z" fill="#ffffff"></path>
-      <path d="M0 1L3.41715e-07 15H8V13H2L2 3H8L8 1L0 1Z" fill="#ffffff"></path>
-    </g>
-  </symbol>
-`;
 
 // Function to inject SVGs into the DOM
 function injectSVGIcons() {
+  const userSVGSymbol = svgIconToSymbol(UserIcon, 'user');
+  const logOutSVGSymbol = svgIconToSymbol(SignOutIcon, 'log-out');
+
   const svgContainer = document.createElement('div');
   svgContainer.style.display = 'none';
   svgContainer.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg">${userSVGSymbol}${logOutSVGSymbol}</svg>`;

--- a/src/components/MediaPlayer/VideoJS/components/js/VideoJSTrackScrubber.js
+++ b/src/components/MediaPlayer/VideoJS/components/js/VideoJSTrackScrubber.js
@@ -3,35 +3,13 @@ import videojs from 'video.js';
 import '../styles/VideoJSTrackScrubber.scss';
 import '../styles/VideoJSProgress.scss';
 import { timeToHHmmss } from '@Services/utility-helpers';
-
-// SVG icons for zoom-in and zoom-out icons as strings
-const zoomOutIconSVG = `
-<symbol id="zoomed-out" viewBox="0 0 20 20">
-  <g id="SVGRepo_bgCarrier" stroke-width="0"></g>
-  <g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g>
-  <g id="SVGRepo_iconCarrier">
-    <path fill="#ffffff" fill-rule="evenodd" d="M4 9a5 5 0 1110 0A5 5 0 014 9zm5-7a7 7 
-      0 104.2 12.6.999.999 0 00.093.107l3 3a1 1 0 001.414-1.414l-3-3a.999.999 0 00-.107-.093A7 
-      7 0 009 2zM8 6.5a1 1 0 112 0V8h1.5a1 1 0 110 2H10v1.5a1 1 0 11-2 0V10H6.5a1 1 0 010-2H8V6.5z">
-    </path>
-  </g>
-</symbol>`;
-
-const zoomInIconSVG = `
-<symbol id="zoomed-in" viewBox="0 0 20 20">
-  <g id="SVGRepo_bgCarrier" stroke-width="0"></g>
-  <g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g>
-  <g id="SVGRepo_iconCarrier">
-    <path fill="#ffffff" fill-rule="evenodd" d="M9 4a5 5 0 100 10A5 5 0 009 4zM2 9a7 
-      7 0 1112.6 4.2.999.999 0 01.107.093l3 3a1 1 0 01-1.414 1.414l-3-3a.999.999 0 
-      01-.093-.107A7 7 0 012 9zm10.5 0a1 1 0 00-1-1h-5a1 1 0 100 2h5a1 1 0 001-1z">
-    </path>
-  </g>
-</symbol>`;
-
+import { svgIconToSymbol, TrackScrubberZoomInIcon, TrackScrubberZoomOutIcon } from '@Services/svg-icons';
 
 // Function to inject SVGs into the DOM
 function injectSVGIcons() {
+  const zoomOutIconSVG = svgIconToSymbol(TrackScrubberZoomOutIcon, 'zoomed-out');
+  const zoomInIconSVG = svgIconToSymbol(TrackScrubberZoomInIcon, 'zoomed-in');
+
   const svgContainer = document.createElement('div');
   svgContainer.style.display = 'none';
   svgContainer.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg">${zoomOutIconSVG}${zoomInIconSVG}</svg>`;

--- a/src/services/svg-icons.js
+++ b/src/services/svg-icons.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
 
 /** SVG icons for the edit buttons in Annotations component */
 export const EditIcon = () => {
@@ -203,4 +204,20 @@ export const UserIcon = () => {
       </g>
     </svg>
   );
+};
+
+/**
+ * Convert a React SVG icon component into an SVG <symbol> markup string to be used in
+ * custom VideoJS components.
+ * @param {Function} IconComponent React SVG icon component
+ * @param {String} id id of the SVG <symbol>
+ * @param {Object} props props to pass to IconComponent when rendering
+ * @returns {String} `<symbol id="${id}">...</symbol>` markup string
+ */
+export const svgIconToSymbol = (IconComponent, id, props = {}) => {
+  const markup = renderToStaticMarkup(<IconComponent {...props} />);
+  const viewBoxMatch = markup.match(/viewBox="([^"]*)"/);
+  const viewBox = viewBoxMatch ? viewBoxMatch[1] : '0 0 24 24';
+  const innerContent = markup.replace(/^<svg[^>]*>/, '').replace(/<\/svg>$/, '');
+  return `<symbol id="${id}" viewBox="${viewBox}">${innerContent}</symbol>`;
 };

--- a/src/services/svg-icons.js
+++ b/src/services/svg-icons.js
@@ -221,7 +221,7 @@ export const svgIconToSymbol = (IconComponent, id, props = {}) => {
   flushSync(() => root.render(<IconComponent {...props} />));
 
   const svgEl = container.firstElementChild;
-  const viewBox = svgEl.getAttribute('viewBox') || '0 0 24 24' || '0 0 20 20';
+  const viewBox = svgEl.getAttribute('viewBox') || '0 0 20 20';
   const innerContent = svgEl.innerHTML;
 
   root.unmount();

--- a/src/services/svg-icons.js
+++ b/src/services/svg-icons.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { renderToStaticMarkup } from 'react-dom/server';
+import { flushSync } from 'react-dom';
+import { createRoot } from 'react-dom/client';
 
 /** SVG icons for the edit buttons in Annotations component */
 export const EditIcon = () => {
@@ -92,10 +93,12 @@ export const TrackScrubberZoomInIcon = ({ scale }) => {
   return (
     <svg viewBox='0 0 20 20' xmlns='http://www.w3.org/2000/svg'
       style={{ fill: 'white', height: '1.25rem', width: '1.25rem', scale: scale }}>
-      <g strokeWidth='0' strokeLinecap='round' strokeLinejoin='round'>
-        <path fill='#ffffff' fillRule='evenodd' d='M4 9a5 5 0 1110 0A5 5 0 014 9zm5-7a7 7 0 104.2 12.6.999.999 
-				0 00.093.107l3 3a1 1 0 001.414-1.414l-3-3a.999.999 0 00-.107-.093A7 7 0 009 2zM8 6.5a1 1 0 112 0V8h1.5a1 
-				1 0 110 2H10v1.5a1 1 0 11-2 0V10H6.5a1 1 0 010-2H8V6.5z'>
+      <g id="SVGRepo_bgCarrier" strokeWidth="0"></g>
+      <g id="SVGRepo_tracerCarrier" strokeLinecap="round" strokeLinejoin="round"></g>
+      <g id="SVGRepo_iconCarrier">
+        <path fill="#ffffff" fillRule="evenodd" d="M9 4a5 5 0 100 10A5 5 0 009 4zM2 9a7 
+      7 0 1112.6 4.2.999.999 0 01.107.093l3 3a1 1 0 01-1.414 1.414l-3-3a.999.999 0 
+      01-.093-.107A7 7 0 012 9zm10.5 0a1 1 0 00-1-1h-5a1 1 0 100 2h5a1 1 0 001-1z">
         </path>
       </g>
     </svg>
@@ -104,16 +107,14 @@ export const TrackScrubberZoomInIcon = ({ scale }) => {
 
 export const TrackScrubberZoomOutIcon = ({ scale }) => {
   return (
-    <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"
+    <svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"
       style={{ fill: 'white', height: '1.25rem', width: '1.25rem', scale: scale }}>
-      <g strokeWidth="0" strokeLinecap="round" strokeLinejoin="round">
-        <path fillRule="evenodd" clipRule="evenodd" d="M4 11C4 7.13401 7.13401 4 11 4C14.866 4 18 7.13401 18 11C18 14.866 
-				14.866 18 11 18C7.13401 18 4 14.866 4 11ZM11 2C6.02944 2 2 6.02944 2 11C2 15.9706 6.02944 20 11 20C13.125 20 15.078 
-				19.2635 16.6177 18.0319L20.2929 21.7071C20.6834 22.0976 21.3166 22.0976 21.7071 21.7071C22.0976 21.3166 22.0976 
-				20.6834 21.7071 20.2929L18.0319 16.6177C19.2635 15.078 20 13.125 20 11C20 6.02944 15.9706 2 11 2Z" fill="#ffffff">
-        </path>
-        <path fillRule="evenodd" clipRule="evenodd" d="M7 11C7 10.4477 7.44772 10 8 10H14C14.5523 10 15 10.4477 15 11C15 
-				11.5523 14.5523 12 14 12H8C7.44772 12 7 11.5523 7 11Z" fill="#ffffff">
+      <g id="SVGRepo_bgCarrier" strokeWidth="0"></g>
+      <g id="SVGRepo_tracerCarrier" strokeLinecap="round" strokeLinejoin="round"></g>
+      <g id="SVGRepo_iconCarrier">
+        <path fill="#ffffff" fillRule="evenodd" d="M4 9a5 5 0 1110 0A5 5 0 014 9zm5-7a7 7 
+      0 104.2 12.6.999.999 0 00.093.107l3 3a1 1 0 001.414-1.414l-3-3a.999.999 0 00-.107-.093A7 
+      7 0 009 2zM8 6.5a1 1 0 112 0V8h1.5a1 1 0 110 2H10v1.5a1 1 0 11-2 0V10H6.5a1 1 0 010-2H8V6.5z">
         </path>
       </g>
     </svg>
@@ -215,9 +216,14 @@ export const UserIcon = () => {
  * @returns {String} `<symbol id="${id}">...</symbol>` markup string
  */
 export const svgIconToSymbol = (IconComponent, id, props = {}) => {
-  const markup = renderToStaticMarkup(<IconComponent {...props} />);
-  const viewBoxMatch = markup.match(/viewBox="([^"]*)"/);
-  const viewBox = viewBoxMatch ? viewBoxMatch[1] : '0 0 24 24';
-  const innerContent = markup.replace(/^<svg[^>]*>/, '').replace(/<\/svg>$/, '');
+  const container = document.createElement('div');
+  const root = createRoot(container);
+  flushSync(() => root.render(<IconComponent {...props} />));
+
+  const svgEl = container.firstElementChild;
+  const viewBox = svgEl.getAttribute('viewBox') || '0 0 24 24' || '0 0 20 20';
+  const innerContent = svgEl.innerHTML;
+
+  root.unmount();
   return `<symbol id="${id}" viewBox="${viewBox}">${innerContent}</symbol>`;
 };

--- a/vite.config.js
+++ b/vite.config.js
@@ -85,12 +85,18 @@ export default defineConfig({
     // Rollup options for external dependencies
     rollupOptions: {
       external: [
-        ...Object.keys(pkg.peerDependencies || {})
+        ...Object.keys(pkg.peerDependencies || {}),
+        /* This is not an explicit perrDependency, however this must stay external like 'react'
+        and 'react-dom' so that, a second copy of React internals doesn't get bundled parallel
+        to a host application's own copy. */
+        'react-dom/client',
       ],
       output: {
         globals: {
           react: 'React',
           'react-dom': 'ReactDOM',
+          // 'createRoot' from 'react-dom/client' is exposed on the same ReactDOM UMD in the bundle
+          'react-dom/client': 'ReactDOM',
           'manifesto.js': 'manifesto',
           'mime-db': 'mimeDB',
           'dompurify': 'DOMPurify',


### PR DESCRIPTION
Related issue: #982 

Changes in this PR:
- Remove duplicated SVG definitions as symbols in VideoJS custom components
- Introduce a bridge function in `svg-icons.js` to convert the React SVG icon components to SVG `<symbol>` strings in VideoJS components 