### PR TITLE
Waveform display

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -67,7 +67,8 @@ const App = ({ manifestURL, DEMO_MANIFEST_OPTIONS }) => {
       <main className='ramp--player_container'>
         <IIIFPlayer manifestUrl={manifestUrl}>
           <div className='iiif-player-demo'>
-            <MediaPlayer enableFileDownload={true} enablePlaybackRate={true} resumeCache={{ enable: true }} />
+            <MediaPlayer enableFileDownload={true} enablePlaybackRate={true} resumeCache={{ enable: true }}
+              showWaveform={true} />
             <div className='components-row'>
               <div className='nav'>
                 <AutoAdvanceToggle />

--- a/jest.config.js
+++ b/jest.config.js
@@ -29,7 +29,8 @@ module.exports = {
   // An array of regexp pattern strings used to skip coverage collection
   coveragePathIgnorePatterns: [
     '/node_modules/',
-    '/src/components/MediaPlayer/VideoJS/components'
+    '/src/components/MediaPlayer/VideoJS/components',
+    '/src/test_data'
   ],
 
   // A list of reporter names that Jest uses when writing coverage reports

--- a/package.json
+++ b/package.json
@@ -95,7 +95,8 @@
     "mime-types": "^3.0.2",
     "react-error-boundary": "^4.0.11",
     "video.js": "^8.23.7",
-    "videojs-markers-plugin": "^1.0.2"
+    "videojs-markers-plugin": "^1.0.2",
+    "waveform-data": "^4.5.2"
   },
   "peerDependencies": {
     "react": "^19.0.0",

--- a/src/components/MediaPlayer/MediaPlayer.js
+++ b/src/components/MediaPlayer/MediaPlayer.js
@@ -23,9 +23,10 @@ const PLAYER_ID = 'iiif-media-player';
  * @param {Boolean} props.withCredentials
  * @param {String} props.language
  * @param {Object} props.resumeCache
- * @param {Boolean} props.resumeCache.enable whether to enable caching of playback positions
- * @param {Number} props.resumeCache.ttlDays number of days before a cached entry expires, default: 30 days
- * @param {Number} props.resumeCache.maxItems maximum number of entries to be stored in the cache, default: 200 entries
+ * @param {Boolean} props.resumeCache.enable
+ * @param {Number} props.resumeCache.ttlDays
+ * @param {Number} props.resumeCache.maxItems
+ * @param {Boolean} props.showWaveform
  */
 const MediaPlayer = ({
   enableFileDownload = false,
@@ -35,19 +36,28 @@ const MediaPlayer = ({
   withCredentials = false,
   language = 'en',
   resumeCache = { enable: false, ttlDays: 30, maxItems: 200 },
+  showWaveform = false,
 }) => {
   const manifestState = useManifestState();
   const manifestDispatch = useManifestDispatch();
   const playerState = usePlayerState();
   const { showBoundary } = useErrorBoundary();
 
-  const { srcIndex, playlist, structures, auth, allCanvases } = manifestState;
+  const { srcIndex, playlist, structures, auth, allCanvases, waveform } = manifestState;
   const { isPlaylist } = playlist;
   const { hasStructure } = structures;
   const { currentTime } = playerState;
 
+  /* Enable VideoJSWaveform control when 'showWaveform' is turned ON 
+  and the current Canvas has a waveform */
+  const enableWaveform = waveform?.data != null && showWaveform;
+
+  /* React Refs for external UI DOM elements created in VideoJSPlayer that are referenced in
+  VideoJS's custom components. e.g.: trackScrubberRef in VideoJSTrackScrubber */
   const trackScrubberRef = useRef();
   const timeToolRef = useRef();
+  const waveformRef = useRef();
+
   let videoJSLangMap = useRef('{}');
   const [languageLoaded, setLanguageLoaded] = useState(false);
 
@@ -173,6 +183,7 @@ const MediaPlayer = ({
             (tracks.length > 0 && isVideo) ? 'subsCapsButton' : '',
             (audioDescTracks.length > 0 && isVideo) ? 'videoJSADButton' : '',
             (hasStructure || isPlaylist) ? 'videoJSTrackScrubber' : '',
+            enableWaveform ? 'videoJSWaveform' : '',
             'qualitySelector',
             enablePlaybackRate ? 'playbackRateMenuButton' : '',
             enablePIP ? 'pictureInPictureToggle' : '',
@@ -207,6 +218,7 @@ const MediaPlayer = ({
             { canvasIndex, lastCanvasIndex, switchPlayer },
           videoJSTrackScrubber: (hasStructure || isPlaylist) &&
             { trackScrubberRef, timeToolRef, isPlaylist },
+          videoJSWaveform: enableWaveform && { waveformRef },
           videoJSADButton: (audioDescTracks.length > 0) && { audioDescTracks }
         },
         // Only pass along the sources with access in VideoJS options
@@ -241,6 +253,7 @@ const MediaPlayer = ({
           tracks={tracks}
           trackScrubberRef={trackScrubberRef}
           videoJSLangMap={videoJSLangMap.current}
+          waveformConfig={{ waveformRef, showWaveform }}
           withCredentials={withCredentials}
         />
       </div>
@@ -291,6 +304,11 @@ MediaPlayer.propTypes = {
     ttlDays: PropTypes.number,
     maxItems: PropTypes.number,
   }),
+  /** Adds a toggle control to the player's control-bar to turn ON/OFF waveform display panel. When this is enabled, the MediaPlayer checks if the
+   * active Canvas has a waveform representation of its media attached via a 'seeAlso' or 'accompanyingCanvas' property before displaying the player
+   * control in the player's control-bar. When the toggle is ON, a panel is shown beneath the player similar to track-scrubber to display the waveform
+   * data (**NEXT_RELEASE**). */
+  showWaveform: PropTypes.bool,
 };
 
 export default MediaPlayer;

--- a/src/components/MediaPlayer/MediaPlayer.js
+++ b/src/components/MediaPlayer/MediaPlayer.js
@@ -56,7 +56,6 @@ const MediaPlayer = ({
   VideoJS's custom components. e.g.: trackScrubberRef in VideoJSTrackScrubber */
   const trackScrubberRef = useRef();
   const timeToolRef = useRef();
-  const waveformRef = useRef();
 
   let videoJSLangMap = useRef('{}');
   const [languageLoaded, setLanguageLoaded] = useState(false);
@@ -218,7 +217,6 @@ const MediaPlayer = ({
             { canvasIndex, lastCanvasIndex, switchPlayer },
           videoJSTrackScrubber: (hasStructure || isPlaylist) &&
             { trackScrubberRef, timeToolRef, isPlaylist },
-          videoJSWaveform: enableWaveform && { waveformRef },
           videoJSADButton: (audioDescTracks.length > 0) && { audioDescTracks }
         },
         // Only pass along the sources with access in VideoJS options
@@ -253,7 +251,7 @@ const MediaPlayer = ({
           tracks={tracks}
           trackScrubberRef={trackScrubberRef}
           videoJSLangMap={videoJSLangMap.current}
-          waveformConfig={{ waveformRef, showWaveform }}
+          showWaveform={showWaveform}
           withCredentials={withCredentials}
         />
       </div>

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -18,6 +18,7 @@ import {
 } from '@Services/browser';
 import { useLocalStorage } from '@Services/local-storage';
 import { usePlaybackPositions } from '@Services/save-playback-positions';
+import { useWaveform } from '@Services/hooks/useWaveform';
 import { requestLogout } from '@Services/auth-service';
 import { showResumeModal } from './VideoJSResumeModal';
 import { showErrorModal } from './components/js/VideoJSErrorModal';
@@ -37,6 +38,7 @@ import VideoJSNextButton from './components/js/VideoJSNextButton';
 import VideoJSPreviousButton from './components/js/VideoJSPreviousButton';
 import VideoJSTitleLink from './components/js/VideoJSTitleLink';
 import VideoJSTrackScrubber from './components/js/VideoJSTrackScrubber';
+import VideoJSWaveform from './components/js/VideoJSWaveform';
 import VideoJSADButton from './components/js/VideoJSADButton';
 import VideoJSAuthMenu from './components/js/VideoJSAuthMenu';
 
@@ -58,6 +60,7 @@ import VideoJSAuthMenu from './components/js/VideoJSAuthMenu';
  * @param {Boolean} props.enableTitleLink
  * @param {String} props.videoJSLangMap
  * @param {Object} props.options
+ * @param {Object} props.waveformConfig
  */
 function VideoJSPlayer({
   audioDescTracks,
@@ -71,6 +74,7 @@ function VideoJSPlayer({
   tracks,
   trackScrubberRef,
   videoJSLangMap,
+  waveformConfig = { waveformRef: null, showWaveform: false },
   withCredentials,
 }) {
   const playerState = usePlayerState();
@@ -91,6 +95,7 @@ function VideoJSPlayer({
     canvasSegments,
     auth,
   } = manifestState;
+  const { waveformRef, showWaveform } = waveformConfig;
   const { hasStructure, structItems } = structures;
   const { clickedUrl, isEnded, isPlaying, currentTime } = playerState;
 
@@ -104,6 +109,8 @@ function VideoJSPlayer({
     maxItems: resumeCache?.maxItems,
     ttlDays: resumeCache?.ttlDays,
   });
+
+  const { hasWaveform } = useWaveform({ showWaveform, waveformRef });
 
   const videoJSRef = useRef(null);
   const captionsOnRef = useRef();
@@ -1740,6 +1747,11 @@ function VideoJSPlayer({
           <p className="vjs-time track-duration" role="presentation"></p>
         </div>)
       }
+      {hasWaveform &&
+        (<div className="vjs-waveform-container hidden" ref={waveformRef} id="waveform_panel"
+          data-testid="videojs-waveform-panel">
+        </div>)
+      }
     </div >
   );
 };
@@ -1756,6 +1768,10 @@ VideoJSPlayer.propTypes = {
   tracks: PropTypes.array,
   trackScrubberRef: PropTypes.object,
   videoJSLangMap: PropTypes.string,
+  waveformConfig: PropTypes.shape({
+    showWaveform: PropTypes.bool,
+    waveformRef: PropTypes.object
+  }),
   withCredentials: PropTypes.bool,
 };
 

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -47,20 +47,18 @@ import VideoJSAuthMenu from './components/js/VideoJSAuthMenu';
  * on successive player reloads on Canvas changes.
  * @param {Object} props
  * @param {Array} props.audioDescTracks
- * @param {Boolean} props.isVideo
- * @param {Boolean} props.isPlaylist
- * @param {Object} props.trackScrubberRef
- * @param {Object} props.scrubberTooltipRef
- * @param {Array} props.tracks
- * @param {String} props.placeholderText
- * @param {Array} props.renderingFiles
  * @param {Boolean} props.enableFileDownload
- * @param {Function} props.loadPrevOrNext
- * @param {Number} props.lastCanvasIndex
  * @param {Boolean} props.enableTitleLink
- * @param {String} props.videoJSLangMap
+ * @param {Boolean} props.isVideo
  * @param {Object} props.options
- * @param {Object} props.waveformConfig
+ * @param {String} props.placeholderText
+ * @param {Object} props.resumeCache
+ * @param {Object} props.scrubberTooltipRef
+ * @param {Object} props.showWaveform
+ * @param {Array} props.tracks
+ * @param {Object} props.trackScrubberRef
+ * @param {String} props.videoJSLangMap
+ * @param {Boolean} props.withCredentials
  */
 function VideoJSPlayer({
   audioDescTracks,
@@ -71,10 +69,10 @@ function VideoJSPlayer({
   placeholderText,
   resumeCache,
   scrubberTooltipRef,
+  showWaveform,
   tracks,
   trackScrubberRef,
   videoJSLangMap,
-  waveformConfig = { waveformRef: null, showWaveform: false },
   withCredentials,
 }) {
   const playerState = usePlayerState();
@@ -95,7 +93,6 @@ function VideoJSPlayer({
     canvasSegments,
     auth,
   } = manifestState;
-  const { waveformRef, showWaveform } = waveformConfig;
   const { hasStructure, structItems } = structures;
   const { clickedUrl, isEnded, isPlaying, currentTime } = playerState;
 
@@ -104,18 +101,17 @@ function VideoJSPlayer({
   const [startCaptioned, setStartCaptioned] = useLocalStorage('startCaptioned', true);
   const [startQuality, setStartQuality] = useLocalStorage('startQuality', null);
 
-  const { savePosition, getPosition, clearPosition } = usePlaybackPositions({
+  const { clearPosition, savedPosition, savePosition } = usePlaybackPositions({
     enable: resumeCache?.enable,
     maxItems: resumeCache?.maxItems,
     ttlDays: resumeCache?.ttlDays,
   });
 
-  const { hasWaveform } = useWaveform({ showWaveform, waveformRef });
-
   const videoJSRef = useRef(null);
   const captionsOnRef = useRef();
   const activeTextTrackRef = useRef();
   const isForcedTextTrackRef = useRef(false);
+  const waveformRef = useRef();
   // Ref to store track.change event handler with up-to-date sticky settings
   const trackChangeHandlerRef = useRef(null);
   const resumeModalRef = useRef(null);
@@ -127,6 +123,8 @@ function VideoJSPlayer({
   const { isPlaylist, renderingFiles, srcIndex, switchPlayer }
     = useSetupPlayer({ enableFileDownload, withCredentials, lastCanvasIndex });
   const { messageTime } = useShowInaccessibleMessage({ lastCanvasIndex });
+
+  const { hasWaveform } = useWaveform({ savedPosition, showWaveform, waveformRef });
 
   const canvasIsEmptyRef = useRef();
   canvasIsEmptyRef.current = useMemo(() => { return canvasIsEmpty; }, [canvasIsEmpty]);
@@ -1589,27 +1587,12 @@ function VideoJSPlayer({
    * @param {Object} player Video.js player instance
    */
   const resumePlaybackModal = () => {
-    /* Skip the resume playback modal when,
-    - there is a custom start indicated via 'startCanvasTime' prop
-    - the Manifest is a playlist
-    */
-    if (customStart?.startTime > 0 || isPlaylist) return;
+    // Skip if the current Canvas doesn't have a saved playback position
+    if (!savedPosition) return;
+
+    const { canvasURL: savedCanvasURL, time: savedTime } = savedPosition;
 
     const manifestURL = manifestURLRef.current;
-    if (!manifestURL) return;
-
-    const saved = getPosition(manifestURL);
-    if (!saved || saved.time <= 0) return;
-
-    const { canvasURL: savedCanvasURL, time: savedTime } = saved;
-
-    /* When a 'startCanvasId' is set, only show resume modal if the saved position
-    is on the 'startCanvasId' Canvas. Ignore saves on any other canvas. */
-    if (customStart?.startIndex > 0) {
-      const startCanvasURL = allCanvases[customStart.startIndex]?.canvasURL;
-      if (savedCanvasURL !== startCanvasURL) return;
-    }
-
     if (savedCanvasURL !== canvasURLRef.current) {
       // When saved position is on a different Canvas load the saved Canvas first
       const savedCanvasIndex = allCanvases.findIndex((c) => c.canvasURL === savedCanvasURL);
@@ -1768,10 +1751,7 @@ VideoJSPlayer.propTypes = {
   tracks: PropTypes.array,
   trackScrubberRef: PropTypes.object,
   videoJSLangMap: PropTypes.string,
-  waveformConfig: PropTypes.shape({
-    showWaveform: PropTypes.bool,
-    waveformRef: PropTypes.object
-  }),
+  showWaveform: PropTypes.bool,
   withCredentials: PropTypes.bool,
 };
 

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.test.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.test.js
@@ -8,6 +8,7 @@ import videoManifest from '@TestData/lunchroom-manners';
 import playlistManifest from '@TestData/playlist';
 import singleCanvasManifest from '@TestData/single-canvas';
 import authManifest from '@TestData/auth-manifest';
+import waveformManifest from '@TestData/waveform-example';
 
 // Mock 'requestLogout' from auth-service module
 jest.mock('@Services/auth-service', () => ({
@@ -647,6 +648,217 @@ describe('VideoJSPlayer component', () => {
           expect(aspectRatioSpy).toHaveBeenCalledWith('16:9');
           expect(player.hasClass('vjs-disabled')).toBe(true);
         });
+      });
+    });
+  });
+
+  describe('feature: waveform display', () => {
+    // Jest does not support the ResizeObserver API so mock it here to allow tests to run.
+    const ResizeObserver = jest.fn().mockImplementation(() => ({
+      disconnect: jest.fn(),
+      observe: jest.fn(),
+      unobserve: jest.fn(),
+    }));
+    window.ResizeObserver = ResizeObserver;
+
+    const waveformRef = { current: document.createElement('div') };
+    const resumeModalRef = { current: document.createElement('div') };
+    const props = { resumeModalRef, waveformRef };
+
+    const mockWaveformFetch = () => {
+      jest.spyOn(global, 'fetch').mockImplementation(() => {
+        return Promise.resolve({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce({
+            version: 2, channels: 1, sample_rate: 44100, samples_per_pixel: 512,
+            bits: 8, length: 2, data: [0, 10, -5, 8],
+          }),
+        });
+      });
+    };
+
+    describe('doesn\'t add waveform toggle button or panel', () => {
+      test('when the Canvas has no waveform resource', async () => {
+        await renderPlayer({ manifest: videoManifest, canvasIndex: 0, ...props });
+
+        expect(screen.queryByTestId('videojs-waveform-button')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('videojs-waveform-panel')).not.toBeInTheDocument();
+      });
+
+      test('when "showWaveform" prop is turned off (default)', async () => {
+        await renderPlayer({ manifest: waveformManifest, canvasIndex: 0 });
+
+        expect(screen.queryByTestId('videojs-waveform-button')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('videojs-waveform-panel')).not.toBeInTheDocument();
+      });
+
+      test('when the waveform resource fetch fails', async () => {
+        const fetchSpy = jest.spyOn(global, 'fetch')
+          .mockRejectedValueOnce(new Error('Network error'));
+
+        await renderPlayer({
+          manifest: waveformManifest, canvasIndex: 0,
+          props: { ...props, showWaveform: true },
+        });
+
+        expect(fetchSpy).toHaveBeenCalledWith('http://example.com/waveform.json', expect.anything());
+        expect(console.error).toHaveBeenCalled();
+
+        // The panel is added to the DOM because the waveform resource is present in Canvas
+        expect(screen.queryByTestId('videojs-waveform-panel')).toBeInTheDocument();
+        // Waveform toggle button is not added to the control-bar
+        expect(screen.queryByTestId('videojs-waveform-button')).not.toBeInTheDocument();
+      });
+
+      test('when the waveform resource is not a waveform', async () => {
+        const fetchSpy = jest.spyOn(global, 'fetch');
+
+        /* The 4th Canvas in this Manifest has a .xml with format 'text/xml' attached in 'seeAlso',
+        which is not a vali waveform format. Therefore, it gets filtered out during parsing. */
+        await renderPlayer({
+          manifest: waveformManifest, canvasIndex: 3,
+          props: { ...props, showWaveform: true },
+        });
+
+        expect(fetchSpy).not.toHaveBeenCalled();
+
+        expect(screen.queryByTestId('videojs-waveform-panel')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('videojs-waveform-button')).not.toBeInTheDocument();
+      });
+    });
+
+    describe('adds waveform toggle and panel', () => {
+      test('when a waveform resource is present', async () => {
+        jest.spyOn(global, 'fetch').mockImplementation(() => {
+          return Promise.resolve({
+            ok: true,
+            json: jest.fn().mockResolvedValueOnce({
+              version: 2, channels: 1, sample_rate: 44100, samples_per_pixel: 512,
+              bits: 8, length: 2, data: [0, 10, -5, 8],
+            }),
+          });
+        });
+
+        await renderPlayer({
+          manifest: waveformManifest, canvasIndex: 0,
+          props: { ...props, showWaveform: true }
+        });
+
+        expect(screen.queryByTestId('videojs-waveform-panel')).toBeInTheDocument();
+        expect(screen.queryByTestId('videojs-waveform-button')).toBeInTheDocument();
+      });
+
+      test('with a waveform visualization as pixels in a canvas for a waveform dataset', async () => {
+        jest.spyOn(global, 'fetch').mockImplementation(() => {
+          return Promise.resolve({
+            ok: true,
+            json: jest.fn().mockResolvedValueOnce({
+              version: 2, channels: 1, sample_rate: 44100, samples_per_pixel: 512,
+              bits: 8, length: 2, data: [0, 10, -5, 8],
+            }),
+          });
+        });
+
+        await renderPlayer({
+          manifest: waveformManifest, canvasIndex: 0, props: { ...props, showWaveform: true },
+        });
+
+        expect(screen.queryByTestId('videojs-waveform-panel')).toBeInTheDocument();
+        const panel = screen.getByTestId('videojs-waveform-panel');
+        expect(panel).toBeInTheDocument();
+        expect(panel.querySelector('canvas.vjs-waveform-canvas')).toBeInTheDocument();
+      });
+
+      test('with a waveform visualization a an image for a waveform image', async () => {
+        await renderPlayer({
+          manifest: waveformManifest, canvasIndex: 1,
+          props: { ...props, showWaveform: true },
+        });
+
+        expect(screen.queryByTestId('videojs-waveform-panel')).toBeInTheDocument();
+        const panel = screen.getByTestId('videojs-waveform-panel');
+        expect(panel.style.backgroundImage).toContain('http://example.com/waveform.jpg');
+        expect(panel.querySelector('canvas.vjs-waveform-canvas')).not.toBeInTheDocument();
+      });
+    });
+
+    test('toggles waveform panel visibility', async () => {
+      mockWaveformFetch();
+      await renderPlayer({
+        manifest: waveformManifest, canvasIndex: 0,
+        props: { ...props, showWaveform: true },
+      });
+
+      const panel = await screen.findByTestId('videojs-waveform-panel');
+      expect(panel).toHaveClass('hidden');
+
+      const toggleButton = screen.getByTestId('videojs-waveform-button');
+      fireEvent.click(toggleButton);
+      expect(panel).not.toHaveClass('hidden');
+
+      fireEvent.click(toggleButton);
+      expect(panel).toHaveClass('hidden');
+    });
+
+    describe('on page load', () => {
+      test('shows the panel for an audio Canvas without a saved playback position', async () => {
+        mockWaveformFetch();
+
+        await renderPlayer({
+          manifest: waveformManifest, canvasIndex: 2,
+          props: { ...props, showWaveform: true },
+        });
+
+        await screen.findByTestId('videojs-waveform-button');
+        const panel = screen.getByTestId('videojs-waveform-panel');
+        expect(panel).not.toHaveClass('hidden');
+      });
+
+      test('hides the panel for an audio Canvas with a saved playback position', async () => {
+        mockWaveformFetch();
+        localStorage.setItem(
+          'playbackPositions',
+          JSON.stringify([{
+            key: 'http://example.com/waveform-example/manifest.json',
+            value: {
+              canvasURL: 'http://example.com/waveform-example/canvas/1',
+              time: 30, savedAt: Date.now(),
+            },
+          }])
+        );
+
+        await renderPlayer({
+          manifest: waveformManifest, canvasIndex: 2,
+          props: { ...props, showWaveform: true, resumeCache: { enable: true } },
+        });
+
+        await screen.findByTestId('videojs-waveform-button');
+        const panel = screen.getByTestId('videojs-waveform-panel');
+        expect(panel).toHaveClass('hidden');
+      });
+
+      test('hides the panel for a video Canvas regardless of saved playback position', async () => {
+        mockWaveformFetch();
+        localStorage.setItem(
+          'playbackPositions',
+          JSON.stringify([{
+            key: 'http://example.com/single-canvas-manifest/manifest.json',
+            value: {
+              canvasURL: 'http://example.com/single-canvas-manifest/canvas/1',
+              time: 30,
+              savedAt: Date.now(),
+            },
+          }])
+        );
+
+        await renderPlayer({
+          manifest: waveformManifest, canvasIndex: 0,
+          props: { ...props, showWaveform: true, resumeCache: { enable: true } },
+        });
+
+        await screen.findByTestId('videojs-waveform-button');
+        const panel = screen.getByTestId('videojs-waveform-panel');
+        expect(panel).toHaveClass('hidden');
       });
     });
   });

--- a/src/components/MediaPlayer/VideoJS/components/js/VideoJSTrackScrubber.js
+++ b/src/components/MediaPlayer/VideoJS/components/js/VideoJSTrackScrubber.js
@@ -47,31 +47,12 @@ class VideoJSTrackScrubber extends Button {
     this.playerInterval;
 
     this.zoomedOutRef = createRef();
+    this.zoomedOutRef.current = true;
+
     this.currentTrackRef = createRef();
+    this.currentTrackRef.current = {};
 
-    // Attach interval on first load for time updates
-    this.player.on('ready', () => {
-      if (this.options.trackScrubberRef.current) {
-        this.playerInterval = setInterval(() => {
-          this.handleTimeUpdate();
-        }, 100);
-      }
-    });
-
-    /* 
-      When player is fully built and the trackScrubber element is initialized,
-      call method to mount React component.
-    */
-    this.player.on('loadstart', () => {
-      if (this.options.trackScrubberRef.current) {
-        this.updateComponent();
-        if (!this.playerInterval) {
-          this.playerInterval = setInterval(() => {
-            this.handleTimeUpdate();
-          }, 100);
-        }
-      }
-    });
+    this.attachListeners();
 
     // Hide track scrubber if it is displayed when player is going fullscreen
     this.player.on('fullscreenchange', () => {
@@ -111,46 +92,45 @@ class VideoJSTrackScrubber extends Button {
 
   attachListeners() {
     const { trackScrubberRef } = this.options;
-    if (trackScrubberRef.current) {
-      // Initialize the track scrubber's current time and duration
-      this.populateTrackScrubber();
-      this.updateTrackScrubberProgressBar();
+    if (!trackScrubberRef.current) return;
 
-      let pointerDragged = false;
-      // Attach mouse pointer events to track scrubber progress bar
-      let [_, progressBar, __] = trackScrubberRef.current.children;
-      progressBar.addEventListener('mouseenter', (e) => {
-        this.handleMouseMove(e);
-      });
-      /*
-        Using pointerup, pointermove, pointerdown events instead of
-        mouseup, mousemove, mousedown events to make it work with both
-        mouse pointer and touch events 
-      */
-      progressBar.addEventListener('pointerup', (e) => {
-        if (pointerDragged) {
-          this.handleSetProgress(e);
-        }
-      });
-      progressBar.addEventListener('pointermove', (e) => {
-        this.handleMouseMove(e);
-        pointerDragged = true;
-      });
-      progressBar.addEventListener('pointerdown', (e) => {
-        // Only handle left click event
-        if (e.which === 1) {
-          this.handleSetProgress(e);
-          pointerDragged = false;
-        }
-      });
+    // Initialize the track scrubber's current time and duration
+    this.populateTrackScrubber();
+    this.updateTrackScrubberProgressBar();
+
+    let pointerDragged = false;
+    // Attach mouse pointer events to track scrubber progress bar
+    let [_, progressBar, __] = trackScrubberRef.current.children;
+    progressBar.addEventListener('mouseenter', (e) => {
+      this.handleMouseMove(e);
+    });
+    /*
+      Using pointerup, pointermove, pointerdown events instead of
+      mouseup, mousemove, mousedown events to make it work with both
+      mouse pointer and touch events 
+    */
+    progressBar.addEventListener('pointerup', (e) => {
+      if (pointerDragged) {
+        this.handleSetProgress(e);
+      }
+    });
+    progressBar.addEventListener('pointermove', (e) => {
+      this.handleMouseMove(e);
+      pointerDragged = true;
+    });
+    progressBar.addEventListener('pointerdown', (e) => {
+      // Only handle left click event
+      if (e.which === 1) {
+        this.handleSetProgress(e);
+        pointerDragged = false;
+      }
+    });
+
+    if (!this.playerInterval) {
+      this.playerInterval = setInterval(() => {
+        this.handleTimeUpdate();
+      }, 100);
     }
-  }
-
-  updateComponent() {
-    // Reset refs to initial value
-    this.zoomedOutRef.current = true;
-    this.currentTrackRef.current = {};
-    this.attachListeners();
   }
 
   /**

--- a/src/components/MediaPlayer/VideoJS/components/js/VideoJSWaveform.js
+++ b/src/components/MediaPlayer/VideoJS/components/js/VideoJSWaveform.js
@@ -25,6 +25,8 @@ const Button = videojs.getComponent('Button');
  * @param {Object} props
  * @param {Object} props.player VideoJS player instance
  * @param {Object} props.options
+ * @param {Boolean} props.options.hasSavedPosition the current Manifest has a saved
+ * playback position in localStorage
  * @param {Object} props.options.waveformRef React ref to the waveform panel element
  */
 class VideoJSWaveform extends Button {
@@ -42,13 +44,18 @@ class VideoJSWaveform extends Button {
     this.player = player;
     this.playerInterval;
 
+    /* Read the 'audioOnlyMode' in player options instead of 'player.audioOnlyMode_',
+    since Video.js only apply the second one on its 'ready' event, which is not guaranteed
+    to have fired at this point of time. */
+    const isAudioOnly = !!this.player.options_.audioOnlyMode;
+
     this.hiddenRef = createRef();
-    this.hiddenRef.current = true;
+    // Display waveform panel by default for audio players without a saved playback position
+    this.hiddenRef.current = !(isAudioOnly && !options.hasSavedPosition);
 
     this.waveformData = null;
 
     this.canvas = null;
-    this.progressCanvas = null;
     this.resizeObserver = null;
 
     // Initial panel setup and waveform draw on the state changes as the player loads
@@ -60,8 +67,9 @@ class VideoJSWaveform extends Button {
       this.refreshWaveformData();
     });
 
-    // Unblock the waveform panel
-    this.player.on('seeked', () => {
+    /* Unblock the waveform panel using either 'loadeddata' or 'loadstart' events,
+    but this could be flaky. */
+    this.player.on(['loadeddata', 'loadstart'], () => {
       const { waveformRef } = this.options;
       if (waveformRef.current && waveformRef.current.classList.contains('vjs-disabled')) {
         waveformRef.current?.classList.remove('vjs-disabled');
@@ -88,6 +96,8 @@ class VideoJSWaveform extends Button {
   attachListeners() {
     const { waveformRef } = this.options;
     if (!waveformRef.current) return;
+
+    this.setHidden(this.hiddenRef.current);
 
     let pointerDragged = false;
     waveformRef.current.addEventListener('pointerup', (e) => {
@@ -179,10 +189,6 @@ class VideoJSWaveform extends Button {
     }
     this.waveformData = null;
 
-    if (this.progressCanvas) {
-      this.progressCanvas.remove();
-      this.progressCanvas = null;
-    }
     this.resizeObserver?.disconnect();
     this.resizeObserver = null;
 
@@ -191,6 +197,7 @@ class VideoJSWaveform extends Button {
 
     // If the current waveform is an image set it as the background of the panel
     if (waveform.type === 'image') {
+      panel.style.backgroundColor = '#696667';
       panel.style.backgroundImage = `url(${waveform.url})`;
       panel.style.setProperty('--waveform-image-url', `url(${waveform.url})`);
       return;
@@ -198,18 +205,13 @@ class VideoJSWaveform extends Button {
 
     // If the current waveform is a dataset re-initialize the canvases and observers
     if (waveform.type === 'peaks') {
+      panel.style.backgroundColor = '#000';
       const canvas = videojs.dom.createEl('canvas', {
         className: 'vjs-waveform-canvas',
         role: 'presentation',
       });
-      const progressCanvas = videojs.dom.createEl('canvas', {
-        className: 'vjs-waveform-canvas vjs-waveform-progress-canvas',
-        role: 'presentation',
-      });
       panel.appendChild(canvas);
       this.canvas = canvas;
-      panel.appendChild(progressCanvas);
-      this.progressCanvas = progressCanvas;
       this.waveformData = waveform.data;
 
       this.resizeObserver = new ResizeObserver(() => {
@@ -219,6 +221,12 @@ class VideoJSWaveform extends Button {
 
       // Draw the waveform visualization in canvas
       this.drawWaveform();
+
+      /* Fallback to remove the waveform panel blocking if the 'loadeddata'
+       and 'loadstart' events don't trigger this. */
+      if (panel.classList.contains('vjs-disabled')) {
+        panel.classList.remove('vjs-disabled');
+      }
     }
   }
 
@@ -227,8 +235,8 @@ class VideoJSWaveform extends Button {
    * using CanvasAPI.
    */
   drawWaveform() {
-    const { canvas, progressCanvas, waveformData } = this;
-    if (!canvas || !progressCanvas || !waveformData) return;
+    const { canvas, waveformData } = this;
+    if (!canvas || !waveformData) return;
 
     const width = canvas.clientWidth;
     const height = canvas.clientHeight;
@@ -244,35 +252,31 @@ class VideoJSWaveform extends Button {
       return height - ((amplitude + offset) * height) / range;
     };
 
-    /* Draw the waveform on both base canvas and progress canvas at in the
-    same loop. Add stroke and fill styles to the progress canvas to indicate
-    playback progress. */
-    [canvas, progressCanvas].forEach((c) => {
-      c.width = width;
-      c.height = height;
-      const ctx = c.getContext('2d');
-      ctx.beginPath();
+    // Draw the waveform on canvas 
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext('2d');
+    ctx.beginPath();
 
-      // Loop forwards, drawing the upper half of the waveform
-      for (let x = 0; x < width; x++) {
-        const max = channel.max_sample(x);
-        ctx.lineTo(x + 0.5, scaleY(max, c.height) + 0.5);
-      }
+    // Loop forwards, drawing the upper half of the waveform
+    for (let x = 0; x < width; x++) {
+      const max = channel.max_sample(x);
+      ctx.lineTo(x + 0.5, scaleY(max, canvas.height) + 0.5);
+    }
 
-      // Loop backwards, drawing the lower half of the waveform
-      for (let x = width - 1; x >= 0; x--) {
-        const min = channel.min_sample(x);
-        ctx.lineTo(x + 0.5, scaleY(min, c.height) + 0.5);
-      }
+    // Loop backwards, drawing the lower half of the waveform
+    for (let x = width - 1; x >= 0; x--) {
+      const min = channel.min_sample(x);
+      ctx.lineTo(x + 0.5, scaleY(min, canvas.height) + 0.5);
+    }
 
-      // Set stroke and fill colors for played progress in the waveform
-      ctx.strokeStyle = c === progressCanvas ? '#80a590' : '#ffffff';
-      ctx.fillStyle = c === progressCanvas ? '#80a590' : '#ffffff';
+    // Set stroke and fill colors
+    ctx.strokeStyle = '#696667';
+    ctx.fillStyle = '#696667';
 
-      ctx.closePath();
-      ctx.stroke();
-      ctx.fill();
-    });
+    ctx.closePath();
+    ctx.stroke();
+    ctx.fill();
   }
 
   /**
@@ -289,9 +293,6 @@ class VideoJSWaveform extends Button {
     if (!duration) return;
 
     let playerCurrentTime = player.currentTime();
-    if (player.srcIndex && player.srcIndex > 0) {
-      playerCurrentTime += player.altStart ?? 0;
-    }
     const played = Math.min(100, Math.max(0, 100 * (playerCurrentTime / duration)));
     document.documentElement.style.setProperty('--range-progress', `calc(${played}%)`);
   }

--- a/src/components/MediaPlayer/VideoJS/components/js/VideoJSWaveform.js
+++ b/src/components/MediaPlayer/VideoJS/components/js/VideoJSWaveform.js
@@ -40,19 +40,32 @@ class VideoJSWaveform extends Button {
 
     this.options = options;
     this.player = player;
+    this.playerInterval;
 
     this.hiddenRef = createRef();
     this.hiddenRef.current = true;
 
-    this.canvas = null;
     this.waveformData = null;
 
+    this.canvas = null;
+    this.progressCanvas = null;
+    this.resizeObserver = null;
+
     // Initial panel setup and waveform draw on the state changes as the player loads
-    this.initializePanel();
+    this.attachListeners();
+    this.refreshWaveformData();
 
     // Refresh the waveform data and visualization on Canvas switches
-    this.player.on('waveformUpdated', () => {
+    this.player.on('waveformupdated', () => {
       this.refreshWaveformData();
+    });
+
+    // Unblock the waveform panel
+    this.player.on('seeked', () => {
+      const { waveformRef } = this.options;
+      if (waveformRef.current && waveformRef.current.classList.contains('vjs-disabled')) {
+        waveformRef.current?.classList.remove('vjs-disabled');
+      }
     });
 
     // Hide waveform panel if it is displayed when player is going fullscreen
@@ -61,13 +74,43 @@ class VideoJSWaveform extends Button {
         this.setHidden(true);
       }
     });
+
+    // Clean up interval and observers when player is disposed
+    this.player.on('dispose', () => {
+      clearInterval(this.playerInterval);
+      this.resizeObserver?.disconnect();
+    });
   }
 
-  initializePanel() {
+  /**
+   * Attach pointer event listeners to the waveform panel for click/seek actions
+   */
+  attachListeners() {
     const { waveformRef } = this.options;
     if (!waveformRef.current) return;
 
-    this.refreshWaveformData();
+    let pointerDragged = false;
+    waveformRef.current.addEventListener('pointerup', (e) => {
+      if (pointerDragged) {
+        this.handleSetProgress(e);
+      }
+    });
+    waveformRef.current.addEventListener('pointermove', (e) => {
+      pointerDragged = true;
+    });
+    waveformRef.current.addEventListener('pointerdown', (e) => {
+      // Only handle left click event
+      if (e.which === 1) {
+        this.handleSetProgress(e);
+        pointerDragged = false;
+      }
+    });
+
+    if (!this.playerInterval) {
+      this.playerInterval = setInterval(() => {
+        this.handleTimeUpdate();
+      }, 100);
+    }
   }
 
   setHidden(h) {
@@ -122,9 +165,13 @@ class VideoJSWaveform extends Button {
     const waveform = player.waveform;
     const panel = options.waveformRef.current;
 
+    // Block the waveform panel on refresh
+    panel.classList.add('vjs-disabled');
+
     // Clean existing waveform visualization canvases and observers
     if (panel) {
       panel.style.backgroundImage = '';
+      panel.style.removeProperty('--waveform-image-url');
     }
     if (this.canvas) {
       this.canvas.remove();
@@ -132,12 +179,20 @@ class VideoJSWaveform extends Button {
     }
     this.waveformData = null;
 
+    if (this.progressCanvas) {
+      this.progressCanvas.remove();
+      this.progressCanvas = null;
+    }
+    this.resizeObserver?.disconnect();
+    this.resizeObserver = null;
+
     if (!panel) return;
     if (!waveform) return;
 
     // If the current waveform is an image set it as the background of the panel
     if (waveform.type === 'image') {
       panel.style.backgroundImage = `url(${waveform.url})`;
+      panel.style.setProperty('--waveform-image-url', `url(${waveform.url})`);
       return;
     }
 
@@ -147,9 +202,20 @@ class VideoJSWaveform extends Button {
         className: 'vjs-waveform-canvas',
         role: 'presentation',
       });
+      const progressCanvas = videojs.dom.createEl('canvas', {
+        className: 'vjs-waveform-canvas vjs-waveform-progress-canvas',
+        role: 'presentation',
+      });
       panel.appendChild(canvas);
       this.canvas = canvas;
+      panel.appendChild(progressCanvas);
+      this.progressCanvas = progressCanvas;
       this.waveformData = waveform.data;
+
+      this.resizeObserver = new ResizeObserver(() => {
+        this.drawWaveform();
+      });
+      this.resizeObserver.observe(panel);
 
       // Draw the waveform visualization in canvas
       this.drawWaveform();
@@ -161,8 +227,8 @@ class VideoJSWaveform extends Button {
    * using CanvasAPI.
    */
   drawWaveform() {
-    const { canvas, waveformData } = this;
-    if (!canvas || !waveformData) return;
+    const { canvas, progressCanvas, waveformData } = this;
+    if (!canvas || !progressCanvas || !waveformData) return;
 
     const width = canvas.clientWidth;
     const height = canvas.clientHeight;
@@ -178,26 +244,74 @@ class VideoJSWaveform extends Button {
       return height - ((amplitude + offset) * height) / range;
     };
 
-    canvas.width = width;
-    canvas.height = height;
-    const ctx = canvas.getContext('2d');
-    ctx.beginPath();
+    /* Draw the waveform on both base canvas and progress canvas at in the
+    same loop. Add stroke and fill styles to the progress canvas to indicate
+    playback progress. */
+    [canvas, progressCanvas].forEach((c) => {
+      c.width = width;
+      c.height = height;
+      const ctx = c.getContext('2d');
+      ctx.beginPath();
 
-    // Loop forwards, drawing the upper half of the waveform
-    for (let x = 0; x < width; x++) {
-      const max = channel.max_sample(x);
-      ctx.lineTo(x + 0.5, scaleY(max, canvas.height) + 0.5);
+      // Loop forwards, drawing the upper half of the waveform
+      for (let x = 0; x < width; x++) {
+        const max = channel.max_sample(x);
+        ctx.lineTo(x + 0.5, scaleY(max, c.height) + 0.5);
+      }
+
+      // Loop backwards, drawing the lower half of the waveform
+      for (let x = width - 1; x >= 0; x--) {
+        const min = channel.min_sample(x);
+        ctx.lineTo(x + 0.5, scaleY(min, c.height) + 0.5);
+      }
+
+      // Set stroke and fill colors for played progress in the waveform
+      ctx.strokeStyle = c === progressCanvas ? '#80a590' : '#ffffff';
+      ctx.fillStyle = c === progressCanvas ? '#80a590' : '#ffffff';
+
+      ctx.closePath();
+      ctx.stroke();
+      ctx.fill();
+    });
+  }
+
+  /**
+   * Event handler for VideoJS player instance's 'timeupdate' event, which
+   * updates the played progress in the waveform canvas from player state.
+   */
+  handleTimeUpdate() {
+    const { player, hiddenRef } = this;
+    // Hide waveform toggle for inaccessible item if it is open
+    if (player.canvasIsEmpty && !hiddenRef.current) { this.setHidden(true); }
+    if (player.isDisposed() || player.ended()) return;
+
+    const duration = player.playableDuration ?? player.duration();
+    if (!duration) return;
+
+    let playerCurrentTime = player.currentTime();
+    if (player.srcIndex && player.srcIndex > 0) {
+      playerCurrentTime += player.altStart ?? 0;
     }
+    const played = Math.min(100, Math.max(0, 100 * (playerCurrentTime / duration)));
+    document.documentElement.style.setProperty('--range-progress', `calc(${played}%)`);
+  }
 
-    // Loop backwards, drawing the lower half of the waveform
-    for (let x = width - 1; x >= 0; x--) {
-      const min = channel.min_sample(x);
-      ctx.lineTo(x + 0.5, scaleY(min, canvas.height) + 0.5);
-    }
+  /**
+   * Event handler for pointerdown/pointerup events on the waveform panel.
+   * This updates the player's current time when user clicks on a point
+   * within the panel.
+   * @param {Event} e pointer event for user interaction
+   */
+  handleSetProgress(e) {
+    const { player } = this;
+    const duration = player.playableDuration ?? player.duration();
+    if (!duration) return;
 
-    ctx.closePath();
-    ctx.stroke();
-    ctx.fill();
+    const offsetx = e.offsetX;
+    if (offsetx == undefined || !e.target.clientWidth) return;
+
+    const time = (offsetx / e.target.clientWidth) * duration;
+    player.currentTime(time);
   }
 }
 

--- a/src/components/MediaPlayer/VideoJS/components/js/VideoJSWaveform.js
+++ b/src/components/MediaPlayer/VideoJS/components/js/VideoJSWaveform.js
@@ -1,0 +1,206 @@
+import { createRef } from 'react';
+import videojs from 'video.js';
+import '../styles/VideoJSWaveform.scss';
+import { svgIconToSymbol, WaveformToggleIcon } from '@Services/svg-icons';
+
+// Function to inject SVGs into the DOM
+function injectSVGIcons() {
+  const waveformIconSVG = svgIconToSymbol(WaveformToggleIcon, 'waveform-toggle');
+
+  const svgContainer = document.createElement('div');
+  svgContainer.style.display = 'none';
+  svgContainer.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg">${waveformIconSVG}</svg>`;
+  document.body.appendChild(svgContainer);
+}
+
+// Call the function to inject SVG icons
+injectSVGIcons();
+
+const Button = videojs.getComponent('Button');
+
+/**
+ * Custom VideoJS component for toggling the waveform diplay panel for the current Canvas.
+ * The waveform is expected to be refrenced via either 'seeAlso'/'accompanyingCanvas'
+ * at the Canvas level.
+ * @param {Object} props
+ * @param {Object} props.player VideoJS player instance
+ * @param {Object} props.options
+ * @param {Object} props.options.waveformRef React ref to the waveform panel element
+ */
+class VideoJSWaveform extends Button {
+  constructor(player, options) {
+    super(player, options);
+    this.setAttribute('data-testid', 'videojs-waveform-button');
+    this.addClass('vjs-button vjs-waveform-toggle');
+    this.controlText('Toggle waveform display');
+    this.el().innerHTML = `
+      <svg class="vjs-icon-waveform" role="presentation">
+        <use xlink:href="#waveform-toggle"></use>
+      </svg>`;
+
+    this.options = options;
+    this.player = player;
+
+    this.hiddenRef = createRef();
+    this.hiddenRef.current = true;
+
+    this.canvas = null;
+    this.waveformData = null;
+
+    // Initial panel setup and waveform draw on the state changes as the player loads
+    this.initializePanel();
+
+    // Refresh the waveform data and visualization on Canvas switches
+    this.player.on('waveformUpdated', () => {
+      this.refreshWaveformData();
+    });
+
+    // Hide waveform panel if it is displayed when player is going fullscreen
+    this.player.on('fullscreenchange', () => {
+      if (this.player.isFullscreen() && !this.hiddenRef.current) {
+        this.setHidden(true);
+      }
+    });
+  }
+
+  initializePanel() {
+    const { waveformRef } = this.options;
+    if (!waveformRef.current) return;
+
+    this.refreshWaveformData();
+  }
+
+  setHidden(h) {
+    this.hiddenRef.current = h;
+    const { waveformRef } = this.options;
+    if (!waveformRef.current) return;
+
+    if (h) {
+      waveformRef.current.classList.add('hidden');
+    } else {
+      waveformRef.current.classList.remove('hidden');
+    }
+  }
+
+  /**
+   * Keydown event handler for the waveform toggle button, when using
+   * keyboard navigation.
+   * @param {Event} e keydown event
+   */
+  handleKeyDown(e) {
+    if (e.which === 32 || e.which === 13) {
+      e.preventDefault();
+      this.handleWaveformToggleClick();
+      e.stopPropagation();
+    }
+  }
+
+  handleClick() {
+    this.handleWaveformToggleClick();
+  }
+
+  /**
+   * Click event handler for the waveform toggle button on the player controls
+   */
+  handleWaveformToggleClick() {
+    const { player } = this;
+
+    // If player is fullscreen exit before displaying waveform panel
+    if (player.isFullscreen()) {
+      player.exitFullscreen();
+    }
+    const tempHidden = this.hiddenRef.current;
+    this.setHidden(!tempHidden);
+  }
+
+  /**
+   * Refresh waveform data and the current visualization in the canvas in the panel 
+   * when the Canvas switches in VideoJS.
+   */
+  refreshWaveformData() {
+    const { player, options } = this;
+    const waveform = player.waveform;
+    const panel = options.waveformRef.current;
+
+    // Clean existing waveform visualization canvases and observers
+    if (panel) {
+      panel.style.backgroundImage = '';
+    }
+    if (this.canvas) {
+      this.canvas.remove();
+      this.canvas = null;
+    }
+    this.waveformData = null;
+
+    if (!panel) return;
+    if (!waveform) return;
+
+    // If the current waveform is an image set it as the background of the panel
+    if (waveform.type === 'image') {
+      panel.style.backgroundImage = `url(${waveform.url})`;
+      return;
+    }
+
+    // If the current waveform is a dataset re-initialize the canvases and observers
+    if (waveform.type === 'peaks') {
+      const canvas = videojs.dom.createEl('canvas', {
+        className: 'vjs-waveform-canvas',
+        role: 'presentation',
+      });
+      panel.appendChild(canvas);
+      this.canvas = canvas;
+      this.waveformData = waveform.data;
+
+      // Draw the waveform visualization in canvas
+      this.drawWaveform();
+    }
+  }
+
+  /**
+   * Draw the waveform image using the data from the WaveformData instance
+   * using CanvasAPI.
+   */
+  drawWaveform() {
+    const { canvas, waveformData } = this;
+    if (!canvas || !waveformData) return;
+
+    const width = canvas.clientWidth;
+    const height = canvas.clientHeight;
+    if (width === 0 || height === 0) return;
+
+    const channel = width < waveformData.length
+      ? waveformData.resample({ width }).channel(0)
+      : waveformData.channel(0);
+
+    const scaleY = (amplitude, height) => {
+      const range = 256;
+      const offset = 128;
+      return height - ((amplitude + offset) * height) / range;
+    };
+
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext('2d');
+    ctx.beginPath();
+
+    // Loop forwards, drawing the upper half of the waveform
+    for (let x = 0; x < width; x++) {
+      const max = channel.max_sample(x);
+      ctx.lineTo(x + 0.5, scaleY(max, canvas.height) + 0.5);
+    }
+
+    // Loop backwards, drawing the lower half of the waveform
+    for (let x = width - 1; x >= 0; x--) {
+      const min = channel.min_sample(x);
+      ctx.lineTo(x + 0.5, scaleY(min, canvas.height) + 0.5);
+    }
+
+    ctx.closePath();
+    ctx.stroke();
+    ctx.fill();
+  }
+}
+
+videojs.registerComponent('VideoJSWaveform', VideoJSWaveform);
+
+export default VideoJSWaveform;

--- a/src/components/MediaPlayer/VideoJS/components/styles/VideoJSTrackScrubber.scss
+++ b/src/components/MediaPlayer/VideoJS/components/styles/VideoJSTrackScrubber.scss
@@ -25,7 +25,7 @@
   bottom: 0;
   left: 0;
   height: 36px;
-  width: 99.725%;
+  width: 99.75%;
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/src/components/MediaPlayer/VideoJS/components/styles/VideoJSWaveform.scss
+++ b/src/components/MediaPlayer/VideoJS/components/styles/VideoJSWaveform.scss
@@ -16,7 +16,6 @@
 
 .vjs-waveform-container {
   position: relative;
-  background: #696667;
   border: 1pt solid #353536;
   margin: 0;
   padding: 0;
@@ -47,9 +46,8 @@
     position: absolute;
     inset: 0;
     // This green tint is the rgba conversion of #80a590
-    background-image: linear-gradient(rgba(128, 165, 144, 0.55), rgba(128, 165, 144, 0.55)), var(--waveform-image-url);
+    background-image: linear-gradient(rgba(128, 165, 144, 0.55), rgba(128, 165, 144, 0.55));
     background-size: 100% 100%;
-    background-repeat: no-repeat;
     clip-path: inset(0 calc(100% - var(--range-progress, 0%)) 0 0);
     pointer-events: none;
   }

--- a/src/components/MediaPlayer/VideoJS/components/styles/VideoJSWaveform.scss
+++ b/src/components/MediaPlayer/VideoJS/components/styles/VideoJSWaveform.scss
@@ -23,7 +23,7 @@
   bottom: 0;
   left: 0;
   height: 3em;
-  width: 99.725%;
+  width: 99.75%;
   cursor: pointer;
   background-size: 100% 100%;
   background-repeat: no-repeat;
@@ -39,6 +39,20 @@
   &.hidden {
     display: none;
   }
+
+  /* Set the progress as a translucent tint on top of image waveforms using
+  --range-progress property set in the DOM */
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    // This green tint is the rgba conversion of #80a590
+    background-image: linear-gradient(rgba(128, 165, 144, 0.55), rgba(128, 165, 144, 0.55)), var(--waveform-image-url);
+    background-size: 100% 100%;
+    background-repeat: no-repeat;
+    clip-path: inset(0 calc(100% - var(--range-progress, 0%)) 0 0);
+    pointer-events: none;
+  }
 }
 
 .vjs-waveform-canvas {
@@ -48,4 +62,8 @@
   width: 100%;
   height: 100%;
   pointer-events: none;
+}
+
+.vjs-waveform-progress-canvas {
+  clip-path: inset(0 calc(100% - var(--range-progress, 0%)) 0 0);
 }

--- a/src/components/MediaPlayer/VideoJS/components/styles/VideoJSWaveform.scss
+++ b/src/components/MediaPlayer/VideoJS/components/styles/VideoJSWaveform.scss
@@ -1,0 +1,51 @@
+@use '../../../../../styles/_vars.scss';
+
+.vjs-waveform-toggle {
+  cursor: pointer;
+
+  .vjs-icon-waveform {
+    height: 1.25em;
+    width: 1.25em;
+    fill: white;
+
+    &:hover {
+      filter: drop-shadow(0 0 0.25em #fff);
+    }
+  }
+}
+
+.vjs-waveform-container {
+  position: relative;
+  background: #696667;
+  border: 1pt solid #353536;
+  margin: 0;
+  padding: 0;
+  bottom: 0;
+  left: 0;
+  height: 3em;
+  width: 99.725%;
+  cursor: pointer;
+  background-size: 100% 100%;
+  background-repeat: no-repeat;
+
+  @media (max-width: 680px) {
+    width: 99.55%;
+  }
+
+  @media (min-width: 1081px) {
+    width: 99.825%;
+  }
+
+  &.hidden {
+    display: none;
+  }
+}
+
+.vjs-waveform-canvas {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}

--- a/src/context/manifest-context.js
+++ b/src/context/manifest-context.js
@@ -73,7 +73,7 @@ function manifestReducer(state = defaultState, action) {
     case 'updateManifest': {
       const manifest = action.manifest;
       const iiifVersion = getIIIFAPIVersion(manifest);
-      const canvases = canvasesInManifest(manifest);
+      const canvases = canvasesInManifest(manifest, iiifVersion);
       const manifestBehavior = parseAutoAdvance(manifest.behavior);
       const isPlaylist = getIsPlaylist(manifest.label);
       const annotationService = getAnnotationService(manifest.service);

--- a/src/context/manifest-context.js
+++ b/src/context/manifest-context.js
@@ -36,6 +36,7 @@ const defaultState = {
     annotationServiceId: '',
   },
   renderings: {},
+  waveform: { data: null, isLoading: false, error: null },
   canvasSegments: [],
   structures: {
     hasStructure: false, // current Canvas has structure timespans
@@ -103,6 +104,7 @@ function manifestReducer(state = defaultState, action) {
         annotations: hasAnnotations
           ? [...state.annotations]
           : [...state.annotations, parseAnnotationSets(state.manifest, action.canvasIndex)],
+        waveform: { data: null, isLoading: false, error: null },
       };
     }
     case 'switchItem': {
@@ -239,6 +241,12 @@ function manifestReducer(state = defaultState, action) {
       return {
         ...state,
         renderings: { ...action.renderings }
+      };
+    }
+    case 'setWaveform': {
+      return {
+        ...state,
+        waveform: { ...action.waveform }
       };
     }
     case 'setIsCollapsed': {

--- a/src/services/hooks/useWaveform.js
+++ b/src/services/hooks/useWaveform.js
@@ -9,17 +9,18 @@ import { IS_MOBILE } from '@Services/browser';
  * Fetch/parse the current Canvas's waveform resource if it exists, and pass the results to the
  * player instance for the VideoJSWaveform component to render.
  * @param {Object} obj
+ * @param {Object} obj.savedPosition resumable saved playback position in the current Manifest
  * @param {Boolean} obj.showWaveform whether to show the waveform toggle button in the control bar
  * @param {Object} obj.waveformRef React ref to the VideoJSWaveform component
- * @returns { hasWaveform: Boolean } whether the current Canvas has a waveform representation
+ * @returns { hasWaveform }
  */
-export const useWaveform = ({ showWaveform, waveformRef }) => {
+export const useWaveform = ({ savedPosition, showWaveform, waveformRef }) => {
   const { player } = useContext(PlayerStateContext);
   const { canvasIndex, allCanvases } = useContext(ManifestStateContext);
   const manifestDispatch = useContext(ManifestDispatchContext);
 
   const hasWaveform = useMemo(() => {
-    return allCanvases[canvasIndex]?.waveform != null;
+    return allCanvases[canvasIndex]?.waveform != null && showWaveform;
   }, [allCanvases, canvasIndex]);
 
   async function fetchWaveformData(waveform, signal) {
@@ -88,10 +89,11 @@ export const useWaveform = ({ showWaveform, waveformRef }) => {
     if (!hasWaveformResult) {
       controlBar.removeChild('videoJSWaveform');
     } else if (!controlBar.getChild('videoJSWaveform')) {
+      const hasSavedPosition = savedPosition != null || savedPosition != undefined;
       const volumeIndex = IS_MOBILE
         ? controlBar.children().findIndex((c) => c.name_ == 'MuteToggle')
         : controlBar.children().findIndex((c) => c.name_ == 'VolumePanel');
-      controlBar.addChild('videoJSWaveform', { waveformRef }, volumeIndex + 1);
+      controlBar.addChild('videoJSWaveform', { waveformRef, hasSavedPosition }, volumeIndex + 1);
     }
   };
 

--- a/src/services/hooks/useWaveform.js
+++ b/src/services/hooks/useWaveform.js
@@ -1,0 +1,99 @@
+import { useContext, useEffect, useMemo } from 'react';
+import WaveformData from 'waveform-data';
+import { handleFetchErrors } from '@Services/utility-helpers';
+import { ManifestDispatchContext, ManifestStateContext } from '../../context/manifest-context';
+import { PlayerStateContext } from '../../context/player-context';
+import { IS_MOBILE } from '@Services/browser';
+
+/**
+ * Fetch/parse the current Canvas's waveform resource if it exists, and pass the results to the
+ * player instance for the VideoJSWaveform component to render.
+ * @param {Object} obj
+ * @param {Boolean} obj.showWaveform whether to show the waveform toggle button in the control bar
+ * @param {Object} obj.waveformRef React ref to the VideoJSWaveform component
+ * @returns { hasWaveform: Boolean } whether the current Canvas has a waveform representation
+ */
+export const useWaveform = ({ showWaveform, waveformRef }) => {
+  const { player } = useContext(PlayerStateContext);
+  const { canvasIndex, allCanvases } = useContext(ManifestStateContext);
+  const manifestDispatch = useContext(ManifestDispatchContext);
+
+  const hasWaveform = useMemo(() => {
+    return allCanvases[canvasIndex]?.waveform != null;
+  }, [allCanvases, canvasIndex]);
+
+  async function fetchWaveformData(waveform, signal) {
+    const { id, format, waveformType } = waveform ?? {};
+    if (!id || !waveformType) return null;
+
+    if (waveformType === 'image') {
+      return { type: 'image', url: id };
+    }
+
+    try {
+      const response = await fetch(id, { signal }).then(handleFetchErrors);
+      const isJSON = format === 'application/json';
+      const rawData = isJSON ? await response.json() : await response.arrayBuffer();
+      const data = WaveformData.create(rawData);
+      return { type: 'peaks', data };
+    } catch (error) {
+      if (error.name === 'AbortError') return null;
+      console.error('useWaveform -> fetchWaveformData() -> failed to fetch/parse waveform data, ', error);
+      return null;
+    }
+  }
+
+  useEffect(() => {
+    // Do nothing if either player is null or showWaveform is set to false
+    if (!player || !showWaveform) return;
+
+    const waveformResource = allCanvases[canvasIndex]?.waveform;
+    if (!waveformResource) {
+      player.waveform = null;
+      player.trigger('waveformUpdated');
+      manifestDispatch({ type: 'setWaveform', waveform: { data: null, isLoading: false, error: null } });
+      updateWaveformControl(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    // Rest waveform data in state before fetching again
+    manifestDispatch({ type: 'setWaveform', waveform: { data: null, isLoading: true, error: null } });
+
+    fetchWaveformData(waveformResource, controller.signal).then((result) => {
+      if (controller.signal.aborted) return;
+      player.waveform = result;
+      player.trigger('waveformUpdated');
+      manifestDispatch({
+        type: 'setWaveform',
+        waveform: { data: result, isLoading: false, error: result ? null : 'Failed to load waveform' },
+      });
+      updateWaveformControl(!!result);
+    });
+
+    // Cleanup
+    return () => { controller.abort(); };
+  }, [canvasIndex, allCanvases, player]);
+
+  /**
+   * Add/remove the waveform toggle button to the player's control-bar if/when a waveform representation
+   * of the current Canvas is available. This is separated from the control-bar updates in the 'updatePlayer()'
+   * in VideoJSPlayer because, this has to wait till asynchronous fetching of the waveform data is resolved.
+   * @param {Boolean} hasWaveformResult whether the fetch resolved to usable waveform data
+   */
+  const updateWaveformControl = (hasWaveformResult) => {
+    const controlBar = player.getChild('controlBar');
+    if (!controlBar) return;
+
+    if (!hasWaveformResult) {
+      controlBar.removeChild('videoJSWaveform');
+    } else if (!controlBar.getChild('videoJSWaveform')) {
+      const volumeIndex = IS_MOBILE
+        ? controlBar.children().findIndex((c) => c.name_ == 'MuteToggle')
+        : controlBar.children().findIndex((c) => c.name_ == 'VolumePanel');
+      controlBar.addChild('videoJSWaveform', { waveformRef }, volumeIndex + 1);
+    }
+  };
+
+  return { hasWaveform };
+};

--- a/src/services/hooks/useWaveform.js
+++ b/src/services/hooks/useWaveform.js
@@ -50,7 +50,7 @@ export const useWaveform = ({ showWaveform, waveformRef }) => {
     const waveformResource = allCanvases[canvasIndex]?.waveform;
     if (!waveformResource) {
       player.waveform = null;
-      player.trigger('waveformUpdated');
+      player.trigger('waveformupdated');
       manifestDispatch({ type: 'setWaveform', waveform: { data: null, isLoading: false, error: null } });
       updateWaveformControl(false);
       return;
@@ -63,7 +63,7 @@ export const useWaveform = ({ showWaveform, waveformRef }) => {
     fetchWaveformData(waveformResource, controller.signal).then((result) => {
       if (controller.signal.aborted) return;
       player.waveform = result;
-      player.trigger('waveformUpdated');
+      player.trigger('waveformupdated');
       manifestDispatch({
         type: 'setWaveform',
         waveform: { data: result, isLoading: false, error: result ? null : 'Failed to load waveform' },

--- a/src/services/hooks/useWaveform.test.js
+++ b/src/services/hooks/useWaveform.test.js
@@ -1,0 +1,229 @@
+import React, { useEffect } from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { useWaveform } from './useWaveform';
+import { withManifestAndPlayerProvider, manifestState } from '@Services/testing-helpers';
+import waveformManifest from '@TestData/waveform-example';
+
+describe('useWaveform', () => {
+  // not a real ref because react throws a warning if we use useRef outside a component
+  const resultRef = { current: null };
+  const waveformRef = { current: document.createElement('div') };
+
+  // Minimal VideoJS player with a control-bar
+  const mockPlayer = () => {
+    const children = [];
+    const controlBar = {
+      children: () => children,
+      getChild: (name) => children.find((c) => c.name_ === name),
+      addChild: jest.fn((name, options) => {
+        const child = { name_: name, options };
+        children.push(child);
+        return child;
+      }),
+      removeChild: jest.fn((name) => {
+        const index = children.findIndex((c) => c.name_ === name);
+        if (index > -1) children.splice(index, 1);
+      }),
+    };
+    const listeners = {};
+    return {
+      getChild: (name) => (name === 'controlBar' ? controlBar : undefined),
+      on: jest.fn((event, cb) => { listeners[event] = cb; }),
+      trigger: jest.fn((event) => { listeners[event]?.(); }),
+      _controlBar: controlBar,
+    };
+  };
+
+  const renderHook = (props = {}) => {
+    const UIComponent = () => {
+      const results = useWaveform({ savedPosition: undefined, showWaveform: true, waveformRef, ...props });
+      useEffect(() => {
+        resultRef.current = results;
+      }, [results]);
+      return (<div></div>);
+    };
+    return UIComponent;
+  };
+
+  let player, originalError;
+  beforeEach(() => {
+    originalError = console.error;
+    console.error = jest.fn();
+    player = mockPlayer();
+    resultRef.current = null;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    console.error = originalError;
+  });
+
+  describe('hasWaveform', () => {
+    test('is false when the current Canvas has no valid waveform resource', () => {
+      /* The 4th Canvas in this Manifest has a .xml with format 'text/xml' attached in 'seeAlso',
+      which is not a vali waveform format. Therefore, it gets filtered out during parsing. */
+      const CustomComponent = withManifestAndPlayerProvider(renderHook({}), {
+        initialManifestState: { ...manifestState(waveformManifest, 3) },
+        initialPlayerState: { player },
+      });
+      render(<CustomComponent />);
+
+      expect(resultRef.current.hasWaveform).toBe(false);
+    });
+
+    test('is false when "showWaveform" is turned off and the current Canvas has a valid waveform resource', () => {
+      const CustomComponent = withManifestAndPlayerProvider(renderHook({ showWaveform: false }), {
+        initialManifestState: { ...manifestState(waveformManifest) },
+        initialPlayerState: { player },
+      });
+      render(<CustomComponent />);
+
+      expect(resultRef.current.hasWaveform).toBe(false);
+    });
+
+    test('is true when "showWaveform" is turned on and the current Canvas has a valid waveform resource', () => {
+      jest.spyOn(global, 'fetch').mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          version: 2, channels: 1, sample_rate: 44100, samples_per_pixel: 512,
+          bits: 8, length: 1, data: [0, 10],
+        }),
+      });
+      const CustomComponent = withManifestAndPlayerProvider(renderHook({}), {
+        initialManifestState: { ...manifestState(waveformManifest) },
+        initialPlayerState: { player },
+      });
+      render(<CustomComponent />);
+
+      expect(resultRef.current.hasWaveform).toBe(true);
+    });
+  });
+
+  describe('waveform data', () => {
+    test('is not fetched when a player is not available', async () => {
+      const fetchSpy = jest.spyOn(global, 'fetch');
+      const CustomComponent = withManifestAndPlayerProvider(renderHook({}), {
+        initialManifestState: { ...manifestState(waveformManifest) },
+        initialPlayerState: {},
+      });
+      render(<CustomComponent />);
+
+      await new Promise((r) => setTimeout(r, 0));
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    test('is not fetched when "showWaveform" is turned off', async () => {
+      const fetchSpy = jest.spyOn(global, 'fetch');
+      const CustomComponent = withManifestAndPlayerProvider(renderHook({ showWaveform: false }), {
+        initialManifestState: { ...manifestState(waveformManifest) },
+        initialPlayerState: {},
+      });
+      render(<CustomComponent />);
+
+      await new Promise((r) => setTimeout(r, 0));
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    test('fetch is skipped when the Canvas has no waveform resource', async () => {
+      const fetchSpy = jest.spyOn(global, 'fetch');
+      const CustomComponent = withManifestAndPlayerProvider(renderHook({}), {
+        initialManifestState: { ...manifestState(waveformManifest, 3) },
+        initialPlayerState: { player },
+      });
+      render(<CustomComponent />);
+
+      await waitFor(() => {
+        expect(player.trigger).toHaveBeenCalledWith('waveformupdated');
+      });
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(player.waveform).toBeNull();
+      // Does not add the toggle button to the player control-bar
+      expect(player._controlBar.getChild('videoJSWaveform')).toBeUndefined();
+    });
+
+    test('is fetched and parsed for a JSON waveform dataset', async () => {
+      const jsonPayload = {
+        version: 2, channels: 1, sample_rate: 44100, samples_per_pixel: 512,
+        bits: 8, length: 2, data: [0, 10, -5, 8],
+      };
+      const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue(jsonPayload),
+      });
+      const CustomComponent = withManifestAndPlayerProvider(renderHook({}), {
+        initialManifestState: { ...manifestState(waveformManifest) },
+        initialPlayerState: { player },
+      });
+      render(<CustomComponent />);
+
+      // Adds the toggle button to the player control-bar
+      await waitFor(() => {
+        expect(player._controlBar.getChild('videoJSWaveform')).toBeDefined();
+      });
+      expect(fetchSpy).toHaveBeenCalledWith('http://example.com/waveform.json', expect.anything());
+      expect(player.waveform.type).toBe('peaks');
+      expect(player.waveform.data.channel(0).min_sample(0)).toBe(0);
+    });
+
+    test('in an accompanyingCanvas image waveform is updated without fetching', async () => {
+      const fetchSpy = jest.spyOn(global, 'fetch');
+      const CustomComponent = withManifestAndPlayerProvider(renderHook({}), {
+        initialManifestState: { ...manifestState(waveformManifest, 1) },
+        initialPlayerState: { player },
+      });
+      render(<CustomComponent />);
+
+      // Adds the toggle button to the player control-bar
+      await waitFor(() => {
+        expect(player._controlBar.getChild('videoJSWaveform')).toBeDefined();
+      });
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(player.waveform).toEqual({ type: 'image', url: 'http://example.com/waveform.jpg' });
+    });
+
+    test('in a failed fetch removes the toggle button', async () => {
+      jest.spyOn(global, 'fetch').mockRejectedValue(new Error('Network error'));
+      const CustomComponent = withManifestAndPlayerProvider(renderHook({}), {
+        initialManifestState: { ...manifestState(waveformManifest) },
+        initialPlayerState: { player },
+      });
+      render(<CustomComponent />);
+
+      await waitFor(() => {
+        expect(console.error).toHaveBeenCalled();
+      });
+      expect(player.waveform).toBeNull();
+      expect(player._controlBar.getChild('videoJSWaveform')).toBeUndefined();
+    });
+
+    test('is fetched again when the Canvas changes via a re-render', async () => {
+      const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          version: 2, channels: 1, sample_rate: 44100, samples_per_pixel: 512,
+          bits: 8, length: 1, data: [0, 10],
+        }),
+      });
+      const CustomComponent = withManifestAndPlayerProvider(renderHook({}), {
+        initialManifestState: { ...manifestState(waveformManifest) },
+        initialPlayerState: { player },
+      });
+      render(<CustomComponent />);
+
+      await waitFor(() => {
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+      });
+
+      // Re-render with a different Canvas that also has a JSON waveform dataset (canvas index 2)
+      const CustomComponent1 = withManifestAndPlayerProvider(renderHook(), {
+        initialManifestState: { ...manifestState(waveformManifest, 2) },
+        initialPlayerState: { player },
+      });
+      render(<CustomComponent1 />);
+
+      await waitFor(() => {
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+});

--- a/src/services/iiif-parser.js
+++ b/src/services/iiif-parser.js
@@ -5,13 +5,14 @@ import {
   GENERIC_ERROR_MESSAGE,
   getLabelValue,
   getMediaFragment,
+  getWaveformType,
   parseResourceAnnotations,
   setCanvasMessageTimeout,
   timeToHHmmss,
   identifyMachineGen,
   sanitizeHTML,
 } from './utility-helpers';
-import { getPlaceholderProp, hasMotivation } from './iiif-version-parser';
+import { getAccompanyingProp, getPlaceholderProp, hasMotivation } from './iiif-version-parser';
 
 // Do not build structures for the following 'Range' behaviors:
 // Reference: https://iiif.io/api/presentation/3.0/#behavior
@@ -41,6 +42,14 @@ export function canvasesInManifest(manifest) {
         if (canvas.homepage && canvas.homepage.length > 0) {
           homepage = canvas.homepage[0].id;
         }
+        let canvasJSON = {
+          canvasIndex: index,
+          canvasId: canvas.id,
+          canvasURL: canvas.id.split('#t=')[0],
+          searchService: getSearchService(canvas),
+          authService: getAuthService(canvas),
+          waveform: getWaveformResource(canvas)
+        };
         try {
           let isEmpty = true;
           const canvasItems = canvas.items[0]?.items;
@@ -61,31 +70,22 @@ export function canvasesInManifest(manifest) {
           }
           const canvasLabel = getLabelValue(canvas.label) || `Section ${index + 1}`;
           canvasesInfo.push({
-            canvasIndex: index,
-            canvasId: canvas.id,
-            canvasURL: canvas.id.split('#t=')[0],
+            ...canvasJSON,
             duration: canvasDuration,
             range: timeFragment === undefined ? { start: 0, end: canvasDuration } : timeFragment,
-            isEmpty: isEmpty,
-            summary: summary,
+            isEmpty, summary,
             homepage: homepage || '',
-            label: canvasLabel,
-            searchService: getSearchService(canvas),
-            authService: getAuthService(canvas)
+            label: canvasLabel
           });
         } catch (error) {
           canvasesInfo.push({
-            canvasIndex: index,
-            canvasId: canvas.id,
-            canvasURL: canvas.id.split('#t=')[0],
+            ...canvasJSON,
             duration: canvas.duration || 0,
             range: undefined, // set range to undefined, use this check to set duration in UI
             isEmpty: true,
             summary: summary,
             homepage: homepage || '',
-            label: getLabelValue(canvas.label) || `Section ${index + 1}`,
-            searchService: getSearchService(canvas),
-            authService: getAuthService(canvas)
+            label: getLabelValue(canvas.label) || `Section ${index + 1}`
           });
         }
       });
@@ -247,7 +247,7 @@ export function getCanvasId(uri) {
 }
 
 /**
- * Get placeholderCanvas value for images and text messages
+ * Get placeholderCanvas(3.0)/placeholderContainer(4.0) value for images and text messages
  * @function IIIFParser#getPlaceholderResource
  * @param {Object} annotation IIIF Annotation object
  * @param {Boolean} isPoster flag to indicate whether text/image
@@ -787,5 +787,70 @@ export function getAuthService(canvas) {
     }
   } catch {
     return null;
+  }
+}
+
+/**
+ * Read and parse waveform resource in a Canvas. Since waveform can be presented
+ * as both a dataset or an image it can be represented in the Canvas via both
+ * 'seeAlso' and 'accompanyingCanvas' properties.
+ * 1. 'seeAlso' - e.g. Avalon's JSON dataset, British Library's binary dataset
+ * 2. 'accompanyingCanvas' - e.g. Internet Archive's pre-rendered waveform PNG
+ * If both are available waveform datasets are given priority because it allows the panel
+ * to render player progress.
+ * @function IIIFParser#getWaveformResource
+ * @param {Object} canvas current Canvas to look for waveform data in
+ * @returns {Object}
+ */
+export function getWaveformResource(canvas) {
+  const waveformDatasets = [].concat(canvas?.seeAlso ?? [])
+    .map((resource) => ({
+      resource,
+      waveformType: getWaveformType(resource?.format, resource?.id),
+    }))
+    .filter(({ waveformType }) => waveformType !== null);
+
+  const waveformData = waveformDatasets.find(({ waveformType }) => waveformType === 'data');
+  if (waveformData) {
+    return {
+      id: waveformData.resource.id, format: waveformData.resource.format,
+      waveformType: 'data', source: 'seeAlso',
+    };
+  }
+
+  // Fallback to accompanyingCanvas/accompanyingContainer resource
+  const waveformImage = getAccompanyingResource(canvas);
+  if (waveformImage?.type === 'Image' && waveformImage?.id) {
+    return {
+      id: waveformImage.id, format: waveformImage.format,
+      waveformType: 'image', source: 'accompanyingCanvas'
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Get accompanyingCanvas(3.0)/accompanyingContainer(4.0) value for images
+ * @function IIIFParser#getAccompanyingResource
+ * @param {Object} annotation IIIF Annotation object
+ * @param {String} version Presentation API version of the Manifest
+ * @return {String}
+ */
+export function getAccompanyingResource(annotation, version = '3') {
+  try {
+    let accompanyingResource = annotation[getAccompanyingProp(version)];
+    if (accompanyingResource && accompanyingResource != undefined) {
+      let items = accompanyingResource.items[0].items;
+      if (items?.length > 0 && items[0].body != undefined
+        && hasMotivation(items[0].motivation, 'painting')) {
+        const body = items[0].body;
+        return { id: body.id, format: body.format ?? null, type: body?.type ?? null };
+      }
+    } else {
+      return null;
+    }
+  } catch (error) {
+    throw error;
   }
 }

--- a/src/services/iiif-parser.js
+++ b/src/services/iiif-parser.js
@@ -21,9 +21,11 @@ const NO_DISPLAY_STRUCTURE_BEHAVIORS = ['no-nav', 'thumbnail-nav'];
 /**
  * Get all the canvases in manifest with related information
  * @function IIIFParser#canvasesInManifest
+ * @param {Object} manifest
+ * @param {Number} version Presentation API version of the Manifest
  * @return {Array} array of canvas IDs in manifest
  **/
-export function canvasesInManifest(manifest) {
+export function canvasesInManifest(manifest, version = '3') {
   let canvasesInfo = [];
   try {
     if (!manifest?.items) {
@@ -48,7 +50,7 @@ export function canvasesInManifest(manifest) {
           canvasURL: canvas.id.split('#t=')[0],
           searchService: getSearchService(canvas),
           authService: getAuthService(canvas),
-          waveform: getWaveformResource(canvas)
+          waveform: getWaveformResource(canvas, version)
         };
         try {
           let isEmpty = true;
@@ -800,9 +802,10 @@ export function getAuthService(canvas) {
  * to render player progress.
  * @function IIIFParser#getWaveformResource
  * @param {Object} canvas current Canvas to look for waveform data in
+ * @param {Number} version Presentation API version of the Manifest
  * @returns {Object}
  */
-export function getWaveformResource(canvas) {
+export function getWaveformResource(canvas, version = '3') {
   const waveformDatasets = [].concat(canvas?.seeAlso ?? [])
     .map((resource) => ({
       resource,
@@ -821,7 +824,7 @@ export function getWaveformResource(canvas) {
   /* Fallback to accompanyingCanvas/accompanyingContainer resource. Only treat this as a
   waveform image when its label says so because, the 'accompanyingCanvas' can carry
   non-waveform specific image resources. */
-  const waveformImage = getAccompanyingResource(canvas);
+  const waveformImage = getAccompanyingResource(canvas, version);
   const labledAsWaveform = getLabelValue(waveformImage?.label).toLowerCase().includes('waveform');
   if (waveformImage?.type === 'Image' && waveformImage?.id && labledAsWaveform) {
     return {

--- a/src/services/iiif-parser.js
+++ b/src/services/iiif-parser.js
@@ -806,21 +806,24 @@ export function getWaveformResource(canvas) {
   const waveformDatasets = [].concat(canvas?.seeAlso ?? [])
     .map((resource) => ({
       resource,
-      waveformType: getWaveformType(resource?.format, resource?.id),
+      ...getWaveformType(resource?.format, resource?.id),
     }))
     .filter(({ waveformType }) => waveformType !== null);
 
   const waveformData = waveformDatasets.find(({ waveformType }) => waveformType === 'data');
   if (waveformData) {
     return {
-      id: waveformData.resource.id, format: waveformData.resource.format,
+      id: waveformData.resource.id, format: waveformData.format,
       waveformType: 'data', source: 'seeAlso',
     };
   }
 
-  // Fallback to accompanyingCanvas/accompanyingContainer resource
+  /* Fallback to accompanyingCanvas/accompanyingContainer resource. Only treat this as a
+  waveform image when its label says so because, the 'accompanyingCanvas' can carry
+  non-waveform specific image resources. */
   const waveformImage = getAccompanyingResource(canvas);
-  if (waveformImage?.type === 'Image' && waveformImage?.id) {
+  const labledAsWaveform = getLabelValue(waveformImage?.label).toLowerCase().includes('waveform');
+  if (waveformImage?.type === 'Image' && waveformImage?.id && labledAsWaveform) {
     return {
       id: waveformImage.id, format: waveformImage.format,
       waveformType: 'image', source: 'accompanyingCanvas'
@@ -845,7 +848,11 @@ export function getAccompanyingResource(annotation, version = '3') {
       if (items?.length > 0 && items[0].body != undefined
         && hasMotivation(items[0].motivation, 'painting')) {
         const body = items[0].body;
-        return { id: body.id, format: body.format ?? null, type: body?.type ?? null };
+        const { waveformType, format } = getWaveformType(body?.format, body.id);
+        return {
+          id: body.id, format, type: body?.type ?? null, waveformType,
+          label: accompanyingResource.label
+        };
       }
     } else {
       return null;

--- a/src/services/iiif-parser.test.js
+++ b/src/services/iiif-parser.test.js
@@ -130,6 +130,51 @@ describe('iiif-parser', () => {
       expect(canvases[0].authService.probe.type).toBe('AuthProbeService2');
       expect(canvases[1].authService).toBeNull();
     });
+
+    describe('returns waveform information', () => {
+      test('returns null for waveform by default', () => {
+        const canvases = iiifParser.canvasesInManifest(lunchroomManifest);
+        expect(canvases[0].waveform).toBeNull();
+      });
+
+      test('returns waveform from both "seeAlso" and "accompanyingCanvas" props', () => {
+        const manifestWithWaveforms = {
+          items: [
+            {
+              id: 'http://example.com/canvas/1', type: 'Canvas', duration: 60,
+              items: [{ items: [{ body: { id: 'http://example.com/1.mp3' } }] }],
+              seeAlso: [{ id: 'http://example.com/waveform-1.json', type: 'Dataset', format: 'application/json' }],
+            },
+            {
+              id: 'http://example.com/canvas/2', type: 'Canvas', duration: 60,
+              items: [{ items: [{ body: { id: 'http://example.com/2.mp3' } }] }],
+            },
+            {
+              id: 'http://example.com/canvas/3', type: 'Canvas', duration: 60,
+              items: [{ items: [{ body: { id: 'http://example.com/3.mp3' } }] }],
+              accompanyingCanvas: {
+                type: 'Canvas', label: { en: ['Waveform data as an image'] },
+                items: [{
+                  type: 'AnnotationPage',
+                  items: [{
+                    type: 'Annotation', motivation: 'painting',
+                    body: { id: 'http://example.com/waveform-3.png', type: 'Image', format: 'image/jpeg' },
+                  }],
+                }],
+              },
+            },
+          ],
+        };
+        const canvases = iiifParser.canvasesInManifest(manifestWithWaveforms);
+        expect(canvases[0].waveform).toEqual({
+          id: 'http://example.com/waveform-1.json', format: 'application/json', waveformType: 'data', source: 'seeAlso',
+        });
+        expect(canvases[1].waveform).toBeNull();
+        expect(canvases[2].waveform).toEqual({
+          id: 'http://example.com/waveform-3.png', format: 'image/jpeg', waveformType: 'image', source: 'accompanyingCanvas',
+        });
+      });
+    });
   });
 
   describe('getMediaInfo()', () => {
@@ -1080,6 +1125,151 @@ describe('iiif-parser', () => {
         expect(result.logoutService.label).toBe('');
       });
     });
+  });
 
+  describe('getWaveformResource()', () => {
+    const canvas = {
+      duration: 1094.977, height: 1080, width: 1920, service: [], thumbnail: [], type: "Canvas", items: [],
+      id: "http://example.com/manifest/canvas/1", label: { en: ['Canvas'] },
+      placeholderCanvas: { type: "Canvas", id: "http://example.com/manifest/canvas/1/placeholder", width: 1280, height: 720 },
+    };
+    test('returns null when Canvas is empty', () => {
+      expect(iiifParser.getWaveformResource({})).toBeNull();
+    });
+
+    test('returns null when Canvas doesn\'t have both "seeAlso" and "accompanyingCanvas"', () => {
+      expect(iiifParser.getWaveformResource(canvas)).toBeNull();
+    });
+
+    describe('when "seeAlso"', () => {
+      test('doesn\'t include a recognized waveform format returns null', () => {
+        expect(iiifParser.getWaveformResource({
+          ...canvas,
+          seeAlso: [{ id: 'http://example.com/structure.xml', type: 'Dataset', format: 'application/xml' }],
+        })).toBeNull();
+      });
+
+      test('has a .dat resource returns waveformType: "data" ', () => {
+        const seeAlso = [{ id: 'http://example.com/waveform.dat', type: 'Dataset', format: 'application/octet-stream' }];
+        const waveform = iiifParser.getWaveformResource({ ...canvas, seeAlso });
+        expect(waveform.waveformType).toBe('data');
+        expect(waveform.id).toBe('http://example.com/waveform.dat');
+        expect(waveform.source).toBe('seeAlso');
+        expect(waveform.format).toBe('application/octet-stream');
+      });
+
+      test('has a .json resource returns waveformType: "data"', () => {
+        const seeAlso = [{ id: 'http://example.com/waveform.json', type: 'Dataset', format: 'application/json' }];
+        const waveform = iiifParser.getWaveformResource({ ...canvas, seeAlso });
+        expect(waveform.waveformType).toBe('data');
+        expect(waveform.source).toBe('seeAlso');
+        expect(waveform.id).toBe('http://example.com/waveform.json');
+        expect(waveform.format).toBe('application/json');
+      });
+
+      test('has a .png resource returns null', () => {
+        const seeAlso = [{ id: 'https://example.com/waveform.png', type: 'Image', format: 'image/png' }];
+        expect(iiifParser.getWaveformResource({ ...canvas, seeAlso })).toBeNull();
+      });
+
+      test('has both dataset and image resources binary dataset takes precendence', () => {
+        const seeAlso = [
+          { id: 'http://example.com/waveform.png', type: 'Image', format: 'image/png' },
+          { id: 'http://example.com/waveform.json', type: 'Dataset', format: 'application/json' },
+        ];
+        const waveform = iiifParser.getWaveformResource({ ...canvas, seeAlso });
+        expect(waveform.waveformType).toBe('data');
+        expect(waveform.id).toBe('http://example.com/waveform.json');
+      });
+    });
+
+    describe('resolves type using resource id extension when format is absent for', () => {
+      test('a seeAlso resource', () => {
+        const seeAlso = [{ id: 'http://example.com/waveform.dat', type: 'Dataset' }];
+        const waveform = iiifParser.getWaveformResource({ ...canvas, seeAlso });
+        expect(waveform.waveformType).toBe('data');
+        expect(waveform.source).toBe('seeAlso');
+        expect(waveform.id).toBe('http://example.com/waveform.dat');
+        expect(waveform.format).toBe('application/octet-stream');
+      });
+
+      test('an accompanyingCanvas resource', () => {
+        const accompanyingCanvas = {
+          type: 'Canvas',
+          label: { en: ['Waveform'] },
+          items: [{
+            type: 'AnnotationPage',
+            items: [{
+              type: 'Annotation', motivation: 'painting',
+              body: { id: 'http://example.com/waveform.png', type: 'Image' },
+            }],
+          }],
+        };
+        const waveform = iiifParser.getWaveformResource({ ...canvas, accompanyingCanvas });
+        expect(waveform.waveformType).toBe('image');
+        expect(waveform.source).toBe('accompanyingCanvas');
+        expect(waveform.id).toBe('http://example.com/waveform.png');
+        expect(waveform.format).toBe('image/png');
+      });
+    });
+
+    describe('when "accompanyingCanvas"', () => {
+      test('has a waveform image returns waveformType: "image"', () => {
+        const accompanyingCanvas = {
+          type: 'Canvas', label: { en: ['Waveform data as an image'] },
+          items: [{
+            type: 'AnnotationPage',
+            items: [{
+              type: 'Annotation', motivation: 'painting',
+              body: {
+                id: 'http://example.com/waveform.png',
+                type: 'Image', format: 'image/jpeg',
+              },
+            }],
+          }],
+        };
+        const waveform = iiifParser.getWaveformResource({ ...canvas, accompanyingCanvas });
+        expect(waveform.waveformType).toBe('image');
+        expect(waveform.id).toBe('http://example.com/waveform.png');
+        expect(waveform.format).toBe('image/jpeg');
+        expect(waveform.source).toBe('accompanyingCanvas');
+      });
+
+      test('doesn\'t have text "waveform" in its label returns null', () => {
+        const accompanyingCanvas = {
+          type: 'Canvas',
+          label: { en: ['Poster frame'] },
+          items: [{
+            type: 'AnnotationPage',
+            items: [{
+              type: 'Annotation', motivation: 'painting',
+              body: { id: 'http://example.com/poster.png', type: 'Image', format: 'image/png' },
+            }],
+          }],
+        };
+        expect(iiifParser.getWaveformResource({ ...canvas, accompanyingCanvas })).toBeNull();
+      });
+    });
+
+    test('"seeAlso" takes precendence over "accompanyingCanvas" when both are present', () => {
+      const waveformRes = {
+        seeAlso: [{ id: 'http://example.com/waveform.json', type: 'Dataset', format: 'application/json' }],
+        accompanyingCanvas: {
+          label: { en: ['Waveform as an image'] },
+          items: [{ items: [{ body: { id: 'http://example.com/waveform.png', type: 'Image', format: 'image/png' } }] }],
+        },
+      };
+      const waveform = iiifParser.getWaveformResource({ ...canvas, ...waveformRes });
+      expect(waveform.waveformType).toBe('data');
+      expect(waveform.source).toBe('seeAlso');
+    });
+
+    test('returns null when "accompanyingCanvas" is not an image with text "waveform" in label', () => {
+      const accompanyingCanvas = {
+        label: { en: ['WebVTT not a waveform'] },
+        items: [{ items: [{ body: { id: 'https://example.com/text.vtt', type: 'Text' } }] }]
+      };
+      expect(iiifParser.getWaveformResource({ ...canvas, accompanyingCanvas })).toBeNull();
+    });
   });
 });

--- a/src/services/iiif-version-parser.js
+++ b/src/services/iiif-version-parser.js
@@ -1,5 +1,6 @@
 const PRESENTATION_4_CONTEXT = 'http://iiif.io/api/presentation/4/context.json';
 const PLACEHOLDER_PROP = { '3': 'placeholderCanvas', '4': 'placeholderContainer' };
+const ACCOMPANYING_PROP = { '3': 'accompanyingCanvas', '4': 'accompanyingContainer' };
 
 /**
  * Determine the Presentation API version of a given Manifest from its
@@ -27,6 +28,19 @@ export function getIIIFAPIVersion(manifest) {
  */
 export function getPlaceholderProp(version) {
   return PLACEHOLDER_PROP[version] || PLACEHOLDER_PROP['3'];
+}
+
+/**
+ * Get the accompanying property name for a Canvas/Timeline or Annotation based on the
+ * IIIF Presentation API version of the given Manifest.
+ * - Presentation v3 -> 'accompanyingCanvas'
+ * - Presentation v4 -> 'accompanyingContainer'
+ * @function VersionParser#getAccompanyingProp
+ * @param {String} version Presentation API version, as returned by getIIIFAPIVersion
+ * @returns {String} 'accompanyingCanvas' | 'accompanyingContainer'
+ */
+export function getAccompanyingProp(version) {
+  return ACCOMPANYING_PROP[version] || ACCOMPANYING_PROP['3'];
 }
 
 /**

--- a/src/services/iiif-version-parser.test.js
+++ b/src/services/iiif-version-parser.test.js
@@ -1,4 +1,7 @@
-import { getIIIFAPIVersion, getPlaceholderProp, hasMotivation, normalizeMotivation } from './iiif-version-parser';
+import {
+  getIIIFAPIVersion, getPlaceholderProp, getAccompanyingProp,
+  hasMotivation, normalizeMotivation
+} from './iiif-version-parser';
 
 describe('iiif-version-parser', () => {
   describe('getIIIFAPIVersion()', () => {
@@ -98,6 +101,20 @@ describe('iiif-version-parser', () => {
 
     test('returns an empty array when motivation is null', () => {
       expect(normalizeMotivation(null)).toEqual([]);
+    });
+  });
+
+  describe('getAccompanyingProp()', () => {
+    test('returns "AccompanyingCanvas" for version "3"', () => {
+      expect(getAccompanyingProp('3')).toEqual('accompanyingCanvas');
+    });
+
+    test('returns "accompanyingContainer" for version "4"', () => {
+      expect(getAccompanyingProp('4')).toEqual('accompanyingContainer');
+    });
+
+    test('defaults to "accompanyingCanvas" for an unrecognized version', () => {
+      expect(getAccompanyingProp('5')).toEqual('accompanyingCanvas');
     });
   });
 });

--- a/src/services/save-playback-positions.js
+++ b/src/services/save-playback-positions.js
@@ -1,5 +1,6 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useContext, useEffect, useMemo } from "react";
 import { useLocalStorage } from '@Services/local-storage';
+import { ManifestStateContext } from '../context/manifest-context';
 
 /**
  * Read a playback position from the cache by canvasId. Returns null if not found.
@@ -64,10 +65,13 @@ function isExpired(savedAt, ttlDays) {
  * @param {Boolean} obj.enable whether to enable saving playback positions
  * @param {Number}  obj.maxItems LRU capacity (number of max entries) -> default: 200
  * @param {Number}  obj.ttlDays days before an entry expires -> default: 30
- * @returns {{ savePosition, getPosition, clearPosition }}
+ * @returns {{ clearPosition, getPosition, savedPosition, savePosition  }}
  */
 export const usePlaybackPositions = ({ enable, maxItems, ttlDays } = {}) => {
   const [cache, setCache] = useLocalStorage('playbackPositions', []);
+
+  const manifestState = useContext(ManifestStateContext);
+  const { allCanvases, customStart, manifest, playlist } = manifestState;
 
   /* When caching is disabled, clear the cache. This ensures that when users toggle
   off the resume feature, all saved positions are cleared and they won't be resumed
@@ -102,5 +106,26 @@ export const usePlaybackPositions = ({ enable, maxItems, ttlDays } = {}) => {
     setCache((current) => deleteCacheEntry(current, manifestURL));
   }, [enable, setCache]);
 
-  return { savePosition, getPosition, clearPosition };
+  /* Get the saved playback position for the current Manifest. Avoid reading saved position
+  from localStorage (using getPosition) if the current Manifest is a playlist Manifest or it
+  has a custom start position. */
+  const savedPosition = useMemo(() => {
+    if (customStart?.startTime > 0 || playlist?.isPlaylist) return;
+
+    const manifestURL = manifest?.id;
+    if (!manifestURL) return;
+
+    const saved = getPosition(manifestURL);
+    if (!saved || saved.time <= 0) return;
+
+    /* When a 'startCanvasId' is set for Ramp, ignore saved playback positions that are
+    on a different Canvas than the current Canvas. */
+    if (customStart?.startIndex > 0) {
+      const startCanvasURL = allCanvases[customStart.startIndex]?.canvasURL;
+      if (saved.canvasURL !== startCanvasURL) return;
+    }
+    return saved;
+  }, [allCanvases, customStart, getPosition, playlist?.isPlaylist, manifest]);
+
+  return { clearPosition, getPosition, savedPosition, savePosition };
 };

--- a/src/services/save-playback-positions.test.js
+++ b/src/services/save-playback-positions.test.js
@@ -1,5 +1,8 @@
-import { renderHook, act } from '@testing-library/react';
+import React, { useEffect } from 'react';
+import { render, act } from '@testing-library/react';
 import { usePlaybackPositions } from './save-playback-positions';
+import { manifestState, withManifestProvider } from "./testing-helpers";
+import lunchroomManners from '@TestData/lunchroom-manners';
 
 describe('usePlaybackPositions', () => {
   const defaultOptions = { enable: false, ttlDays: 30, maxItems: 200 };
@@ -14,7 +17,24 @@ describe('usePlaybackPositions', () => {
     jest.restoreAllMocks();
   });
 
-  const MANIFEST_URL = 'https://example.com/manifest.json';
+  // not a real ref because react throws warning if we use outside a component
+  const resultRef = { current: null };
+  const renderHook = (props = {}) => {
+    const UIComponent = () => {
+      const results = usePlaybackPositions({
+        ...props
+      });
+      useEffect(() => {
+        resultRef.current = results;
+      }, [results]);
+      return (
+        <div></div>
+      );
+    };
+    return UIComponent;
+  };
+
+  const MANIFEST_URL = 'https://example.com/manifest/lunchroom_manners';
   const MANIFEST_URL_1 = 'https://example.com/manifest/1';
   const MANIFEST_URL_2 = 'https://example.com/manifest/2';
   const MANIFEST_URL_3 = 'https://example.com/manifest/3';
@@ -23,109 +43,126 @@ describe('usePlaybackPositions', () => {
 
   describe('savePosition()', () => {
     test('returns nothing when resume cache is disabled (default)', () => {
-      const { result } = renderHook(() => usePlaybackPositions(defaultOptions));
-      act(() => {
-        result.current.savePosition(MANIFEST_URL, CANVAS_URL_1, 42.5);
-      });
+      const CustomComponent = withManifestProvider(renderHook(defaultOptions), {});
+      render(<CustomComponent />);
+
+      resultRef.current.savePosition(MANIFEST_URL, CANVAS_URL_1, 42.5);
       const stored = JSON.parse(localStorage.getItem('playbackPositions'));
       expect(stored).toEqual([]);
     });
 
-    test('saves a position for a manifest URL', () => {
-      const { result } = renderHook(() => usePlaybackPositions(turnedOnOptions));
-      act(() => {
-        result.current.savePosition(MANIFEST_URL, CANVAS_URL_1, 42.5);
+    describe('when resume cache is enabled', () => {
+      test('saves a position for a manifest URL', () => {
+        const CustomComponent = withManifestProvider(renderHook(turnedOnOptions), {});
+        render(<CustomComponent />);
+        act(() => {
+          resultRef.current.savePosition(MANIFEST_URL, CANVAS_URL_1, 42.5);
+        });
+        const stored = JSON.parse(localStorage.getItem('playbackPositions'));
+        expect(stored).toHaveLength(1);
+        expect(stored[0].key).toBe(MANIFEST_URL);
+        expect(stored[0].value.canvasURL).toBe(CANVAS_URL_1);
+        expect(stored[0].value.time).toBe(42.5);
       });
-      const stored = JSON.parse(localStorage.getItem('playbackPositions'));
-      expect(stored).toHaveLength(1);
-      expect(stored[0].key).toBe(MANIFEST_URL);
-      expect(stored[0].value.canvasURL).toBe(CANVAS_URL_1);
-      expect(stored[0].value.time).toBe(42.5);
-    });
 
-    test('replaces and moves an existing entry to the front on update', () => {
-      const { result } = renderHook(() => usePlaybackPositions(turnedOnOptions));
-      act(() => {
-        result.current.savePosition(MANIFEST_URL_1, CANVAS_URL_1, 10);
-        result.current.savePosition(MANIFEST_URL_2, CANVAS_URL_2, 20);
-        result.current.savePosition(MANIFEST_URL_1, CANVAS_URL_1, 50);
-      });
-      const stored = JSON.parse(localStorage.getItem('playbackPositions'));
-      expect(stored).toHaveLength(2);
-      expect(stored[0].key).toBe(MANIFEST_URL_1);
-      expect(stored[0].value.time).toBe(50);
-      expect(stored[1].key).toBe(MANIFEST_URL_2);
-    });
+      test('replaces and moves an existing entry to the front on update', () => {
+        const CustomComponent = withManifestProvider(renderHook(turnedOnOptions), {});
+        render(<CustomComponent />);
 
-    test('evicts the least-recently-used entry when maxItems is exceeded', () => {
-      const { result } = renderHook(() => usePlaybackPositions({ ...turnedOnOptions, maxItems: 2 }));
-      act(() => {
-        result.current.savePosition(MANIFEST_URL_1, CANVAS_URL_1, 10);
-        result.current.savePosition(MANIFEST_URL_2, CANVAS_URL_1, 20);
-        result.current.savePosition(MANIFEST_URL_3, CANVAS_URL_1, 30);
+        act(() => {
+          resultRef.current.savePosition(MANIFEST_URL_1, CANVAS_URL_1, 10);
+          resultRef.current.savePosition(MANIFEST_URL_2, CANVAS_URL_2, 20);
+          resultRef.current.savePosition(MANIFEST_URL_1, CANVAS_URL_1, 50);
+        });
+        const stored = JSON.parse(localStorage.getItem('playbackPositions'));
+        expect(stored).toHaveLength(2);
+        expect(stored[0].key).toBe(MANIFEST_URL_1);
+        expect(stored[0].value.time).toBe(50);
+        expect(stored[1].key).toBe(MANIFEST_URL_2);
       });
-      const stored = JSON.parse(localStorage.getItem('playbackPositions'));
-      expect(stored).toHaveLength(2);
-      expect(stored.map((e) => e.key)).not.toContain(MANIFEST_URL_1);
-      expect(stored[0].key).toBe(MANIFEST_URL_3);
-      expect(stored[1].key).toBe(MANIFEST_URL_2);
+
+      test('evicts the least-recently-used entry when maxItems is exceeded', () => {
+        const CustomComponent = withManifestProvider(renderHook({ ...turnedOnOptions, maxItems: 2 }), {});
+        render(<CustomComponent />);
+
+        act(() => {
+          resultRef.current.savePosition(MANIFEST_URL_1, CANVAS_URL_1, 10);
+          resultRef.current.savePosition(MANIFEST_URL_2, CANVAS_URL_1, 20);
+          resultRef.current.savePosition(MANIFEST_URL_3, CANVAS_URL_1, 30);
+        });
+        const stored = JSON.parse(localStorage.getItem('playbackPositions'));
+        expect(stored).toHaveLength(2);
+        expect(stored.map((e) => e.key)).not.toContain(MANIFEST_URL_1);
+        expect(stored[0].key).toBe(MANIFEST_URL_3);
+        expect(stored[1].key).toBe(MANIFEST_URL_2);
+      });
     });
   });
 
   describe('getPosition()', () => {
     test('returns nothing when resume cache is disabled (default)', () => {
-      const { result } = renderHook(() => usePlaybackPositions(defaultOptions));
-      act(() => {
-        result.current.savePosition(MANIFEST_URL, CANVAS_URL_1, 42.5);
-      });
+      const CustomComponent = withManifestProvider(renderHook(defaultOptions), {});
+      render(<CustomComponent />);
 
-      expect(result.current.getPosition(MANIFEST_URL)).toBeNull();
+      resultRef.current.savePosition(MANIFEST_URL, CANVAS_URL_1, 42.5);
+      expect(resultRef.current.getPosition(MANIFEST_URL)).toBeNull();
     });
 
-    test('returns null when no entry exists for the manifest URL', () => {
-      const { result } = renderHook(() => usePlaybackPositions(turnedOnOptions));
-      expect(result.current.getPosition(MANIFEST_URL)).toBeNull();
-    });
+    describe('when resume cache is enabled', () => {
+      test('returns null when no entry exists for the manifest URL', () => {
+        const CustomComponent = withManifestProvider(renderHook(turnedOnOptions), {});
+        render(<CustomComponent />);
 
-    test('returns the saved canvas URL and time for a valid, non-expired entry', () => {
-      const { result } = renderHook(() => usePlaybackPositions(turnedOnOptions));
-      act(() => {
-        result.current.savePosition(MANIFEST_URL, CANVAS_URL_1, 42.5);
-      });
-      expect(result.current.getPosition(MANIFEST_URL)).toEqual({ canvasURL: CANVAS_URL_1, time: 42.5 });
-    });
-
-    test('returns null and removes the entry when it is expired', () => {
-      // Save position at time 0
-      jest.spyOn(Date, 'now').mockReturnValue(0);
-      const { result } = renderHook(() => usePlaybackPositions({ ...turnedOnOptions, ttlDays: 1 }));
-      act(() => {
-        result.current.savePosition(MANIFEST_URL, CANVAS_URL_1, 42.5);
+        expect(resultRef.current.getPosition(MANIFEST_URL)).toBeNull();
       });
 
-      // Advance time past TTL (1 day + 1ms)
-      jest.spyOn(Date, 'now').mockReturnValue(24 * 60 * 60 * 1000 + 1);
-      let position;
-      act(() => {
-        position = result.current.getPosition(MANIFEST_URL);
-      });
-      expect(position).toBeNull();
+      test('returns the saved canvas URL and time for a valid, non-expired entry', () => {
+        const CustomComponent = withManifestProvider(renderHook(turnedOnOptions), {});
+        render(<CustomComponent />);
 
-      const stored = JSON.parse(localStorage.getItem('playbackPositions'));
-      expect(stored.find((e) => e.key === MANIFEST_URL)).toBeUndefined();
-    });
-
-    test('returns the saved position when entry is within TTL', () => {
-      jest.spyOn(Date, 'now').mockReturnValue(0);
-      const { result } = renderHook(() => usePlaybackPositions({ ...turnedOnOptions, ttlDays: 30 }));
-      act(() => {
-        result.current.savePosition(MANIFEST_URL, CANVAS_URL_1, 99);
+        act(() => {
+          resultRef.current.savePosition(MANIFEST_URL, CANVAS_URL_1, 42.5);
+        });
+        expect(resultRef.current.getPosition(MANIFEST_URL))
+          .toEqual({ canvasURL: CANVAS_URL_1, time: 42.5 });
       });
 
-      // Advance time to just before TTL expires (29 days)
-      jest.spyOn(Date, 'now').mockReturnValue(29 * 24 * 60 * 60 * 1000);
-      const { result: result2 } = renderHook(() => usePlaybackPositions({ ...turnedOnOptions, ttlDays: 30 }));
-      expect(result2.current.getPosition(MANIFEST_URL)).toEqual({ canvasURL: CANVAS_URL_1, time: 99 });
+      test('returns null and removes the entry when it is expired', () => {
+        const CustomComponent = withManifestProvider(renderHook({ ...turnedOnOptions, ttlDays: 1 }), {});
+        render(<CustomComponent />);
+
+        // Save position at time 0
+        jest.spyOn(Date, 'now').mockReturnValue(0);
+        act(() => {
+          resultRef.current.savePosition(MANIFEST_URL, CANVAS_URL_1, 42.5);
+        });
+
+        // Advance time past TTL (1 day + 1ms)
+        jest.spyOn(Date, 'now').mockReturnValue(24 * 60 * 60 * 1000 + 1);
+        let position;
+        act(() => {
+          position = resultRef.current.getPosition(MANIFEST_URL);
+        });
+        expect(position).toBeNull();
+
+        const stored = JSON.parse(localStorage.getItem('playbackPositions'));
+        expect(stored.find((e) => e.key === MANIFEST_URL)).toBeUndefined();
+      });
+
+      test('returns the saved position when entry is within TTL', () => {
+        jest.spyOn(Date, 'now').mockReturnValue(0);
+        const CustomComponent = withManifestProvider(renderHook(turnedOnOptions), {});
+        render(<CustomComponent />);
+
+        act(() => {
+          resultRef.current.savePosition(MANIFEST_URL, CANVAS_URL_1, 99);
+        });
+
+        // Advance time to just before TTL expires (29 days)
+        jest.spyOn(Date, 'now').mockReturnValue(29 * 24 * 60 * 60 * 1000);
+        expect(resultRef.current.getPosition(MANIFEST_URL))
+          .toEqual({ canvasURL: CANVAS_URL_1, time: 99 });
+      });
     });
   });
 
@@ -135,78 +172,137 @@ describe('usePlaybackPositions', () => {
         'playbackPositions',
         JSON.stringify([{ key: MANIFEST_URL, value: { canvasURL: CANVAS_URL_1, time: 120, savedAt: Date.now() } }])
       );
+      const CustomComponent = withManifestProvider(renderHook(defaultOptions), {});
+      render(<CustomComponent />);
 
-      const { result } = renderHook(() => usePlaybackPositions(defaultOptions));
-      act(() => {
-        result.current.clearPosition(MANIFEST_URL);
-      });
-
+      resultRef.current.clearPosition(MANIFEST_URL);
       const stored = JSON.parse(localStorage.getItem('playbackPositions'));
       expect(stored).toEqual([]);
     });
 
-    test('removes the entry for the given manifest URL', () => {
-      const { result } = renderHook(() => usePlaybackPositions(turnedOnOptions));
-      act(() => {
-        result.current.savePosition(MANIFEST_URL_1, CANVAS_URL_1, 42.5);
-        result.current.savePosition(MANIFEST_URL_2, CANVAS_URL_2, 10);
+    describe('when resume cache is enabled', () => {
+      beforeEach(() => {
+        const CustomComponent = withManifestProvider(renderHook(turnedOnOptions), {});
+        render(<CustomComponent />);
       });
-      act(() => {
-        result.current.clearPosition(MANIFEST_URL_1);
-      });
-      const stored = JSON.parse(localStorage.getItem('playbackPositions'));
-      expect(stored.find((e) => e.key === MANIFEST_URL_1)).toBeUndefined();
-      expect(stored.find((e) => e.key === MANIFEST_URL_2)).toBeDefined();
-    });
 
-    test('does nothing when entry does not exist', () => {
-      const { result } = renderHook(() => usePlaybackPositions(turnedOnOptions));
-      act(() => {
-        result.current.savePosition(MANIFEST_URL_2, CANVAS_URL_2, 10);
+      test('removes the entry for the given manifest URL', () => {
+        act(() => {
+          resultRef.current.savePosition(MANIFEST_URL_1, CANVAS_URL_1, 42.5);
+          resultRef.current.savePosition(MANIFEST_URL_2, CANVAS_URL_2, 10);
+        });
+        act(() => {
+          resultRef.current.clearPosition(MANIFEST_URL_1);
+        });
+        const stored = JSON.parse(localStorage.getItem('playbackPositions'));
+        expect(stored.find((e) => e.key === MANIFEST_URL_1)).toBeUndefined();
+        expect(stored.find((e) => e.key === MANIFEST_URL_2)).toBeDefined();
       });
-      act(() => {
-        result.current.clearPosition(MANIFEST_URL_1);
+
+      test('does nothing when entry does not exist', () => {
+        act(() => {
+          resultRef.current.savePosition(MANIFEST_URL_2, CANVAS_URL_2, 10);
+        });
+        act(() => {
+          resultRef.current.clearPosition(MANIFEST_URL_1);
+        });
+        const stored = JSON.parse(localStorage.getItem('playbackPositions'));
+        expect(stored).toHaveLength(1);
+        expect(stored[0].key).toBe(MANIFEST_URL_2);
       });
-      const stored = JSON.parse(localStorage.getItem('playbackPositions'));
-      expect(stored).toHaveLength(1);
-      expect(stored[0].key).toBe(MANIFEST_URL_2);
     });
   });
 
   describe('turned ON with default values', () => {
+    beforeEach(() => {
+      const CustomComponent = withManifestProvider(renderHook(turnedOnOptions), {});
+      render(<CustomComponent />);
+    });
+
     test('uses maxItems=200', () => {
-      const { result } = renderHook(() => usePlaybackPositions(turnedOnOptions));
       // Fill up to 201 entries to trigger eviction at 200
       act(() => {
         for (let i = 0; i < 201; i++) {
-          result.current.savePosition(`https://example.com/manifest/${i}`, CANVAS_URL_1, i);
+          resultRef.current.savePosition(`https://example.com/manifest/${i}`, CANVAS_URL_1, i);
         }
       });
       const stored = JSON.parse(localStorage.getItem('playbackPositions'));
       expect(stored).toHaveLength(200);
-
     });
 
     test('uses ttlDays=30', () => {
       const savedAt = 0;
-      const { result } = renderHook(() => usePlaybackPositions(turnedOnOptions));
       act(() => {
-        result.current.savePosition(MANIFEST_URL, CANVAS_URL_1, 42.5);
+        resultRef.current.savePosition(MANIFEST_URL, CANVAS_URL_1, 42.5);
       });
 
       // Verify entry with default TTL of 30 days is still valid after 29 days of saving
       jest.spyOn(Date, 'now').mockReturnValue(savedAt + 29 * 24 * 60 * 60 * 1000);
-      const { result: result2 } = renderHook(() => usePlaybackPositions(turnedOnOptions));
-      expect(result2.current.getPosition(MANIFEST_URL)).not.toBeNull();
+      expect(resultRef.current.getPosition(MANIFEST_URL)).not.toBeNull();
 
       // Verify entry is expired after the default TTL of 30 days
       jest.spyOn(Date, 'now').mockReturnValue(savedAt + 31 * 24 * 60 * 60 * 1000);
-      const { result: result3 } = renderHook(() => usePlaybackPositions(turnedOnOptions));
-      let position;
       act(() => {
-        position = result3.current.getPosition(MANIFEST_URL);
+        expect(resultRef.current.getPosition(MANIFEST_URL)).toBeNull();
       });
-      expect(position).toBeNull();
+    });
+  });
+
+  describe('savedPosition', () => {
+    test('returns undefined when there is no saved position in localStorage', () => {
+      const CustomComponent = withManifestProvider(renderHook(turnedOnOptions), {});
+      render(<CustomComponent />);
+
+      expect(resultRef.current.savedPosition).toBeUndefined();
+    });
+
+    describe('when a saved position is present for the current Manifest', () => {
+      beforeEach(() => {
+        localStorage.setItem(
+          'playbackPositions',
+          JSON.stringify([{ key: MANIFEST_URL, value: { canvasURL: CANVAS_URL_2, time: 42.5, savedAt: 0 } }])
+        );
+      });
+
+      test('returns undefined when a customStart time is present', () => {
+        const CustomComponent = withManifestProvider(renderHook(turnedOnOptions), {
+          intialState: { ...manifestState(lunchroomManners), customStart: { startIndex: 0, startTime: 120.3 } }
+        });
+        render(<CustomComponent />);
+
+        expect(resultRef.current.savedPosition).toBeUndefined();
+      });
+
+      test('returns the saved position', () => {
+        const CustomComponent = withManifestProvider(renderHook(turnedOnOptions), {
+          initialState: { ...manifestState(lunchroomManners) },
+        });
+        render(<CustomComponent />);
+
+        expect(resultRef.current.savedPosition).toEqual({ canvasURL: CANVAS_URL_2, time: 42.5 });
+      });
+
+      test('returns undefined when resume cache is disabled', () => {
+        const CustomComponent = withManifestProvider(renderHook(defaultOptions), {
+          initialState: { ...manifestState(lunchroomManners) },
+        });
+        render(<CustomComponent />);
+
+        expect(resultRef.current.hasSavedPosition).toBeUndefined();
+      });
+    });
+
+    test('returns undefined when the saved position doesn\'t match the current Manifest', () => {
+      localStorage.setItem(
+        'playbackPositions',
+        JSON.stringify([{ key: MANIFEST_URL_1, value: { canvasURL: CANVAS_URL_1, time: 42.5, savedAt: 0 } }])
+      );
+      const CustomComponent = withManifestProvider(renderHook(turnedOnOptions), {
+        initialState: { ...manifestState(lunchroomManners) },
+      });
+      render(<CustomComponent />);
+
+      expect(resultRef.current.hasSavedPosition).toBeUndefined();
     });
   });
 });

--- a/src/services/svg-icons.js
+++ b/src/services/svg-icons.js
@@ -121,6 +121,20 @@ export const TrackScrubberZoomOutIcon = ({ scale }) => {
   );
 };
 
+/** SVG icon for waveform toggle button in player control bar */
+export const WaveformToggleIcon = () => {
+  return (
+    <svg xmlns="http://w3.org" viewBox="0 0 20 20" width="20" height="20" fill="currentColor">
+      <rect x="1" y="7" width="2" height="6" rx="1" />
+      <rect x="4" y="4" width="2" height="12" rx="1" />
+      <rect x="7" y="2" width="2" height="16" rx="1" />
+      <rect x="10" y="5" width="2" height="10" rx="1" />
+      <rect x="13" y="3" width="2" height="14" rx="1" />
+      <rect x="16" y="8" width="2" height="4" rx="1" />
+    </svg>
+  );
+};
+
 /** SVG icon for inaccessible items in StructuredNavigation component */
 export const LockedSVGIcon = () => {
   return (

--- a/src/services/utility-helpers.js
+++ b/src/services/utility-helpers.js
@@ -34,6 +34,12 @@ const DOMPURIFY_CONFIG = {
   ALLOWED_ATTR: ['href', 'src', 'alt'],
   ALLOWED_URI_REGEXP: /^(?:https?|mailto):/i,
 };
+/* MIME types dictionary for resolving waveform resource format by its extension
+when 'format' is not given in the Manifest. */
+const WAVEFORM_EXTENSION_FORMATS = {
+  dat: 'application/octet-stream', json: 'application/json',
+  png: 'image/png', jpeg: 'image/jpeg', jpg: 'image/jpeg',
+};
 
 /**
  * Sets the timer for displaying the placeholderCanvas text in the player
@@ -1102,22 +1108,25 @@ export const sanitizeHTML = (html) => {
 };
 
 /**
- * Get the data type of the given waveform resources by its 'format' property.
- * Fallback to checking the resource extension against the MIME type to derive
- * the data type if the 'format' is not available.
+ * Get the data type and a resolved MIME type of a given waveform resource by its
+ * 'format' property. Fallback to checking the resource extension against the MIME
+ * type to derive the data type and/or the format if 'format' is missing.
  * @function Utils#getWaveformType
  * @param {String} format MIME type of the waveform resource
  * @param {String} id resource URL
- * @returns {String} waveform type from 'data' | 'image' | null
+ * @returns {Object} { waveformType: 'data' | 'image' | null, format: String|null }
+ * resolved format falls back to the MIME type looked up from the resource's file extension
  */
 export const getWaveformType = (format, id) => {
-  if (format === 'application/octet-stream') return 'data';
-  if (format === 'image/png' || format === 'image/jpeg') return 'image';
+  if (format === 'application/octet-stream') return { waveformType: 'data', format };
+  if (format === 'image/png' || format === 'image/jpeg') return { waveformType: 'image', format };
 
-  // Fallback to using file extension to resolve the data type of the resource
+  // Fallback to using file extension to resolve the resource data type and format if it is missing
   const extension = format ? mimeTypes.extension(format) : null;
   const ext = extension || id?.split('.').pop()?.toLowerCase();
-  if (ext === 'dat' || ext === 'json') return 'data';
-  if (ext === 'png' || ext === 'jpeg' || ext === 'jpg') return 'image';
-  return null;
+  const resolvedFormat = format || WAVEFORM_EXTENSION_FORMATS[ext] || null;
+
+  if (ext === 'dat' || ext === 'json') return { waveformType: 'data', format: resolvedFormat };
+  if (ext === 'png' || ext === 'jpeg' || ext === 'jpg') return { waveformType: 'image', format: resolvedFormat };
+  return { waveformType: null, format: resolvedFormat };
 };

--- a/src/services/utility-helpers.js
+++ b/src/services/utility-helpers.js
@@ -1118,8 +1118,12 @@ export const sanitizeHTML = (html) => {
  * resolved format falls back to the MIME type looked up from the resource's file extension
  */
 export const getWaveformType = (format, id) => {
-  if (format === 'application/octet-stream') return { waveformType: 'data', format };
-  if (format === 'image/png' || format === 'image/jpeg') return { waveformType: 'image', format };
+  if (format === 'application/octet-stream' || format === 'application/json') {
+    return { waveformType: 'data', format };
+  };
+  if (format === 'image/png' || format === 'image/jpeg') {
+    return { waveformType: 'image', format };
+  };
 
   // Fallback to using file extension to resolve the resource data type and format if it is missing
   const extension = format ? mimeTypes.extension(format) : null;

--- a/src/services/utility-helpers.js
+++ b/src/services/utility-helpers.js
@@ -1100,3 +1100,24 @@ export const sanitizeHTML = (html) => {
   if (!html) return '';
   return DOMPurify.sanitize(html, { ...DOMPURIFY_CONFIG });
 };
+
+/**
+ * Get the data type of the given waveform resources by its 'format' property.
+ * Fallback to checking the resource extension against the MIME type to derive
+ * the data type if the 'format' is not available.
+ * @function Utils#getWaveformType
+ * @param {String} format MIME type of the waveform resource
+ * @param {String} id resource URL
+ * @returns {String} waveform type from 'data' | 'image' | null
+ */
+export const getWaveformType = (format, id) => {
+  if (format === 'application/octet-stream') return 'data';
+  if (format === 'image/png' || format === 'image/jpeg') return 'image';
+
+  // Fallback to using file extension to resolve the data type of the resource
+  const extension = format ? mimeTypes.extension(format) : null;
+  const ext = extension || id?.split('.').pop()?.toLowerCase();
+  if (ext === 'dat' || ext === 'json') return 'data';
+  if (ext === 'png' || ext === 'jpeg' || ext === 'jpg') return 'image';
+  return null;
+};

--- a/src/test_data/waveform-example.js
+++ b/src/test_data/waveform-example.js
@@ -1,0 +1,169 @@
+export default {
+  '@context': "http://iiif.io/api/presentation/3/context.json",
+  id: "http://example.com/waveform-example/manifest.json",
+  type: "Manifest",
+  label: {
+    it: [
+      "L'Elisir D'Amore"
+    ],
+    en: [
+      "The Elixir of Love"
+    ]
+  },
+  items: [
+    {
+      id: "http://example.com/waveform-example/canvas/1",
+      type: "Canvas",
+      width: 1920,
+      height: 1080,
+      duration: 7278.422,
+      items: [
+        {
+          id: "http://example.com/waveform-example/canvas/1/annotation_page/1",
+          type: "AnnotationPage",
+          items: [
+            {
+              id: "http://example.com/waveform-example/canvas/1/annotation_page/1/annotation/1",
+              type: "Annotation",
+              motivation: "painting",
+              target: "http://example.com/waveform-example/canvas/1",
+              body: {
+                id: "http://example.com/donizetti-elixir/low.mp4",
+                type: "Video",
+                format: "video/mp4",
+                height: 1080,
+                width: 1920,
+                duration: 7278.422
+              }
+            }
+          ]
+        }
+      ],
+      seeAlso: [
+        {
+          type: "Dataset",
+          format: "application/json",
+          id: "http://example.com/waveform.json",
+          label: { en: ["waveform.json"] }
+        }
+      ]
+    },
+    {
+      id: 'https://example.com/waveform-example/canvas/2',
+      type: 'Canvas',
+      height: 1080,
+      width: 1920,
+      duration: 7278.422,
+      items: [
+        {
+          id: 'https://example.com/waveform-example/canvas/2/page/1',
+          type: 'AnnotationPage',
+          items: [
+            {
+              id: 'https://example.com/waveform-example/canvas/2/page/1/annotation/1',
+              type: 'Annotation',
+              motivation: 'painting',
+              body: {
+                id: "https://example.com/high/media.mp4",
+                type: "Video",
+                format: "video/mp4",
+                height: 1080,
+                width: 1920,
+                duration: 7278.422
+              },
+              target: 'https://example.com/waveform-example/canvas/2',
+            },
+          ],
+        }
+      ],
+      accompanyingCanvas: {
+        height: 200, width: 800, type: "Canvas", label: { en: ["Waveform"] },
+        id: "http://example.com/waveform-example/canvas/2/accompanying",
+        items: [
+          {
+            id: "http://example.com/waveform-example/canvas/2/accompanying/page",
+            items: [
+              {
+                body: {
+                  format: "image/jpeg", height: 200, width: 800,
+                  id: "http://example.com/waveform.jpg", type: "Image"
+                },
+                id: "http://example.com/waveform-example/canvas/2/accompanying/page/annotation",
+                motivation: "painting",
+                target: "http://example.com/waveform-example/canvas/2/accompanying",
+                type: "Annotation"
+              }
+            ],
+            "type": "AnnotationPage"
+          }
+        ],
+      },
+    },
+    {
+      id: "http://example.com/waveform-example/canvas/3",
+      type: "Canvas",
+      duration: 300.0,
+      items: [
+        {
+          id: "http://example.com/waveform-example/canvas/3/annotation_page/1",
+          type: "AnnotationPage",
+          items: [
+            {
+              id: "http://example.com/waveform-example/canvas/3/annotation_page/1/annotation/1",
+              type: "Annotation",
+              motivation: "painting",
+              target: "http://example.com/waveform-example/canvas/3",
+              body: {
+                id: "http://example.com/waveform-example/audio.mp3",
+                type: "Sound",
+                format: "audio/mp3",
+                duration: 300.0
+              }
+            }
+          ]
+        }
+      ],
+      seeAlso: [
+        {
+          type: "Dataset",
+          format: "application/json",
+          id: "http://example.com/waveform.json",
+          label: { en: ["waveform.json"] }
+        }
+      ]
+    },
+    {
+      id: "http://example.com/waveform-example/canvas/4",
+      type: "Canvas",
+      duration: 300.0,
+      items: [
+        {
+          id: "http://example.com/waveform-example/canvas/4/annotation_page/1",
+          type: "AnnotationPage",
+          items: [
+            {
+              id: "http://example.com/waveform-example/canvas/4/annotation_page/1/annotation/1",
+              type: "Annotation",
+              motivation: "painting",
+              target: "http://example.com/waveform-example/canvas/4",
+              body: {
+                id: "http://example.com/waveform-example/audio.mp3",
+                type: "Sound",
+                format: "audio/mp3",
+                duration: 300.0
+              }
+            }
+          ]
+        }
+      ],
+      seeAlso: [
+        {
+          type: "Dataset",
+          format: "text/xml",
+          id: "http://example.com/waveform.xml",
+          label: { en: ["not a waveform"] }
+        }
+      ]
+    }
+  ]
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -6521,6 +6521,11 @@ warning@^4.0.0, warning@^4.0.3:
   dependencies:
     loose-envify "^1.0.0"
 
+waveform-data@^4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/waveform-data/-/waveform-data-4.5.2.tgz#6818620df01e5aeebab06f477250b30b77454f39"
+  integrity sha512-1wDQ2LmaCM76xXXkOamWui1dp7uS2UHVeNccuHDS/qnoOrczrXR6g7Q9m/UjlibHfukxBrceoRIVTKKY1tDLdA==
+
 webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"


### PR DESCRIPTION
Related issue: #998 

Changes in this PR:

- Add a new prop to `MediaPlayer` component named `showWaveform` to enable a toggle button to control visibility of a waveform display panel below the player (similar to track-scrubber)
- Read and parse waveform resources for a given Canvas in the following priority order;
  - a waveform dataset presented via `seeAlso` property (supports `.dat` and `.json` file types)
  - a waveform image presented via `accompanyingCanvas` property with a label that includes the text `waveform` (this guard against reading other images in a `accompanyingCanvas` as waveforms
  - the waveform information is read at the initial parsing stage for each Canvas, and then the actual waveform content is fetched as each Canvas is loaded into the player
- Create a new VideoJS custom component named `VideoJSWaveform` as a toggle button. This is wired to a static DOM element created as a panel identical to track-scrubber implementation, which displays the waveform visualization. 
- When the waveform control is enabled in `MediaPlayer` component props and the current Canvas has a valid waveform,
  - a waveform toggle control in the control-bar is displayed for both audio and video players
  - the waveform panel is expanded by default for audio players IF a saved playback position is not available for the Manifest
  - the waveform panel is always collapsed by default for video players
- Wire the waveform visualization using pointer event handlers to enable seek actions on the media playback
- Display the playback progress using the `background-image` CSS property as a tinted overlay on top of the waveform visualization. The area of this CSS property is clipped dynamically using the DOM property named `--range-progress` set by `VideoJSProgress` component, which aligns with the current playback progress

- Other helpful refactors:
  - move the saved playback position calculation logic into the `usePlaybackPosition` custom hook. This is used by both the waveform-display and resume-playback-modal implementations
  - reduce event handler dependent code in track-scrubber component identical to the new implementation in `VideoJSWaveform` 

<img width="901" height="118" alt="audio-waveform" src="https://github.com/user-attachments/assets/e3fdfe30-e001-40d0-b924-29a3fb9e5a22" />

<img width="901" height="560" alt="video-waveform" src="https://github.com/user-attachments/assets/6bca0d74-5b3d-42c2-b5ff-149c9b1f1f81" />


### Note: 
Still in progress work - adding support for multi-source canvases with a waveform presented using the `seeAlso` property for each Annotation body in the Canvas.