### PR TITLE
Fix UX for out of range structure timespans

### DIFF
--- a/src/components/StructuredNavigation/NavUtils/TreeNode.js
+++ b/src/components/StructuredNavigation/NavUtils/TreeNode.js
@@ -57,6 +57,8 @@ const TreeNode = ({
   const { isCollapsed, updateSectionStatus } = useCollapseExpandAll();
   // Root structure items are always expanded
   const [sectionIsCollapsed, setSectionIsCollapsed] = useState(isRoot ? false : true);
+  // Controls visibility of the descriptive tooltip for out-of-range timespans
+  const [isTooltipVisible, setIsTooltipVisible] = useState(false);
 
   const { currentNavItem, handleClick, isActiveLi,
     isActiveSection, isPlaylist, screenReaderTime } = useActiveStructure({
@@ -188,7 +190,9 @@ const TreeNode = ({
     }
     // If the section is expanded, move focus to the first child on ArrowRight keypress
     if (e.keyCode === 39 && !sectionIsCollapsed && liRef.current) {
-      const children = liRef.current.querySelectorAll('a.ramp--structured-nav__item-link');
+      const children = liRef.current.querySelectorAll(
+        'a.ramp--structured-nav__item-link, span.ramp--structured-nav__item-link.not-clickable'
+      );
       if (children?.length > 0) {
         children[0].focus();
         setFocusedItem(children[0]);
@@ -197,7 +201,7 @@ const TreeNode = ({
     }
   };
 
-  const handleLinkKeyDown = (e) => {
+  const handleTimespanKeyDown = (e) => {
     // ArrowRight keypress does nothing, prevent +5 second jump in playerHotKeys
     if (e.keyCode === 39) {
       e.stopPropagation();
@@ -291,7 +295,7 @@ const TreeNode = ({
                       href={homepage && homepage != '' ? homepage : id}
                       aria-label={ariaLabel}
                       onClick={handleClick}
-                      onKeyDown={handleLinkKeyDown}
+                      onKeyDown={handleTimespanKeyDown}
                       tabIndex={-1}>
                       {isEmpty && <LockedSVGIcon />}
                       {`${itemIndex}.`}
@@ -300,7 +304,38 @@ const TreeNode = ({
                       </span>
                     </a>
                   ) : (
-                    <span aria-label={label}>{label}</span>
+                    <span
+                      className='ramp--structured-nav__tooltip-wrapper'
+                      data-testid='out-of-range-timespan'
+                      /* Show/hide descriptive tooltip on pointer hover */
+                      onMouseOver={() => setIsTooltipVisible(true)}
+                      onMouseOut={() => setIsTooltipVisible(false)}
+                    >
+                      <span
+                        className='ramp--structured-nav__item-link not-clickable'
+                        tabIndex={-1}
+                        onKeyDown={handleTimespanKeyDown}
+                        /* Show/hide descriptive tooltip on keyboard focus */
+                        onFocus={() => setIsTooltipVisible(true)}
+                        onBlur={() => setIsTooltipVisible(false)}
+                        aria-describedby={`out-of-range-${rangeId}`}
+                      >
+                        {`${itemIndex}.`}
+                        <span className='structured-nav__item-label' aria-label={label}>
+                          {label} {duration.length > 0 ? ` (${duration})` : ''}
+                        </span>
+                      </span>
+                      <span
+                        role='tooltip'
+                        id={`out-of-range-${rangeId}`}
+                        className={cx(
+                          'ramp--structured-nav__tooltip',
+                          isTooltipVisible && 'visible'
+                        )}
+                      >
+                        This timespan is outside the available media duration and cannot be played.
+                      </span>
+                    </span>
                   )}
                 </Fragment>
               )

--- a/src/components/StructuredNavigation/NavUtils/TreeNode.test.js
+++ b/src/components/StructuredNavigation/NavUtils/TreeNode.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import TreeNode from './TreeNode';
 import {
   withManifestProvider,
@@ -199,7 +199,7 @@ describe('TreeNode component', () => {
     setFocusedItem: setFocusedItemMock,
   };
   const canvasItemWithMediaFragment = {
-    id: 'https://example.com/manifest/lunchroome_manners/canvas/1#t=0.0,572.32',
+    id: 'https://example.com/manifest/lunchroom_manners/canvas/1#t=0.0,572.32',
     duration: '09:32',
     rangeId: 'https://example.com/manifest/lunchroom_manners/range/1',
     isTitle: false,
@@ -213,7 +213,7 @@ describe('TreeNode component', () => {
     label: 'Lunchroom Manners',
     items: [
       {
-        id: 'https://example.com/manifest/lunchroome_manners/canvas/1#t=0.0,45.321',
+        id: 'https://example.com/manifest/lunchroom_manners/canvas/1#t=0.0,45.321',
         duration: '00:45',
         rangeId: 'https://example.com/manifest/lunchroom_manners/range/1-1',
         isTitle: false,
@@ -229,7 +229,7 @@ describe('TreeNode component', () => {
         times: { start: 0, end: 45.321 },
       },
       {
-        id: 'https://example.com/manifest/lunchroome_manners/canvas/1#t=60,120.321',
+        id: 'https://example.com/manifest/lunchroom_manners/canvas/1#t=60,120.321',
         duration: '01:00',
         rangeId: 'https://example.com/manifest/lunchroom_manners/range/1-2',
         isTitle: false,
@@ -249,6 +249,26 @@ describe('TreeNode component', () => {
     sectionRef: sectionRef,
     structureContainerRef,
     times: { start: 0, end: 0 },
+    setFocusedItem: setFocusedItemMock,
+  };
+  const outOfRangeItem = {
+    id: 'https://example.com/manifest/lunchroom_manners/canvas/1#t=650,700',
+    duration: '00:50',
+    rangeId: 'https://example.com/manifest/lunchroom_manners/range/1',
+    isTitle: false,
+    isCanvas: false,
+    canvasIndex: 1,
+    itemIndex: 3,
+    isClickable: false,
+    isEmpty: false,
+    isRoot: false,
+    label: 'Out of Range Timespan',
+    items: [],
+    canvasDuration: 572.034,
+    times: { start: 650, end: 700 },
+    sectionCount: 1,
+    sectionRef: sectionRef,
+    structureContainerRef,
     setFocusedItem: setFocusedItemMock,
   };
 
@@ -502,6 +522,52 @@ describe('TreeNode component', () => {
       const structItem = screen.getByText('Part I (00:45)');
       expect(structItem.parentElement.getAttribute('href'))
         .toEqual('https://example.com/manifest/lunchroome_manners/canvas/1#t=0.0,45.321');
+    });
+  });
+
+  describe('with an out-of-range timespan', () => {
+    beforeEach(() => {
+      const props = { ...outOfRangeItem };
+      const TreeNodeWithPlayer = withPlayerProvider(TreeNode, {
+        ...props,
+        initialState: {},
+      });
+      const TreeNodeWithManifest = withManifestProvider(TreeNodeWithPlayer, {
+        initialState: { ...initialManifestState, playlist: { isPlaylist: false } },
+      });
+      render(<TreeNodeWithManifest />);
+    });
+
+    test('renders as plain text', () => {
+      expect(screen.queryByText(/Out of Range Timespan \(00:50/)).toBeInTheDocument();
+      expect(screen.getByText(/Out of Range Timespan \(00:50/).tagName).toBe('SPAN');
+      expect(screen.getByText(/Out of Range Timespan \(00:50/)).toHaveClass('structured-nav__item-label');
+    });
+
+    test('renders an accessible tooltip description elements', () => {
+      const timespanParent = screen.getByText(/Out of Range Timespan \(00:50/).parentElement;
+
+      expect(timespanParent.tagName).toBe('SPAN');
+      expect(timespanParent).toHaveClass('ramp--structured-nav__item-link not-clickable');
+      expect(timespanParent).not.toHaveAttribute('href');
+
+      // Has tabIndex set to enable keyboard navigation using roving tabindex
+      expect(timespanParent).toHaveAttribute('tabIndex', '-1');
+
+      // Has an accessible description pointing to a tooltip element
+      expect(timespanParent).toHaveAttribute(
+        'aria-describedby', 'out-of-range-https://example.com/manifest/lunchroom_manners/range/1'
+      );
+
+      const descTooltip = document.getElementById(timespanParent.getAttribute('aria-describedby'));
+      expect(descTooltip).toBeInTheDocument();
+      expect(descTooltip).toHaveAttribute('role', 'tooltip');
+      expect(descTooltip.tagName).toBe('SPAN');
+      expect(descTooltip).toHaveClass('ramp--structured-nav__tooltip');
+      expect(descTooltip).not.toHaveClass('visible');
+      expect(descTooltip).toHaveTextContent(
+        'This timespan is outside the available media duration and cannot be played.'
+      );
     });
   });
 });

--- a/src/components/StructuredNavigation/StructuredNavigation.js
+++ b/src/components/StructuredNavigation/StructuredNavigation.js
@@ -211,9 +211,10 @@ const StructuredNavigation = ({ showAllSectionsButton = false, sectionsHeading =
   };
 
   const handleKeyDown = (e) => {
-    // Get all linked structure items in the component
+    // Get all timespan (both links/plain text) structure items in the component
     const structureItems = structureContainerRef.current.querySelectorAll(
-      'button.ramp--structured-nav__section-title, a.ramp--structured-nav__item-link'
+      'button.ramp--structured-nav__section-title, a.ramp--structured-nav__item-link, \
+      span.ramp--structured-nav__item-link.not-clickable'
     );
     if (structureItems?.length > 0) {
       // Re-calculate the nextIndex when focused item is changed from within TreeNode
@@ -233,7 +234,10 @@ const StructuredNavigation = ({ showAllSectionsButton = false, sectionsHeading =
         nextIndex = (focusedItemIndexRef.current + 1) % structureItems.length;
         e.preventDefault();
       } else if (e.key === 'ArrowUp') {
-        nextIndex = (focusedItemIndexRef.current - 1 + structureItems.length) % structureItems.length;
+        // When nothing has been focused yet, pressing 'up' arrow moves focus to the last struct item
+        nextIndex = focusedItemIndexRef.current < 0
+          ? structureItems.length - 1
+          : (focusedItemIndexRef.current - 1 + structureItems.length) % structureItems.length;
         e.preventDefault();
       } else if (e.key === 'Tab') {
         if (e.shiftKey) {

--- a/src/components/StructuredNavigation/StructuredNavigation.scss
+++ b/src/components/StructuredNavigation/StructuredNavigation.scss
@@ -200,6 +200,40 @@ ul.ramp--structured-nav__tree {
       .structured-nav__item-label {
         margin-left: 0.2em;
       }
+
+      // Out-of-range timespans rendered as plain text
+      &.not-clickable {
+        color: vars.$primaryDark;
+        cursor: not-allowed;
+      }
+    }
+
+    .ramp--structured-nav__tooltip-wrapper {
+      position: relative;
+      display: inline-block;
+
+      // Show visible outline on keyboard focus for out-of-range timespan
+      .ramp--structured-nav__item.not-clickable:focus {
+        outline: 1px solid vars.$primaryDark;
+        outline-offset: 2px;
+      }
+
+      .ramp--structured-nav__tooltip {
+        display: none;
+        position: absolute;
+        left: 0;
+        bottom: 100%;
+        margin-bottom: 0.3em;
+        padding: 0.4em 0.6em;
+        border-radius: 0.25rem;
+        background-color: vars.$primaryDarker;
+        color: #fff;
+        font-size: vars.$fontSizeMedium;
+
+        &.visible {
+          display: block;
+        }
+      }
     }
 
     ul {

--- a/src/components/StructuredNavigation/StructuredNavigation.test.js
+++ b/src/components/StructuredNavigation/StructuredNavigation.test.js
@@ -8,6 +8,7 @@ import invalidStructure from '@TestData/invalid-structure';
 import thumbnailNavStructure from '@TestData/transcript-multiple-canvas';
 import playlist from '@TestData/playlist';
 import nonCollapsibleStructure from '@TestData/multiple-canvas-auto-advance';
+import outOfRangeManifest from '@TestData/out-of-range-structure';
 import {
   withManifestProvider,
   withManifestAndPlayerProvider,
@@ -595,251 +596,357 @@ describe('StructuredNavigation component', () => {
     expect(treeItems[1]).toHaveClass('ramp--structured-nav__tree-item active');
   });
 
-  describe('allows keyboard nav according to tree view a11y design pattern', () => {
-    const handleClickMock = jest.fn();
-    let structuredNav, treeItems;
-    const props = { showAllSectionsButton: true };
-    beforeEach(() => {
-      jest.spyOn(hooks, 'useActiveStructure').mockImplementation(() => ({
-        handleClick: handleClickMock
-      }));
+  describe('provides keyboard nav according to tree view a11y design pattern', () => {
+    describe('for nested structures', () => {
+      const handleClickMock = jest.fn();
+      let structuredNav, treeItems;
+      const props = { showAllSectionsButton: true };
+      beforeEach(() => {
+        jest.spyOn(hooks, 'useActiveStructure').mockImplementation(() => ({
+          handleClick: handleClickMock
+        }));
+        const NavWithPlayer = withPlayerProvider(StructuredNavigation, {
+          ...props,
+          initialState: {},
+        });
+        const NavWithManifest = withManifestProvider(NavWithPlayer, {
+          initialState: { ...manifestState(manifest) },
+        });
+        render(
+          <ErrorBoundary>
+            <NavWithManifest />
+          </ErrorBoundary>
+        );
+        treeItems = screen.getAllByTestId('tree-item');
+      });
+
+      test('rendered as sections', () => {
+        expect(screen.queryAllByTestId('tree-item').length).toEqual(21);
+        expect(treeItems[0].children[1].children.length).toBe(2);
+
+        expect(treeItems[0].children[1].children[0]).toHaveTextContent('Lunchroom Manners');
+        expect(treeItems[0].children[1].children[1]).toHaveTextContent('Lunchroom Manners 2');
+
+        const firstSection = treeItems[0].children[1].children[0];
+        expect(firstSection.children).toHaveLength(2);
+
+        const secondSection = treeItems[0].children[1].children[1];
+        expect(secondSection.children).toHaveLength(1);
+      });
+
+      describe('when focused on an expanded section item', () => {
+        beforeEach(() => {
+          // Set focus to structure nav container
+          structuredNav = screen.getByTestId('structured-nav');
+          structuredNav.focus();
+          // Move focus to the first section in structure by pressing ArrowDown twice
+          fireEvent.keyDown(structuredNav, { key: 'ArrowDown', keyCode: 40 });
+          fireEvent.keyDown(structuredNav, { key: 'ArrowDown', keyCode: 40 });
+          treeItems = screen.getAllByTestId('tree-item');
+        });
+
+        test('first section with collapsible structure has focus', () => {
+          const sectionButton = treeItems[1].children[0].children[0];
+          const collapseIcon = treeItems[1].children[0].children[1];
+
+          // First collapsible section has focus
+          expect(sectionButton).toHaveTextContent('Lunchroom Manners');
+          expect(sectionButton).toHaveFocus();
+
+          // Nested child structure is expanded
+          expect(collapseIcon.children[0]).toHaveClass('arrow up');
+          expect(treeItems[1].children).toHaveLength(2);
+          expect(treeItems[1].children[1].tagName).toEqual('UL');
+        });
+
+        test('ArrowLeft keydown event collapses the nested structure', () => {
+          const sectionButton = treeItems[1].children[0].children[0];
+          const collapseIcon = treeItems[1].children[0].children[1];
+
+          fireEvent.keyDown(sectionButton, { key: 'ArrowLeft', keyCode: 37 });
+
+          // Collapses on click and hides the nested child structure
+          expect(collapseIcon.children[0]).toHaveClass('arrow down');
+          expect(treeItems[1].children).toHaveLength(1);
+        });
+
+        test('ArrowRight keydown event moves focus to first child', () => {
+          const sectionButton = treeItems[1].children[0].children[0];
+
+          fireEvent.keyDown(sectionButton, { key: 'ArrowRight', keyCode: 39 });
+
+          // Focus is moved from section button to its first child
+          expect(sectionButton).not.toHaveFocus();
+          expect(treeItems[1].querySelectorAll('a')[0]).toHaveFocus();
+          expect(treeItems[1].children[1]).toHaveTextContent('Using Soap');
+        });
+
+        test('Enter keydown event loads media into the player', () => {
+          const sectionButton = treeItems[1].children[0].children[0];
+          // Press 'Enter' key
+          fireEvent.keyDown(sectionButton, { key: 'Enter', keyCode: 13 });
+          // Calls handleClick in useActiveStructure custom hook
+          expect(handleClickMock).toHaveBeenCalled();
+        });
+      });
+
+      describe('when focused on a timespan item', () => {
+        const mockStopPropagation = jest.spyOn(Event.prototype, 'stopPropagation');
+        beforeEach(() => {
+          // Set focus to structure nav container
+          structuredNav = screen.getByTestId('structured-nav');
+          structuredNav.focus();
+          // Move focus to the first section in structure by pressing ArrowDown thrice
+          fireEvent.keyDown(structuredNav, { key: 'ArrowDown', keyCode: 40 });
+          fireEvent.keyDown(structuredNav, { key: 'ArrowDown', keyCode: 40 });
+          fireEvent.keyDown(structuredNav, { key: 'ArrowDown', keyCode: 40 });
+          treeItems = screen.getAllByTestId('tree-item');
+        });
+
+        test('first child in first section has focus', () => {
+          // First child is the 4th in the list because of 'Washing Hands' div
+          const firstChildTracker = treeItems[3].children[0];
+          const firstChildLink = treeItems[3].children[1];
+          expect(firstChildTracker).toHaveClass('tracker');
+          expect(firstChildLink).toHaveTextContent('Using Soap');
+          expect(firstChildLink).toHaveFocus();
+        });
+
+        test('ArrowRight keydown event does nothing', () => {
+          const firstChild = treeItems[3].children[1];
+          // Press 'ArrowRight' key
+          fireEvent.keyDown(firstChild, { key: 'ArrowRight', keyCode: 39 });
+          expect(mockStopPropagation).toHaveBeenCalledTimes(1);
+        });
+
+        test('ArrowLeft keydown moves focus to section item', () => {
+          const firstChild = treeItems[3].children[1];
+
+          // Press 'ArrowDown' key moves focus to the next timespan: Rinsing Well
+          fireEvent.keyDown(firstChild, { key: 'ArrowDown', keyCode: 40 });
+          expect(treeItems[4].children[1]).toHaveFocus();
+          expect(treeItems[4].children[1]).toHaveTextContent('Rinsing Well');
+
+          // Press 'ArrowLeft' key moves focus to the parent section: Lunchroom Manners
+          fireEvent.keyDown(treeItems[4].children[1], { key: 'ArrowLeft', keyCode: 37 });
+
+          expect(treeItems[4].children[1]).not.toHaveFocus();
+          expect(treeItems[1].children[0].children[0]).toHaveFocus();
+          expect(treeItems[1].children[0].children[0]).toHaveTextContent('Lunchroom Manners');
+        });
+
+        test('ArrowDown keydown event moves focus to next timespan', () => {
+          const firstChild = treeItems[3].children[1];
+          expect(firstChild).toHaveFocus();
+          // Press 'ArrowDown' key moves focus to the next timespan: Rinsing Well
+          fireEvent.keyDown(firstChild, { key: 'ArrowDown', keyCode: 40 });
+
+          // Focus is moved from the first child to next
+          expect(firstChild).not.toHaveFocus();
+          expect(treeItems[4].children[1]).toHaveFocus();
+          expect(treeItems[4].children[1]).toHaveTextContent('Rinsing Well');
+        });
+
+        test('Space keydown event activates the timespan', () => {
+          const firstChild = treeItems[3].children[1];
+          expect(firstChild).toHaveFocus();
+          // Press 'ArrowDown' key
+          fireEvent.keyDown(firstChild, { key: 'ArrowDown', keyCode: 40 });
+
+          // Focus is moved from the first child to next
+          expect(firstChild).not.toHaveFocus();
+          expect(treeItems[4].children[1]).toHaveFocus();
+          expect(treeItems[4].children[1]).toHaveTextContent('Rinsing Well');
+
+          fireEvent.keyDown(treeItems[4].children[1], { key: '', code: 'Space', keyCode: 32 });
+
+          expect(handleClickMock).toHaveBeenCalledTimes(1);
+        });
+      });
+
+      describe('when focused on a non-collapsible section item', () => {
+        beforeEach(() => {
+          // Collapse all sections
+          const collapseExpandAll = screen.getByTestId('collapse-expand-all-btn');
+          fireEvent.click(collapseExpandAll);
+
+          // Set focus to structure nav container
+          structuredNav = screen.getByTestId('structured-nav');
+          structuredNav.focus();
+
+          // Move focus to the first section in structure by pressing ArrowDown thrice
+          fireEvent.keyDown(structuredNav, { key: 'ArrowDown', keyCode: 40 });
+          fireEvent.keyDown(structuredNav, { key: 'ArrowDown', keyCode: 40 });
+          fireEvent.keyDown(structuredNav, { key: 'ArrowDown', keyCode: 40 });
+          treeItems = screen.getAllByTestId('tree-item');
+        });
+
+        test('second section without collapsible structure has focus', () => {
+          const sectionButton = treeItems[2].children[0].children[0];
+          expect(sectionButton).toHaveTextContent('Lunchroom Manners 2');
+          expect(sectionButton).toHaveFocus();
+
+          // Does not have nested children
+          expect(treeItems[2].children[0].children).toHaveLength(1);
+        });
+
+        test('ArrowRight keydown event does not do anything', () => {
+          const sectionButton = treeItems[2].children[0].children[0];
+          // Press 'ArrowRight' key
+          fireEvent.keyDown(sectionButton, { key: 'ArrowRight', keyCode: 39 });
+          // Calls handleClick in useActiveStructure custom hook
+          expect(handleClickMock).not.toHaveBeenCalled();
+        });
+
+        test('Enter keydown event loads media into the player', () => {
+          const sectionButton = treeItems[2].children[0].children[0];
+          // Press 'Enter' key
+          fireEvent.keyDown(sectionButton, { key: 'Enter', keyCode: 13 });
+          // Calls handleClick in useActiveStructure custom hook
+          expect(handleClickMock).toHaveBeenCalled();
+        });
+      });
+
+      describe('when focused on a collapsed section item', () => {
+        let sectionButton, collapseIcon;
+        beforeEach(() => {
+          // Set focus to structure nav container
+          structuredNav = screen.getByTestId('structured-nav');
+          structuredNav.focus();
+          // Move focus to the first section in structure by pressing ArrowDown twice
+          fireEvent.keyDown(structuredNav, { key: 'ArrowDown', keyCode: 40 });
+          fireEvent.keyDown(structuredNav, { key: 'ArrowDown', keyCode: 40 });
+
+          treeItems = screen.getAllByTestId('tree-item');
+          sectionButton = treeItems[1].children[0].children[0];
+          collapseIcon = treeItems[1].children[0].children[1];
+          // Collapse the section
+          fireEvent.keyDown(sectionButton, { key: 'ArrowLeft', keyCode: 37 });
+        });
+
+        test('renders successfully', () => {
+          // First collapsible section has focus
+          expect(sectionButton).toHaveTextContent('Lunchroom Manners');
+          expect(sectionButton).toHaveFocus();
+
+          // Nested child structure is collapsed
+          expect(collapseIcon.children[0]).toHaveClass('arrow down');
+          expect(treeItems[1].children).toHaveLength(1);
+        });
+
+        test('first ArrowRight keydown event expands the section without activation', () => {
+          fireEvent.keyDown(sectionButton, { key: 'ArrowRight', keyCode: 39 });
+
+          // Keeps the focus on section button and expands the section
+          expect(sectionButton).toHaveFocus();
+          expect(treeItems[1].children).toHaveLength(2);
+          expect(collapseIcon.children[0]).toHaveClass('arrow up');
+          expect(handleClickMock).not.toHaveBeenCalled();
+        });
+      });
+    });
+
+    test('moves focus to the last item on "ArrowUp" keypress after initial component focus', () => {
       const NavWithPlayer = withPlayerProvider(StructuredNavigation, {
-        ...props,
+        showAllSectionsButton: true,
         initialState: {},
       });
       const NavWithManifest = withManifestProvider(NavWithPlayer, {
-        initialState: { ...manifestState(manifest) },
+        initialState: { ...manifestState(singleCanvasManifest) },
       });
       render(
         <ErrorBoundary>
           <NavWithManifest />
         </ErrorBoundary>
       );
-      treeItems = screen.getAllByTestId('tree-item');
+      const structuredNav = screen.getByTestId('structured-nav');
+      structuredNav.focus();
+
+      fireEvent.keyDown(structuredNav, { key: 'ArrowUp', keyCode: 38 });
+
+      expect(screen.queryByText(/Atto Secondo/)).toBeInTheDocument();
+      const lastTimespan = screen.getByText(/Atto Secondo/).parentElement;
+      expect(lastTimespan).toHaveFocus();
+    });
+  });
+
+  describe('renders out-of-range timespan', () => {
+    let structuredNav;
+    beforeEach(() => {
+      const NavWithPlayer = withPlayerProvider(StructuredNavigation, {
+        showAllSectionsButton: true,
+        initialState: {},
+      });
+      const NavWithManifest = withManifestProvider(NavWithPlayer, {
+        initialState: { ...manifestState(outOfRangeManifest) },
+      });
+      render(
+        <ErrorBoundary>
+          <NavWithManifest />
+        </ErrorBoundary>
+      );
+      structuredNav = screen.getByTestId('structured-nav');
+      structuredNav.focus();
     });
 
-    test('renders successfully', () => {
-      expect(screen.queryAllByTestId('tree-item').length).toEqual(21);
-      expect(treeItems[0].children[1].children.length).toBe(2);
+    test('as plain text with a tooltip', () => {
+      expect(screen.queryByTestId('out-of-range-timespan')).toBeInTheDocument();
+      expect(screen.queryByText(/Out of Range Timespan/)).toBeInTheDocument();
 
-      expect(treeItems[0].children[1].children[0]).toHaveTextContent('Lunchroom Manners');
-      expect(treeItems[0].children[1].children[1]).toHaveTextContent('Lunchroom Manners 2');
+      const timespanWrapper = screen.getByTestId('out-of-range-timespan');
+      expect(timespanWrapper.children).toHaveLength(2);
 
-      const firstSection = treeItems[0].children[1].children[0];
-      expect(firstSection.children).toHaveLength(2);
+      // <span> elements with the text and tooltip
+      const timespan = timespanWrapper.children[0];
+      const tooltip = timespanWrapper.children[1];
 
-      const secondSection = treeItems[0].children[1].children[1];
-      expect(secondSection.children).toHaveLength(1);
+      // First child is a <span> with the class 'not-clickable'
+      expect(timespan.tagName).toEqual('SPAN');
+      expect(timespan).toHaveClass('ramp--structured-nav__item-link not-clickable');
+      // First child has a <span> child element with the label
+      expect(timespan.children[0].tagName).toEqual('SPAN');
+      expect(timespan.children[0]).toHaveClass('structured-nav__item-label');
+      // Second child is a descriptive tooltip <span> element hidden by default
+      expect(tooltip.tagName).toEqual('SPAN');
+      expect(tooltip).toHaveClass('ramp--structured-nav__tooltip');
+      expect(tooltip).not.toHaveClass('visible');
     });
 
-    describe('when focused on an expanded section item', () => {
+    describe('and displays the description tooltip on', () => {
+      let timespanWrapper, timespan, tooltip;
       beforeEach(() => {
-        // Set focus to structure nav container
-        structuredNav = screen.getByTestId('structured-nav');
-        structuredNav.focus();
-        // Move focus to the first section in structure by pressing ArrowDown twice
-        fireEvent.keyDown(structuredNav, { key: 'ArrowDown', keyCode: 40 });
-        fireEvent.keyDown(structuredNav, { key: 'ArrowDown', keyCode: 40 });
-        treeItems = screen.getAllByTestId('tree-item');
+        timespanWrapper = screen.getByTestId('out-of-range-timespan');
+        // <span> elements with the text and tooltip
+        timespan = timespanWrapper.children[0];
+        tooltip = timespanWrapper.children[1];
       });
 
-      test('first section with collapsible structure has focus', () => {
-        const sectionButton = treeItems[1].children[0].children[0];
-        const collapseIcon = treeItems[1].children[0].children[1];
+      test('keyboard focus on timespan', () => {
+        expect(structuredNav).toHaveFocus();
+        expect(timespan).toHaveTextContent(/Out of Range Timespan/);
+        expect(tooltip).not.toHaveClass('visible');
 
-        // First collapsible section has focus
-        expect(sectionButton).toHaveTextContent('Lunchroom Manners');
-        expect(sectionButton).toHaveFocus();
-
-        // Nested child structure is expanded
-        expect(collapseIcon.children[0]).toHaveClass('arrow up');
-        expect(treeItems[1].children).toHaveLength(2);
-        expect(treeItems[1].children[1].tagName).toEqual('UL');
-      });
-
-      test('ArrowLeft keydown event collapses the nested structure', () => {
-        const sectionButton = treeItems[1].children[0].children[0];
-        const collapseIcon = treeItems[1].children[0].children[1];
-
-        fireEvent.keyDown(sectionButton, { key: 'ArrowLeft', keyCode: 37 });
-
-        // Collapses on click and hides the nested child structure
-        expect(collapseIcon.children[0]).toHaveClass('arrow down');
-        expect(treeItems[1].children).toHaveLength(1);
-      });
-
-      test('ArrowRight keydown event moves focus to first child', () => {
-        const sectionButton = treeItems[1].children[0].children[0];
-
-        fireEvent.keyDown(sectionButton, { key: 'ArrowRight', keyCode: 39 });
-
-        // Focus is moved from section button to its first child
-        expect(sectionButton).not.toHaveFocus();
-        expect(treeItems[1].querySelectorAll('a')[0]).toHaveFocus();
-        expect(treeItems[1].children[1]).toHaveTextContent('Using Soap');
-      });
-
-      test('Enter keydown event loads media into the player', () => {
-        const sectionButton = treeItems[1].children[0].children[0];
-        // Press 'Enter' key
-        fireEvent.keyDown(sectionButton, { key: 'Enter', keyCode: 13 });
-        // Calls handleClick in useActiveStructure custom hook
-        expect(handleClickMock).toHaveBeenCalled();
-      });
-    });
-
-    describe('when focused on a timespan item', () => {
-      const mockStopPropagation = jest.spyOn(Event.prototype, 'stopPropagation');
-      beforeEach(() => {
-        // Set focus to structure nav container
-        structuredNav = screen.getByTestId('structured-nav');
-        structuredNav.focus();
-        // Move focus to the first section in structure by pressing ArrowDown thrice
+        // Moves focus to the out-of-range timespan by pressing ArrowDown 3 times
         fireEvent.keyDown(structuredNav, { key: 'ArrowDown', keyCode: 40 });
         fireEvent.keyDown(structuredNav, { key: 'ArrowDown', keyCode: 40 });
         fireEvent.keyDown(structuredNav, { key: 'ArrowDown', keyCode: 40 });
-        treeItems = screen.getAllByTestId('tree-item');
+
+        expect(timespan).toHaveFocus();
+        expect(timespan.tagName).toEqual('SPAN');
+        expect(timespan).toHaveClass('not-clickable');
+
+        expect(tooltip).toHaveClass('visible');
       });
 
-      test('first child in first section has focus', () => {
-        // First child is the 4th in the list because of 'Washing Hands' div
-        const firstChildTracker = treeItems[3].children[0];
-        const firstChildLink = treeItems[3].children[1];
-        expect(firstChildTracker).toHaveClass('tracker');
-        expect(firstChildLink).toHaveTextContent('Using Soap');
-        expect(firstChildLink).toHaveFocus();
-      });
+      test('pointer hover over timepspan wrapper', () => {
+        expect(structuredNav).toHaveFocus();
+        expect(timespan).toHaveTextContent(/Out of Range Timespan/);
+        expect(tooltip).not.toHaveClass('visible');
 
-      test('ArrowRight keydown event does nothing', () => {
-        const firstChild = treeItems[3].children[1];
-        // Press 'ArrowRight' key
-        fireEvent.keyDown(firstChild, { key: 'ArrowRight', keyCode: 39 });
-        expect(mockStopPropagation).toHaveBeenCalledTimes(1);
-      });
+        fireEvent.mouseOver(timespanWrapper);
 
-      test('ArrowLeft keydown moves focus to section item', () => {
-        const firstChild = treeItems[3].children[1];
-
-        // Press 'ArrowDown' key moves focus to the next timespan: Rinsing Well
-        fireEvent.keyDown(firstChild, { key: 'ArrowDown', keyCode: 40 });
-        expect(treeItems[4].children[1]).toHaveFocus();
-        expect(treeItems[4].children[1]).toHaveTextContent('Rinsing Well');
-
-        // Press 'ArrowLeft' key moves focus to the parent section: Lunchroom Manners
-        fireEvent.keyDown(treeItems[4].children[1], { key: 'ArrowLeft', keyCode: 37 });
-
-        expect(treeItems[4].children[1]).not.toHaveFocus();
-        expect(treeItems[1].children[0].children[0]).toHaveFocus();
-        expect(treeItems[1].children[0].children[0]).toHaveTextContent('Lunchroom Manners');
-      });
-
-      test('ArrowDown keydown event moves focus to next timespan', () => {
-        const firstChild = treeItems[3].children[1];
-        expect(firstChild).toHaveFocus();
-        // Press 'ArrowDown' key moves focus to the next timespan: Rinsing Well
-        fireEvent.keyDown(firstChild, { key: 'ArrowDown', keyCode: 40 });
-
-        // Focus is moved from the first child to next
-        expect(firstChild).not.toHaveFocus();
-        expect(treeItems[4].children[1]).toHaveFocus();
-        expect(treeItems[4].children[1]).toHaveTextContent('Rinsing Well');
-      });
-
-      test('Space keydown event activates the timespan', () => {
-        const firstChild = treeItems[3].children[1];
-        expect(firstChild).toHaveFocus();
-        // Press 'ArrowDown' key
-        fireEvent.keyDown(firstChild, { key: 'ArrowDown', keyCode: 40 });
-
-        // Focus is moved from the first child to next
-        expect(firstChild).not.toHaveFocus();
-        expect(treeItems[4].children[1]).toHaveFocus();
-        expect(treeItems[4].children[1]).toHaveTextContent('Rinsing Well');
-
-        fireEvent.keyDown(treeItems[4].children[1], { key: '', code: 'Space', keyCode: 32 });
-
-        expect(handleClickMock).toHaveBeenCalledTimes(1);
-      });
-    });
-
-    describe('when focused on a non-collapsible section item', () => {
-      beforeEach(() => {
-        // Collapse all sections
-        const collapseExpandAll = screen.getByTestId('collapse-expand-all-btn');
-        fireEvent.click(collapseExpandAll);
-
-        // Set focus to structure nav container
-        structuredNav = screen.getByTestId('structured-nav');
-        structuredNav.focus();
-
-        // Move focus to the first section in structure by pressing ArrowDown thrice
-        fireEvent.keyDown(structuredNav, { key: 'ArrowDown', keyCode: 40 });
-        fireEvent.keyDown(structuredNav, { key: 'ArrowDown', keyCode: 40 });
-        fireEvent.keyDown(structuredNav, { key: 'ArrowDown', keyCode: 40 });
-        treeItems = screen.getAllByTestId('tree-item');
-      });
-
-      test('second section without collapsible structure has focus', () => {
-        const sectionButton = treeItems[2].children[0].children[0];
-        expect(sectionButton).toHaveTextContent('Lunchroom Manners 2');
-        expect(sectionButton).toHaveFocus();
-
-        // Does not have nested children
-        expect(treeItems[2].children[0].children).toHaveLength(1);
-      });
-
-      test('ArrowRight keydown event does not do anything', () => {
-        const sectionButton = treeItems[2].children[0].children[0];
-        // Press 'ArrowRight' key
-        fireEvent.keyDown(sectionButton, { key: 'ArrowRight', keyCode: 39 });
-        // Calls handleClick in useActiveStructure custom hook
-        expect(handleClickMock).not.toHaveBeenCalled();
-      });
-
-      test('Enter keydown event loads media into the player', () => {
-        const sectionButton = treeItems[2].children[0].children[0];
-        // Press 'Enter' key
-        fireEvent.keyDown(sectionButton, { key: 'Enter', keyCode: 13 });
-        // Calls handleClick in useActiveStructure custom hook
-        expect(handleClickMock).toHaveBeenCalled();
-      });
-    });
-
-    describe('when focused on a collapsed section item', () => {
-      let sectionButton, collapseIcon;
-      beforeEach(() => {
-        // Set focus to structure nav container
-        structuredNav = screen.getByTestId('structured-nav');
-        structuredNav.focus();
-        // Move focus to the first section in structure by pressing ArrowDown twice
-        fireEvent.keyDown(structuredNav, { key: 'ArrowDown', keyCode: 40 });
-        fireEvent.keyDown(structuredNav, { key: 'ArrowDown', keyCode: 40 });
-
-        treeItems = screen.getAllByTestId('tree-item');
-        sectionButton = treeItems[1].children[0].children[0];
-        collapseIcon = treeItems[1].children[0].children[1];
-        // Collapse the section
-        fireEvent.keyDown(sectionButton, { key: 'ArrowLeft', keyCode: 37 });
-      });
-
-      test('renders successfully', () => {
-        // First collapsible section has focus
-        expect(sectionButton).toHaveTextContent('Lunchroom Manners');
-        expect(sectionButton).toHaveFocus();
-
-        // Nested child structure is collapsed
-        expect(collapseIcon.children[0]).toHaveClass('arrow down');
-        expect(treeItems[1].children).toHaveLength(1);
-      });
-
-      test('first ArrowRight keydown event expands the section without activation', () => {
-        fireEvent.keyDown(sectionButton, { key: 'ArrowRight', keyCode: 39 });
-
-        // Keeps the focus on section button and expands the section
-        expect(sectionButton).toHaveFocus();
-        expect(treeItems[1].children).toHaveLength(2);
-        expect(collapseIcon.children[0]).toHaveClass('arrow up');
-        expect(handleClickMock).not.toHaveBeenCalled();
+        expect(timespan).not.toHaveFocus();
+        expect(tooltip).toHaveClass('visible');
       });
     });
   });

--- a/src/services/iiif-parser.js
+++ b/src/services/iiif-parser.js
@@ -1,6 +1,7 @@
 import { parseManifest } from 'manifesto.js';
 import mimeTypes from 'mime-types';
 import {
+  checkSrcRange,
   GENERIC_EMPTY_MANIFEST_MESSAGE,
   GENERIC_ERROR_MESSAGE,
   getLabelValue,
@@ -623,8 +624,6 @@ export function getStructureRanges(manifest, canvasesInfo, isPlaylist = false) {
         isEmpty = canvasInfo.isEmpty;
         summary = canvasInfo.summary;
         homepage = canvasInfo.homepage;
-        // Mark all timespans as clickable, and provide desired behavior in TreeNode component
-        isClickable = true;
         if (canvasInfo.range != undefined) {
           const { start, end } = canvasInfo.range;
           canvasDuration = end - start;
@@ -635,6 +634,11 @@ export function getStructureRanges(manifest, canvasesInfo, isPlaylist = false) {
       // Parse start and end times from media-fragment URI
       // For Canvas-level timespans returns { start: 0, end: 0 }: to avoid full time-rail highligting
       let times = id ? getMediaFragment(id, canvasDuration) : { start: 0, end: 0 };
+
+      // A timespan is only clickable when its start/end falls within the Canvas' duration
+      if (canvases.length > 0 && canvasesInfo?.length > 0) {
+        isClickable = checkSrcRange(times, { end: canvasDuration });
+      }
 
       let item = {
         label, summary, isRoot, homepage, canvasDuration, id, times,

--- a/src/services/iiif-parser.test.js
+++ b/src/services/iiif-parser.test.js
@@ -11,6 +11,7 @@ import multiCanvasV4Manifest from '@TestData/multi-canvas-v4';
 import audiannotateTest from '@TestData/audiannotate-test';
 import adManifest from '@TestData/ad-annotation';
 import authManifest from '@TestData/auth-manifest';
+import outOfRangeManifest from '@TestData/out-of-range-structure';
 import * as iiifParser from './iiif-parser';
 import * as util from './utility-helpers';
 
@@ -921,6 +922,26 @@ describe('iiif-parser', () => {
       expect(firstStructCanvas.duration).toEqual('00:32');
       expect(firstStructCanvas.canvasDuration).toEqual(32);
       expect(firstStructCanvas.times).toEqual({ start: 0, end: 32 });
+    });
+
+    it('marks a timespan as not clickable when its times are out-of-range of Canvas duration', () => {
+      const { structures, timespans } = iiifParser.getStructureRanges(
+        outOfRangeManifest, iiifParser.canvasesInManifest(outOfRangeManifest)
+      );
+      expect(structures).toHaveLength(1);
+      expect(timespans).toHaveLength(2);
+
+      const inRangeTimespan = timespans[0];
+      expect(inRangeTimespan.label).toEqual('In Range Timespan');
+      expect(inRangeTimespan.times).toEqual({ start: 0, end: 150 });
+      expect(inRangeTimespan.canvasDuration).toEqual(660);
+      expect(inRangeTimespan.isClickable).toBeTruthy();
+
+      const outOfRangeTimespan = timespans[1];
+      expect(outOfRangeTimespan.label).toEqual('Out of Range Timespan');
+      expect(outOfRangeTimespan.times).toEqual({ start: 670, end: 700 });
+      expect(outOfRangeTimespan.canvasDuration).toEqual(660);
+      expect(outOfRangeTimespan.isClickable).toBeFalsy();
     });
 
     it('return empty structures and timespans when behavior is set to thumbnail-nav', () => {

--- a/src/test_data/out-of-range-structure.js
+++ b/src/test_data/out-of-range-structure.js
@@ -1,0 +1,61 @@
+export default {
+  '@context': 'http://iiif.io/api/presentation/3/context.json',
+  id: 'http://example.com/out-of-range-structure/manifest.json',
+  type: 'Manifest',
+  label: { en: ['Out of Range Structure'] },
+  items: [
+    {
+      id: 'http://example.com/out-of-range-structure/canvas/1',
+      type: 'Canvas', width: 480, height: 360, duration: 660,
+      items: [
+        {
+          id: 'http://example.com/out-of-range-structure/canvas/1/annotation_page/1',
+          type: 'AnnotationPage',
+          items: [
+            {
+              id: 'http://example.com/out-of-range-structure/canvas/1/annotation_page/1/annotation/1',
+              type: 'Annotation',
+              motivation: 'painting',
+              target: 'http://example.com/out-of-range-structure/canvas/1',
+              body: {
+                id: 'http://example.com/out-of-range-structure/low.mp4',
+                type: 'Video', format: 'video/mp4', width: 480, height: 360, duration: 660,
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  structures: [
+    {
+      type: 'Range',
+      id: 'http://example.com/out-of-range-structure/range/1',
+      label: { en: ['Out of Range Structure'] },
+      items: [
+        {
+          type: 'Range',
+          id: 'http://example.com/out-of-range-structure/range/2',
+          label: { en: ['In Range Timespan'] },
+          items: [
+            {
+              type: 'Canvas',
+              id: 'http://example.com/out-of-range-structure/canvas/1#t=0,150'
+            }
+          ]
+        },
+        {
+          type: 'Range',
+          id: 'http://example.com/out-of-range-structure/range/3',
+          label: { en: ['Out of Range Timespan'] },
+          items: [
+            {
+              type: 'Canvas',
+              id: 'http://example.com/out-of-range-structure/canvas/1#t=670,700'
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};


### PR DESCRIPTION
Related issue: #999 

Changes in this PR:
- Display out-of-range timespans as plain text with an accessible tooltip
- Use `tab-index` to include the plain text timespan to the page's tab-order so that, it can be included in the keyboard navigation within `StructuredNavigation` component using roving tabindex strategy
- Bug fix: move focus to the last interactive structure item in the `StructuredNavigation` component on `ArrowUp` key-press after initial focus on the component

<img width="469" height="290" alt="Screenshot 2026-08-26 at 2 04 22 PM" src="https://github.com/user-attachments/assets/7b3820bc-d071-4c82-bfc4-7d4e47b4c0d2" />


**Note**: use the `'ramp--structured-nav__item-link'` class for the out-of-range timespan elements displayed using `<span>` HTML element with the addition of `'not-clickable'` class. This helps to keep their appearances consistent with the other timespans created with `<a>` HTML elements. Changing this class name at this point could break styling for current applications.