### PR TITLE
Support display of waveform for each Annotation in multi-src Canvases

### DIFF
--- a/src/components/MediaPlayer/MediaPlayer.js
+++ b/src/components/MediaPlayer/MediaPlayer.js
@@ -216,7 +216,7 @@ const MediaPlayer = ({
           videoJSNextButton: isMultiCanvased &&
             { canvasIndex, lastCanvasIndex, switchPlayer },
           videoJSTrackScrubber: (hasStructure || isPlaylist) &&
-            { trackScrubberRef, timeToolRef, isPlaylist },
+            { trackScrubberRef, timeToolRef, isPlaylist, nextItemClicked },
           videoJSADButton: (audioDescTracks.length > 0) && { audioDescTracks }
         },
         /* Only pass along the sources with access in VideoJS options. Allow both 'authorized' and

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -84,7 +84,6 @@ function VideoJSPlayer({
     allCanvases,
     canvasDuration,
     canvasLink,
-    customStart,
     hasMultiItems,
     manifest,
     targets,
@@ -120,11 +119,11 @@ function VideoJSPlayer({
   const { canvasIndex, canvasIsEmpty, isMultiCanvased, lastCanvasIndex, resetPlayerContainer } = useMediaPlayer();
   const authService = allCanvases[canvasIndex]?.authService ?? null;
 
-  const { isPlaylist, renderingFiles, srcIndex, switchPlayer }
+  const { isPlaylist, nextItemClicked, renderingFiles, srcIndex, switchPlayer }
     = useSetupPlayer({ enableFileDownload, withCredentials, lastCanvasIndex });
   const { messageTime } = useShowInaccessibleMessage({ lastCanvasIndex });
 
-  const { hasWaveform } = useWaveform({ savedPosition, showWaveform, waveformRef });
+  const { hasWaveform } = useWaveform({ nextItemClicked, savedPosition, showWaveform, waveformRef });
 
   const canvasIsEmptyRef = useRef();
   canvasIsEmptyRef.current = useMemo(() => { return canvasIsEmpty; }, [canvasIsEmpty]);
@@ -205,6 +204,15 @@ function VideoJSPlayer({
         options.headers['Authorization'] = `Bearer ${activeToken}`;
         return options;
       });
+    });
+
+    /* VHS can re-report an individual source's duration via a 'durationchange' event
+    after the initial play/seek events. This silently over-writes the Canvas duration
+    set by Ramp. This is especially required for multi-source Canvases. */
+    player.on('durationchange', () => {
+      if (canvasDurationRef.current && player.duration() !== canvasDurationRef.current) {
+        player.duration(canvasDurationRef.current);
+      }
     });
 
     player.on('ready', function () {
@@ -861,7 +869,7 @@ function VideoJSPlayer({
         // Add track-scrubber button after duration display if it is not available
         controlBar.addChild(
           'videoJSTrackScrubber',
-          { trackScrubberRef, timeToolRef: scrubberTooltipRef },
+          { trackScrubberRef, timeToolRef: scrubberTooltipRef, nextItemClicked },
           volumeIndex + 1
         );
       }

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -206,15 +206,6 @@ function VideoJSPlayer({
       });
     });
 
-    /* VHS can re-report an individual source's duration via a 'durationchange' event
-    after the initial play/seek events. This silently over-writes the Canvas duration
-    set by Ramp. This is especially required for multi-source Canvases. */
-    player.on('durationchange', () => {
-      if (canvasDurationRef.current && player.duration() !== canvasDurationRef.current) {
-        player.duration(canvasDurationRef.current);
-      }
-    });
-
     player.on('ready', function () {
       console.log('Player ready');
 

--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.test.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.test.js
@@ -2,13 +2,14 @@ import React from 'react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { ErrorBoundary } from 'react-error-boundary';
 import MediaPlayer from '@Components/MediaPlayer/MediaPlayer';
-import { withManifestAndPlayerProvider, manifestState } from '@Services/testing-helpers';
+import { buildWaveformBinary, manifestState, withManifestAndPlayerProvider } from '@Services/testing-helpers';
 import * as authService from '@Services/auth-service';
 import videoManifest from '@TestData/lunchroom-manners';
 import playlistManifest from '@TestData/playlist';
 import singleCanvasManifest from '@TestData/single-canvas';
 import authManifest from '@TestData/auth-manifest';
 import waveformManifest from '@TestData/waveform-example';
+import multiSourceManifest from '@TestData/multi-source-manifest';
 
 // Mock 'requestLogout' from auth-service module
 jest.mock('@Services/auth-service', () => ({
@@ -700,7 +701,7 @@ describe('VideoJSPlayer component', () => {
     const resumeModalRef = { current: document.createElement('div') };
     const props = { resumeModalRef, waveformRef };
 
-    const mockWaveformFetch = () => {
+    const mockWaveformJSONFetch = () => {
       jest.spyOn(global, 'fetch').mockImplementation(() => {
         return Promise.resolve({
           ok: true,
@@ -710,6 +711,17 @@ describe('VideoJSPlayer component', () => {
           }),
         });
       });
+    };
+
+    const mockWaveformBinFetch = () => {
+      jest.spyOn(global, 'fetch').mockImplementation(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          headers: { 'Content-Type': 'application/octet-stream' },
+          arrayBuffer: () => Promise.resolve(buildWaveformBinary([0, 10, -5, 8]))
+        })
+      );
     };
 
     describe('doesn\'t add waveform toggle button or panel', () => {
@@ -818,7 +830,7 @@ describe('VideoJSPlayer component', () => {
     });
 
     test('toggles waveform panel visibility', async () => {
-      mockWaveformFetch();
+      mockWaveformJSONFetch();
       await renderPlayer({
         manifest: waveformManifest, canvasIndex: 0,
         props: { ...props, showWaveform: true },
@@ -837,7 +849,7 @@ describe('VideoJSPlayer component', () => {
 
     describe('on page load', () => {
       test('shows the panel for an audio Canvas without a saved playback position', async () => {
-        mockWaveformFetch();
+        mockWaveformBinFetch();
 
         await renderPlayer({
           manifest: waveformManifest, canvasIndex: 2,
@@ -850,7 +862,7 @@ describe('VideoJSPlayer component', () => {
       });
 
       test('hides the panel for an audio Canvas with a saved playback position', async () => {
-        mockWaveformFetch();
+        mockWaveformJSONFetch();
         localStorage.setItem(
           'playbackPositions',
           JSON.stringify([{
@@ -873,7 +885,7 @@ describe('VideoJSPlayer component', () => {
       });
 
       test('hides the panel for a video Canvas regardless of saved playback position', async () => {
-        mockWaveformFetch();
+        mockWaveformJSONFetch();
         localStorage.setItem(
           'playbackPositions',
           JSON.stringify([{
@@ -894,6 +906,109 @@ describe('VideoJSPlayer component', () => {
         await screen.findByTestId('videojs-waveform-button');
         const panel = screen.getByTestId('videojs-waveform-panel');
         expect(panel).toHaveClass('hidden');
+      });
+    });
+  });
+
+  describe('feature: track scrubber', () => {
+    /* Simulates the pointer click event at a given pixel offset on the track scrubber's progress
+    bar, which then invokes the VideoJSTrackScrubber component's 'handleSetProgress()' function.
+    Each time the track scrubber's width is set to the corresponding track's duration to keep the
+    pixel:second ratio 1:1 for easier calculation. */
+    const clickTrackScrubberAt = (scrubber, offsetX, clientWidth = 7278.422) => {
+      act(() => {
+        scrubber.handleSetProgress({ offsetX, target: { clientWidth } });
+      });
+    };
+
+    let currentTimeSpy, nextItemClickedSpy;
+    const renderPlayerWithScrubber = async (manifest) => {
+      await renderPlayer({
+        manifest, canvasIndex: 0, manifestOverrides: { structures: { hasStructure: true } }
+      });
+      const player = await triggerLoadedMetadata('videojs-video-element');
+      const scrubber = player.controlBar.getChild('videoJSTrackScrubber');
+      act(() => { scrubber.handleTimeUpdate(); });
+
+      currentTimeSpy = jest.spyOn(player, 'currentTime');
+      nextItemClickedSpy = jest.fn();
+      scrubber.options.nextItemClicked = nextItemClickedSpy;
+
+      return { player, scrubber };
+    };
+
+    describe('with a single-source (regular) Canvas', () => {
+      test('seeks the player to a calculated time for the first track starting at zero', async () => {
+        const { scrubber } = await renderPlayerWithScrubber(singleCanvasManifest);
+        clickTrackScrubberAt(scrubber, 300.34);
+
+        expect(nextItemClickedSpy).not.toHaveBeenCalled();
+        expect(currentTimeSpy).toHaveBeenCalledWith(300.34);
+      });
+
+      test('seeks the player to a calculated time relative to the offset of the current track', async () => {
+        const { scrubber } = await renderPlayerWithScrubber(singleCanvasManifest);
+
+        /* Set a track with a non-zero start time as the current track to test offset time calculation
+        in progress handling. e.g. the second timespan in the example test Manifest which spans from
+        302.05s to 3971.24s */
+        const trackDuration = 3971.24 - 302.05;
+        act(() => {
+          scrubber.setCurrentTrack({
+            time: 302.05, duration: trackDuration, text: 'Remainder of Atto Primo',
+            key: 'http://example.com/single-canvas-manifest/range/4'
+          });
+        });
+
+        /* Click at the same relative position (300.34s) as before within the track scrubber. Since
+        the active track now starts at 302.05s, the resulting player time is offset by that track's start. */
+        act(() => {
+          clickTrackScrubberAt(scrubber, 300.34, trackDuration);
+        });
+
+        expect(nextItemClickedSpy).not.toHaveBeenCalled();
+        expect(currentTimeSpy).toHaveBeenCalledWith(300.34 + 302.05);
+      });
+
+      test('displays the track scrubber for the Canvas duration when playhead is outside of defined timespans', async () => {
+        const { scrubber } = await renderPlayerWithScrubber(singleCanvasManifest);
+
+        /* Set the 'Complete media file' track as the current track. e.g. after the last timespan in
+        the example test Manifest which ends at 7000.422s with a Canvas duration of 7278.422s. */
+        act(() => {
+          scrubber.setCurrentTrack({
+            time: 0, duration: 7278.422, text: 'Complete media file', key: ''
+          });
+        });
+
+        // Click at 7139.422s that is between 7000.422s and 7278.422s gap
+        clickTrackScrubberAt(scrubber, 7139.422);
+
+        expect(nextItemClickedSpy).not.toHaveBeenCalled();
+        expect(currentTimeSpy).toHaveBeenCalledWith(7139.422);
+      });
+    });
+
+    describe('with a multi-source Canvas', () => {
+      test('seeks the player without switching source when clicked within the range of the current source', async () => {
+        const { scrubber } = await renderPlayerWithScrubber(multiSourceManifest);
+        // Click at <50% of the full 7278.422s Canvas => 2534.34s that falls within the current source in Canvas
+        clickTrackScrubberAt(scrubber, 2534.34);
+
+        expect(nextItemClickedSpy).not.toHaveBeenCalled();
+        expect(currentTimeSpy).toHaveBeenCalledWith(2534.34);
+      });
+
+      test('switches the player source when clicked outside of the range of the current source', async () => {
+        const { scrubber } = await renderPlayerWithScrubber(multiSourceManifest);
+
+        // Click at >50% of the full 7278.422s Canvas => 4352.34s that falls in the second source in Canvas
+        clickTrackScrubberAt(scrubber, 4352.34);
+
+        // Switches to second source, offset 381.1s into that source (4352.34 - 3971.24 = 381.1s)
+        expect(nextItemClickedSpy).toHaveBeenCalledWith(1, 381.1);
+        // Seeks to the offset 381.1s within the second source
+        expect(currentTimeSpy).toHaveBeenCalledWith(381.1);
       });
     });
   });

--- a/src/components/MediaPlayer/VideoJS/components/js/VideoJSTrackScrubber.js
+++ b/src/components/MediaPlayer/VideoJS/components/js/VideoJSTrackScrubber.js
@@ -302,7 +302,7 @@ class VideoJSTrackScrubber extends Button {
 
     /* Add the currentTrack's time (start time) to the track offset, as this is the Canvas
     relative time for the trackoffset derived from the pointer event. */
-    const offsetTime = trackoffset + currentTrackRef.current?.time ?? 0;
+    const offsetTime = trackoffset + (currentTrackRef.current?.time ?? 0);
 
     // Find the source corresponding to the pointer click event
     const clickedTarget = targets?.length > 1

--- a/src/components/MediaPlayer/VideoJS/components/js/VideoJSTrackScrubber.js
+++ b/src/components/MediaPlayer/VideoJS/components/js/VideoJSTrackScrubber.js
@@ -2,7 +2,7 @@ import { createRef } from 'react';
 import videojs from 'video.js';
 import '../styles/VideoJSTrackScrubber.scss';
 import '../styles/VideoJSProgress.scss';
-import { timeToHHmmss } from '@Services/utility-helpers';
+import { roundToPrecision, timeToHHmmss } from '@Services/utility-helpers';
 import { svgIconToSymbol, TrackScrubberZoomInIcon, TrackScrubberZoomOutIcon } from '@Services/svg-icons';
 
 // Function to inject SVGs into the DOM
@@ -214,10 +214,11 @@ class VideoJSTrackScrubber extends Button {
     }
 
     const { altStart, srcIndex } = player;
-    // Calculate corresponding time and played percentage values within track
-    let trackoffset = srcIndex > 0
-      ? currentTime - currentTrackRef.current.time + altStart
-      : currentTime - currentTrackRef.current.time;
+    // Calculate corresponding Canvas relative time and played percentage values within track
+    const offsetTime = currentTime - currentTrackRef.current.time;
+    /* For multi-source items, add the current source's altStart to the Canvas
+    relative time to get the source relative time. */
+    let trackoffset = srcIndex > 0 ? offsetTime + altStart : offsetTime;
     let trackpercent = Math.min(
       100,
       Math.max(0, 100 * trackoffset / currentTrackRef.current.duration)
@@ -284,16 +285,39 @@ class VideoJSTrackScrubber extends Button {
    * Event handler for mousedown event on the track scrubber. This sets the
    * progress percentage within track scrubber and update the player's current time
    * when user clicks on a point within the track scrubber.
+   * For a multi-source Canvas, a click past the currently loaded source's duration needs to
+   * switch the source in the VideoJS player instance before loading any corresponding active
+   * tracks into the panel.
    * @param {Event} e pointer event for user interaction
    */
   handleSetProgress(e) {
-    const { currentTrackRef, player } = this;
-    if (!currentTrackRef.current) {
+    const { currentTrackRef, player, options } = this;
+    if (!currentTrackRef.current || !player) {
       return;
     }
+
+    const { altStart, srcIndex, targets } = player;
+
     let trackoffset = this.getTrackTime(e);
 
-    if (trackoffset != undefined) {
+    /* Add the currentTrack's time (start time) to the track offset, as this is the Canvas
+    relative time for the trackoffset derived from the pointer event. */
+    const offsetTime = trackoffset + currentTrackRef.current?.time ?? 0;
+
+    // Find the source corresponding to the pointer click event
+    const clickedTarget = targets?.length > 1
+      ? targets.find((t) => offsetTime >= t.altStart && offsetTime <= t.altStart + t.duration)
+      : undefined;
+
+    /* When clicked past the currently loaded source, switch the source in the main VideoJS instance.
+    This corresponds to the use-case where entire duration of the current player instance is portrayed
+    in the track scrubber. i.e. when a time range not included in the structures is loaded in the
+    player while the track scrubber is open. */
+    if (clickedTarget && clickedTarget.sIndex !== srcIndex) {
+      const playerCurrentTime = roundToPrecision(offsetTime - clickedTarget.altStart);
+      options.nextItemClicked?.(clickedTarget.sIndex, playerCurrentTime);
+      player.currentTime(playerCurrentTime);
+    } else if (trackoffset != undefined) {
       // Calculate percentage of the progress based on the pointer position's
       // time and duration of the track
       let trackpercent = Math.min(
@@ -303,16 +327,10 @@ class VideoJSTrackScrubber extends Button {
 
       this.setTrackScrubberValue(trackpercent, trackoffset);
 
-      /**
-       * Only add the currentTrack's start time for a single source items as this is
-       * the offset of the time displayed in the track scrubber.
-       * For multi-source items; the start time for the currentTrack is the offset of
-       * the duration displayed in the main progress-bar, which translates to 0 in the
-       * track-scrubber display
-       */
-      const playerCurrentTime = player?.srcIndex > 0
-        ? trackoffset
-        : trackoffset + currentTrackRef.current.time;
+      /* For multi-source Canvases, substract the current source's altStart from the Canvas
+      relative time to get the source relative time. This is the inverse of the conversion
+      done in updateTrackScrubberProgressBar(). */
+      const playerCurrentTime = offsetTime - (srcIndex > 0 ? altStart : 0);
       player.currentTime(playerCurrentTime);
     }
   };

--- a/src/components/MediaPlayer/VideoJS/components/js/VideoJSWaveform.js
+++ b/src/components/MediaPlayer/VideoJS/components/js/VideoJSWaveform.js
@@ -25,8 +25,8 @@ const Button = videojs.getComponent('Button');
  * @param {Object} props
  * @param {Object} props.player VideoJS player instance
  * @param {Object} props.options
- * @param {Boolean} props.options.hasSavedPosition the current Manifest has a saved
- * playback position in localStorage
+ * @param {Boolean} props.options.hasSavedPosition has a saved playback position in localStorage
+ * @param {Function} props.nextItemClicked callback function to switch sources from waveform panel
  * @param {Object} props.options.waveformRef React ref to the waveform panel element
  */
 class VideoJSWaveform extends Button {
@@ -280,19 +280,41 @@ class VideoJSWaveform extends Button {
   }
 
   /**
+   * Get the Canvas-relative duration and altStart for the currently active
+   * source in a Canvas.
+   * @returns {Object} { duration, altStart }
+   */
+  getAltStart() {
+    const { player } = this;
+    if (!player) return;
+
+    const { playableDuration, srcIndex, targets } = player;
+
+    const duration = playableDuration ?? player.duration();
+    if (targets?.length > 1) {
+      const { altStart } = targets[srcIndex] ?? {};
+      return { duration, altStart: altStart ?? 0 };
+    }
+
+    return { duration, altStart: 0 };
+  }
+
+  /**
    * Event handler for VideoJS player instance's 'timeupdate' event, which
    * updates the played progress in the waveform canvas from player state.
    */
   handleTimeUpdate() {
     const { player, hiddenRef } = this;
+    if (!player) return;
+
     // Hide waveform toggle for inaccessible item if it is open
     if (player.canvasIsEmpty && !hiddenRef.current) { this.setHidden(true); }
     if (player.isDisposed() || player.ended()) return;
 
-    const duration = player.playableDuration ?? player.duration();
+    const { duration, altStart } = this.getAltStart();
     if (!duration) return;
 
-    let playerCurrentTime = player.currentTime();
+    const playerCurrentTime = altStart + player.currentTime();
     const played = Math.min(100, Math.max(0, 100 * (playerCurrentTime / duration)));
     document.documentElement.style.setProperty('--range-progress', `calc(${played}%)`);
   }
@@ -301,18 +323,33 @@ class VideoJSWaveform extends Button {
    * Event handler for pointerdown/pointerup events on the waveform panel.
    * This updates the player's current time when user clicks on a point
    * within the panel.
+   * In a multi-source Canvas, the pointer event can correspond to a different
+   * source than the currently loaded one. In that case, the function resolves
+   * the pointer event to identify the corresponding source and instruct the main
+   * VideoJS instance to switch sources via 'nextItemClicked' callback function.
    * @param {Event} e pointer event for user interaction
    */
   handleSetProgress(e) {
-    const { player } = this;
-    const duration = player.playableDuration ?? player.duration();
-    if (!duration) return;
+    const { player, options } = this;
+    const { duration, altStart } = this.getAltStart();
+    if (!duration || !player) return;
 
     const offsetx = e.offsetX;
     if (offsetx == undefined || !e.target.clientWidth) return;
 
-    const time = (offsetx / e.target.clientWidth) * duration;
-    player.currentTime(time);
+    const canvasTime = (offsetx / e.target.clientWidth) * duration;
+
+    const { srcIndex, targets } = player;
+    if (targets?.length > 1) {
+      const clickedSrc = targets.find(
+        (t) => canvasTime >= t.altStart && canvasTime <= t.altStart + t.duration
+      );
+      if (clickedSrc && clickedSrc.sIndex !== srcIndex) {
+        const { altStart, sIndex } = clickedSrc;
+        options.nextItemClicked?.(sIndex, canvasTime - altStart);
+      }
+    }
+    player.currentTime(canvasTime - altStart);
   }
 }
 

--- a/src/components/MediaPlayer/VideoJS/videojs-theme.scss
+++ b/src/components/MediaPlayer/VideoJS/videojs-theme.scss
@@ -98,11 +98,13 @@
 
 /* Remove padding around time-divider (/) */
 .vjs-theme-ramp .vjs-time-divider {
+  min-width: 0;
   padding: 0;
+  display: block;
 }
 
 .vjs-theme-ramp .vjs-duration {
-  padding-left: 0;
+  display: block !important;
 }
 
 /* Volume controls */

--- a/src/services/hooks/useWaveform.js
+++ b/src/services/hooks/useWaveform.js
@@ -6,24 +6,29 @@ import { PlayerStateContext } from '../../context/player-context';
 import { IS_MOBILE } from '@Services/browser';
 
 /**
- * Fetch/parse the current Canvas's waveform resource if it exists, and pass the results to the
+ * Fetch/parse the current Canvas's waveform resource(s) if they exist, and pass the results to the
  * player instance for the VideoJSWaveform component to render.
+ * When a given Canvas is multi-sourced, waveforms from each resource are combined into a single
+ * continuous waveform spanning the entire duration of the Canvas.
  * @param {Object} obj
+ * @param {Function} obj.nextItemClicked callback function to switch source when using waveform panel
  * @param {Object} obj.savedPosition resumable saved playback position in the current Manifest
  * @param {Boolean} obj.showWaveform whether to show the waveform toggle button in the control bar
  * @param {Object} obj.waveformRef React ref to the VideoJSWaveform component
  * @returns { hasWaveform }
  */
-export const useWaveform = ({ savedPosition, showWaveform, waveformRef }) => {
+export const useWaveform = ({ nextItemClicked, savedPosition, showWaveform, waveformRef }) => {
   const { player } = useContext(PlayerStateContext);
   const { canvasIndex, allCanvases } = useContext(ManifestStateContext);
   const manifestDispatch = useContext(ManifestDispatchContext);
 
+  const waveformResources = allCanvases[canvasIndex]?.waveform ?? [];
+
   const hasWaveform = useMemo(() => {
-    return allCanvases[canvasIndex]?.waveform != null && showWaveform;
+    return waveformResources.length > 0 && showWaveform;
   }, [allCanvases, canvasIndex]);
 
-  async function fetchWaveformData(waveform, signal) {
+  async function fetchSingleWaveform(waveform, signal) {
     const { id, format, waveformType } = waveform ?? {};
     if (!id || !waveformType) return null;
 
@@ -39,17 +44,42 @@ export const useWaveform = ({ savedPosition, showWaveform, waveformRef }) => {
       return { type: 'peaks', data };
     } catch (error) {
       if (error.name === 'AbortError') return null;
-      console.error('useWaveform -> fetchWaveformData() -> failed to fetch/parse waveform data, ', error);
+      console.error('useWaveform -> fetchSingleWaveform() -> failed to fetch/parse waveform data, ', error);
       return null;
     }
+  }
+
+  /**
+   * Fetch all given waveform resource(s) for the current Canvas and concatenate the peaks data
+   * into a single continuous 'WaveformData' instance. Waveform resources that are failed to
+   * fetch/parse are skipped. Falls back to image waveform when no peaks data is available.
+   */
+  async function fetchWaveformData(resources, signal) {
+    const results = await Promise.all(resources.map((resource) => fetchSingleWaveform(resource, signal)));
+    if (signal.aborted) return null;
+
+    const peaks = results.filter((r) => r?.type === 'peaks').map((r) => r.data);
+    if (peaks.length > 0) {
+      try {
+        const [first, ...rest] = peaks;
+        const data = rest.length > 0 ? first.concat(...rest) : first;
+        return { type: 'peaks', data };
+      } catch (error) {
+        console.error('useWaveform -> fetchWaveformData() -> failed to concatenate waveform data, ', error);
+        return { type: 'peaks', data: peaks[0] };
+      }
+    }
+
+    // Fallback to look for a single image waveform resource
+    const image = results.find((r) => r?.type === 'image');
+    return image ?? null;
   }
 
   useEffect(() => {
     // Do nothing if either player is null or showWaveform is set to false
     if (!player || !showWaveform) return;
 
-    const waveformResource = allCanvases[canvasIndex]?.waveform;
-    if (!waveformResource) {
+    if (waveformResources.length === 0) {
       player.waveform = null;
       player.trigger('waveformupdated');
       manifestDispatch({ type: 'setWaveform', waveform: { data: null, isLoading: false, error: null } });
@@ -61,7 +91,7 @@ export const useWaveform = ({ savedPosition, showWaveform, waveformRef }) => {
     // Rest waveform data in state before fetching again
     manifestDispatch({ type: 'setWaveform', waveform: { data: null, isLoading: true, error: null } });
 
-    fetchWaveformData(waveformResource, controller.signal).then((result) => {
+    fetchWaveformData(waveformResources, controller.signal).then((result) => {
       if (controller.signal.aborted) return;
       player.waveform = result;
       player.trigger('waveformupdated');
@@ -93,7 +123,10 @@ export const useWaveform = ({ savedPosition, showWaveform, waveformRef }) => {
       const volumeIndex = IS_MOBILE
         ? controlBar.children().findIndex((c) => c.name_ == 'MuteToggle')
         : controlBar.children().findIndex((c) => c.name_ == 'VolumePanel');
-      controlBar.addChild('videoJSWaveform', { waveformRef, hasSavedPosition }, volumeIndex + 1);
+      controlBar.addChild(
+        'videoJSWaveform',
+        { waveformRef, hasSavedPosition, nextItemClicked },
+        volumeIndex + 1);
     }
   };
 

--- a/src/services/hooks/useWaveform.test.js
+++ b/src/services/hooks/useWaveform.test.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { render, waitFor } from '@testing-library/react';
 import { useWaveform } from './useWaveform';
-import { withManifestAndPlayerProvider, manifestState } from '@Services/testing-helpers';
+import { buildWaveformBinary, manifestState, withManifestAndPlayerProvider } from '@Services/testing-helpers';
 import waveformManifest from '@TestData/waveform-example';
 
 describe('useWaveform', () => {
@@ -223,6 +223,94 @@ describe('useWaveform', () => {
 
       await waitFor(() => {
         expect(fetchSpy).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    describe('for a multi-source Canvas', () => {
+      const JSON_URL = 'https://example.com/waveform-side-1.json';
+      const DAT_URL = 'https://example.com/waveform-side-2.dat';
+
+      test('is fetched for each source and combined into a single continuous waveform', async () => {
+        const fetchSpy = jest.spyOn(global, 'fetch').mockImplementation((url) => {
+          if (url === JSON_URL) {
+            return Promise.resolve({
+              ok: true,
+              // Set max_sample to 10 in this content
+              json: jest.fn().mockResolvedValue({
+                version: 2, channels: 1, sample_rate: 44100, samples_per_pixel: 512,
+                bits: 8, length: 1, data: [0, 10],
+              }),
+            });
+          }
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            headers: { 'Content-Type': 'application/octet-stream' },
+            // Set min_sample to -5 in this content
+            arrayBuffer: () => Promise.resolve(buildWaveformBinary([-5, 8])),
+          });
+        });
+        const CustomComponent = withManifestAndPlayerProvider(renderHook({}), {
+          initialManifestState: { ...manifestState(waveformManifest, 7) },
+          initialPlayerState: { player },
+        });
+        render(<CustomComponent />);
+
+        await waitFor(() => {
+          expect(player._controlBar.getChild('videoJSWaveform')).toBeDefined();
+        });
+        expect(fetchSpy).toHaveBeenCalledWith(JSON_URL, expect.anything());
+        expect(fetchSpy).toHaveBeenCalledWith(DAT_URL, expect.anything());
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+        expect(player.waveform.type).toBe('peaks');
+        expect(player.waveform.data.length).toBe(2);
+        expect(player.waveform.data.channel(0).min_sample(0)).toBe(0);
+        expect(player.waveform.data.channel(0).min_sample(1)).toBe(-5);
+      });
+
+      test('is fetched while skipping failed waveform resource request(s)', async () => {
+        const fetchSpy = jest.spyOn(global, 'fetch').mockImplementation((url) => {
+          if (url === JSON_URL) {
+            return Promise.resolve({
+              ok: true,
+              json: jest.fn().mockResolvedValue({
+                version: 2, channels: 1, sample_rate: 44100, samples_per_pixel: 512,
+                bits: 8, length: 1, data: [0, 10],
+              }),
+            });
+          }
+          return Promise.reject(new Error('Network error'));
+        });
+        const CustomComponent = withManifestAndPlayerProvider(renderHook({}), {
+          initialManifestState: { ...manifestState(waveformManifest, 7) },
+          initialPlayerState: { player },
+        });
+        render(<CustomComponent />);
+
+        await waitFor(() => {
+          expect(player._controlBar.getChild('videoJSWaveform')).toBeDefined();
+        });
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+        expect(player.waveform.type).toBe('peaks');
+        expect(player.waveform.data.length).toBe(1);
+      });
+
+      test('is failed to fetch; waveform toggle is not displayed', async () => {
+        const fetchSpy = jest.spyOn(global, 'fetch').mockImplementation((url) => {
+          return Promise.reject(new Error('Network error'));
+        });
+        const CustomComponent = withManifestAndPlayerProvider(renderHook({}), {
+          initialManifestState: { ...manifestState(waveformManifest, 7) },
+          initialPlayerState: { player },
+        });
+        render(<CustomComponent />);
+
+        await waitFor(() => {
+          expect(player._controlBar.getChild('videoJSWaveform')).not.toBeDefined();
+        });
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+        expect(player.waveform).toBeNull();
       });
     });
   });

--- a/src/services/iiif-parser.js
+++ b/src/services/iiif-parser.js
@@ -4,6 +4,7 @@ import {
   checkSrcRange,
   GENERIC_EMPTY_MANIFEST_MESSAGE,
   GENERIC_ERROR_MESSAGE,
+  getAnnotations,
   getLabelValue,
   getMediaFragment,
   getWaveformType,
@@ -804,23 +805,20 @@ export function getAuthService(canvas) {
 }
 
 /**
- * Read and parse waveform resource in a Canvas. Since waveform can be presented
- * as both a dataset or an image it can be represented in the Canvas via both
- * 'seeAlso' and 'accompanyingCanvas' properties.
- * 1. 'seeAlso' - e.g. Avalon's JSON dataset, British Library's binary dataset
- * 2. 'accompanyingCanvas' - e.g. Internet Archive's pre-rendered waveform PNG
- * If both are available waveform datasets are given priority because it allows the panel
- * to render player progress.
- * @function IIIFParser#getWaveformResource
- * @param {Object} canvas current Canvas to look for waveform data in
- * @param {Number} version Presentation API version of the Manifest
+ * Read and parse a 'seeAlso' waveform dataset off of a given IIIF resource.
+ * The given IIIF resource can be either a Canvas or a 'painting' Annotation
+ * in a Canvas.
+ * This function treats a value as a waveform if it has only machine-readable
+ * datasets. Images are disregarded.
+ * @function IIIFParser#getSeeAlsoWaveform
+ * @param {Object} resource Canvas or Annotation carrying a 'seeAlso' property
  * @returns {Object}
  */
-export function getWaveformResource(canvas, version = '3') {
-  const waveformDatasets = [].concat(canvas?.seeAlso ?? [])
-    .map((resource) => ({
-      resource,
-      ...getWaveformType(resource?.format, resource?.id),
+function getSeeAlsoWaveform(resource) {
+  const waveformDatasets = [].concat(resource?.seeAlso ?? [])
+    .map((r) => ({
+      resource: r,
+      ...getWaveformType(r?.format, r?.id),
     }))
     .filter(({ waveformType }) => waveformType !== null);
 
@@ -831,6 +829,41 @@ export function getWaveformResource(canvas, version = '3') {
       waveformType: 'data', source: 'seeAlso',
     };
   }
+  return null;
+}
+
+/**
+ * Read and parse waveform resource(s) in a Canvas. Since waveform can be presented
+ * as both a dataset or an image it can be represented in the Canvas via both
+ * 'seeAlso' and 'accompanyingCanvas' properties.
+ * 1. 'seeAlso' - e.g. Avalon's JSON dataset, British Library's binary dataset
+ * 2. 'accompanyingCanvas'/'accompanyingContainer' - e.g. Internet Archive's pre-rendered waveform PNG
+ * Waveform resource is parsed in the following priority order;
+ * - read 'seeAlso' values at each Annotation in the given Canvas (most granular) if available
+ * - read 'seeAlso' values from Canvas if available (binary datasets)
+ * - fallback to check 'accompanyingCanvas'/'accompanyingContainer' property (images) in Canvas
+ * With this approach, if both datasets and images are available as a waveform; datasets
+ * are given priority, because it facilitate a pixel rendering of data.
+ * @function IIIFParser#getWaveformResource
+ * @param {Object} canvas current Canvas to look for waveform data in
+ * @param {Number} version Presentation API version of the Manifest
+ * @returns {Array}
+ */
+export function getWaveformResource(canvas, version = '3') {
+  // Read 'seeAlso' values at each Annotation in the Canvas
+  if (canvas?.items?.[0]?.items?.length > 1) {
+    const paintingAnnotations = getAnnotations(canvas, '', version)
+      .filter((a) => hasMotivation(a?.motivation, 'painting'));
+    if (paintingAnnotations.length > 1) {
+      return paintingAnnotations
+        .map((annotation) => getSeeAlsoWaveform(annotation))
+        .filter((waveform) => waveform !== null);
+    }
+  }
+
+  // Read 'seeAlso' values in the Canvas
+  const waveformData = getSeeAlsoWaveform(canvas);
+  if (waveformData) return [waveformData];
 
   /* Fallback to accompanyingCanvas/accompanyingContainer resource. Only treat this as a
   waveform image when its label says so because, the 'accompanyingCanvas' can carry
@@ -838,13 +871,13 @@ export function getWaveformResource(canvas, version = '3') {
   const waveformImage = getAccompanyingResource(canvas, version);
   const labledAsWaveform = getLabelValue(waveformImage?.label).toLowerCase().includes('waveform');
   if (waveformImage?.type === 'Image' && waveformImage?.id && labledAsWaveform) {
-    return {
+    return [{
       id: waveformImage.id, format: waveformImage.format,
       waveformType: 'image', source: 'accompanyingCanvas'
-    };
+    }];
   }
 
-  return null;
+  return [];
 }
 
 /**

--- a/src/services/iiif-parser.test.js
+++ b/src/services/iiif-parser.test.js
@@ -12,8 +12,10 @@ import audiannotateTest from '@TestData/audiannotate-test';
 import adManifest from '@TestData/ad-annotation';
 import authManifest from '@TestData/auth-manifest';
 import outOfRangeManifest from '@TestData/out-of-range-structure';
+import waveformManifestRaw from '@TestData/waveform-example';
 import * as iiifParser from './iiif-parser';
 import * as util from './utility-helpers';
+import cloneDeep from 'lodash/cloneDeep';
 
 describe('iiif-parser', () => {
   describe('canvasesInManifest()', () => {
@@ -133,9 +135,9 @@ describe('iiif-parser', () => {
     });
 
     describe('returns waveform information', () => {
-      test('returns null for waveform by default', () => {
+      test('returns an empty array for waveform by default', () => {
         const canvases = iiifParser.canvasesInManifest(lunchroomManifest);
-        expect(canvases[0].waveform).toBeNull();
+        expect(canvases[0].waveform).toEqual([]);
       });
 
       test('returns waveform from both "seeAlso" and "accompanyingCanvas" props', () => {
@@ -167,13 +169,13 @@ describe('iiif-parser', () => {
           ],
         };
         const canvases = iiifParser.canvasesInManifest(manifestWithWaveforms);
-        expect(canvases[0].waveform).toEqual({
-          id: 'http://example.com/waveform-1.json', format: 'application/json', waveformType: 'data', source: 'seeAlso',
-        });
-        expect(canvases[1].waveform).toBeNull();
-        expect(canvases[2].waveform).toEqual({
-          id: 'http://example.com/waveform-3.png', format: 'image/jpeg', waveformType: 'image', source: 'accompanyingCanvas',
-        });
+        expect(canvases[0].waveform).toEqual([
+          { id: 'http://example.com/waveform-1.json', format: 'application/json', waveformType: 'data', source: 'seeAlso' },
+        ]);
+        expect(canvases[1].waveform).toEqual([]);
+        expect(canvases[2].waveform).toEqual([
+          { id: 'http://example.com/waveform-3.png', format: 'image/jpeg', waveformType: 'image', source: 'accompanyingCanvas' },
+        ]);
       });
     });
   });
@@ -1214,30 +1216,27 @@ describe('iiif-parser', () => {
   });
 
   describe('getWaveformResource()', () => {
-    const canvas = {
-      duration: 1094.977, height: 1080, width: 1920, service: [], thumbnail: [], type: "Canvas", items: [],
-      id: "http://example.com/manifest/canvas/1", label: { en: ['Canvas'] },
-      placeholderCanvas: { type: "Canvas", id: "http://example.com/manifest/canvas/1/placeholder", width: 1280, height: 720 },
-    };
-    test('returns null when Canvas is empty', () => {
-      expect(iiifParser.getWaveformResource({})).toBeNull();
+    let waveformManifest;
+    beforeEach(() => {
+      // Reset the waveform data before each test
+      waveformManifest = cloneDeep(waveformManifestRaw);
     });
 
-    test('returns null when Canvas doesn\'t have both "seeAlso" and "accompanyingCanvas"', () => {
-      expect(iiifParser.getWaveformResource(canvas)).toBeNull();
+    test('returns an empty array when Canvas is empty', () => {
+      expect(iiifParser.getWaveformResource({})).toEqual([]);
+    });
+
+    test('returns an empty array when Canvas doesn\'t have both "seeAlso" and "accompanyingCanvas"', () => {
+      expect(iiifParser.getWaveformResource(lunchroomManifest.items[0])).toEqual([]);
     });
 
     describe('when "seeAlso"', () => {
-      test('doesn\'t include a recognized waveform format returns null', () => {
-        expect(iiifParser.getWaveformResource({
-          ...canvas,
-          seeAlso: [{ id: 'http://example.com/structure.xml', type: 'Dataset', format: 'application/xml' }],
-        })).toBeNull();
+      test('doesn\'t include a recognized waveform format returns an empty array', () => {
+        expect(iiifParser.getWaveformResource(waveformManifest.items[3])).toEqual([]);
       });
 
       test('has a .dat resource returns waveformType: "data" ', () => {
-        const seeAlso = [{ id: 'http://example.com/waveform.dat', type: 'Dataset', format: 'application/octet-stream' }];
-        const waveform = iiifParser.getWaveformResource({ ...canvas, seeAlso });
+        const [waveform] = iiifParser.getWaveformResource(waveformManifest.items[2]);
         expect(waveform.waveformType).toBe('data');
         expect(waveform.id).toBe('http://example.com/waveform.dat');
         expect(waveform.source).toBe('seeAlso');
@@ -1245,25 +1244,19 @@ describe('iiif-parser', () => {
       });
 
       test('has a .json resource returns waveformType: "data"', () => {
-        const seeAlso = [{ id: 'http://example.com/waveform.json', type: 'Dataset', format: 'application/json' }];
-        const waveform = iiifParser.getWaveformResource({ ...canvas, seeAlso });
+        const [waveform] = iiifParser.getWaveformResource(waveformManifest.items[0]);
         expect(waveform.waveformType).toBe('data');
         expect(waveform.source).toBe('seeAlso');
         expect(waveform.id).toBe('http://example.com/waveform.json');
         expect(waveform.format).toBe('application/json');
       });
 
-      test('has a .png resource returns null', () => {
-        const seeAlso = [{ id: 'https://example.com/waveform.png', type: 'Image', format: 'image/png' }];
-        expect(iiifParser.getWaveformResource({ ...canvas, seeAlso })).toBeNull();
+      test('has a .png resource returns an empty array', () => {
+        expect(iiifParser.getWaveformResource(waveformManifest.items[5])).toEqual([]);
       });
 
       test('has both dataset and image resources binary dataset takes precendence', () => {
-        const seeAlso = [
-          { id: 'http://example.com/waveform.png', type: 'Image', format: 'image/png' },
-          { id: 'http://example.com/waveform.json', type: 'Dataset', format: 'application/json' },
-        ];
-        const waveform = iiifParser.getWaveformResource({ ...canvas, seeAlso });
+        const [waveform] = iiifParser.getWaveformResource(waveformManifest.items[6]);
         expect(waveform.waveformType).toBe('data');
         expect(waveform.id).toBe('http://example.com/waveform.json');
       });
@@ -1271,8 +1264,9 @@ describe('iiif-parser', () => {
 
     describe('resolves type using resource id extension when format is absent for', () => {
       test('a seeAlso resource', () => {
-        const seeAlso = [{ id: 'http://example.com/waveform.dat', type: 'Dataset' }];
-        const waveform = iiifParser.getWaveformResource({ ...canvas, seeAlso });
+        const canvas = waveformManifest.items[0];
+        canvas.seeAlso = [{ id: 'http://example.com/waveform.dat', type: 'Dataset' }];
+        const [waveform] = iiifParser.getWaveformResource(canvas);
         expect(waveform.waveformType).toBe('data');
         expect(waveform.source).toBe('seeAlso');
         expect(waveform.id).toBe('http://example.com/waveform.dat');
@@ -1280,18 +1274,11 @@ describe('iiif-parser', () => {
       });
 
       test('an accompanyingCanvas resource', () => {
-        const accompanyingCanvas = {
-          type: 'Canvas',
-          label: { en: ['Waveform'] },
-          items: [{
-            type: 'AnnotationPage',
-            items: [{
-              type: 'Annotation', motivation: 'painting',
-              body: { id: 'http://example.com/waveform.png', type: 'Image' },
-            }],
-          }],
+        const canvas = waveformManifest.items[1];
+        canvas.accompanyingCanvas.items[0].items[0].body = {
+          id: 'http://example.com/waveform.png', type: 'Image', height: 200, width: 800
         };
-        const waveform = iiifParser.getWaveformResource({ ...canvas, accompanyingCanvas });
+        const [waveform] = iiifParser.getWaveformResource(canvas);
         expect(waveform.waveformType).toBe('image');
         expect(waveform.source).toBe('accompanyingCanvas');
         expect(waveform.id).toBe('http://example.com/waveform.png');
@@ -1301,61 +1288,53 @@ describe('iiif-parser', () => {
 
     describe('when "accompanyingCanvas"', () => {
       test('has a waveform image returns waveformType: "image"', () => {
-        const accompanyingCanvas = {
-          type: 'Canvas', label: { en: ['Waveform data as an image'] },
-          items: [{
-            type: 'AnnotationPage',
-            items: [{
-              type: 'Annotation', motivation: 'painting',
-              body: {
-                id: 'http://example.com/waveform.png',
-                type: 'Image', format: 'image/jpeg',
-              },
-            }],
-          }],
-        };
-        const waveform = iiifParser.getWaveformResource({ ...canvas, accompanyingCanvas });
+        const [waveform] = iiifParser.getWaveformResource(waveformManifest.items[1]);
         expect(waveform.waveformType).toBe('image');
-        expect(waveform.id).toBe('http://example.com/waveform.png');
+        expect(waveform.id).toBe('http://example.com/waveform.jpg');
         expect(waveform.format).toBe('image/jpeg');
         expect(waveform.source).toBe('accompanyingCanvas');
       });
 
-      test('doesn\'t have text "waveform" in its label returns null', () => {
-        const accompanyingCanvas = {
-          type: 'Canvas',
-          label: { en: ['Poster frame'] },
-          items: [{
-            type: 'AnnotationPage',
-            items: [{
-              type: 'Annotation', motivation: 'painting',
-              body: { id: 'http://example.com/poster.png', type: 'Image', format: 'image/png' },
-            }],
-          }],
-        };
-        expect(iiifParser.getWaveformResource({ ...canvas, accompanyingCanvas })).toBeNull();
+      test('doesn\'t have text "waveform" in its label returns an empty array', () => {
+        const canvas = waveformManifest.items[1];
+        canvas.accompanyingCanvas.label = { en: ["Poster Image"] };
+        expect(iiifParser.getWaveformResource(canvas)).toEqual([]);
       });
     });
 
     test('"seeAlso" takes precendence over "accompanyingCanvas" when both are present', () => {
-      const waveformRes = {
-        seeAlso: [{ id: 'http://example.com/waveform.json', type: 'Dataset', format: 'application/json' }],
-        accompanyingCanvas: {
-          label: { en: ['Waveform as an image'] },
-          items: [{ items: [{ body: { id: 'http://example.com/waveform.png', type: 'Image', format: 'image/png' } }] }],
-        },
-      };
-      const waveform = iiifParser.getWaveformResource({ ...canvas, ...waveformRes });
+      const [waveform] = iiifParser.getWaveformResource(waveformManifest.items[4]);
       expect(waveform.waveformType).toBe('data');
       expect(waveform.source).toBe('seeAlso');
     });
 
-    test('returns null when "accompanyingCanvas" is not an image with text "waveform" in label', () => {
-      const accompanyingCanvas = {
+    test('returns an empty array when "accompanyingCanvas" is not an image with text "waveform" in label', () => {
+      const canvas = waveformManifest.items[1];
+      canvas.accompanyingCanvas = {
+        id: "http://example.com/waveform-example/canvas/2/accompanying",
         label: { en: ['WebVTT not a waveform'] },
         items: [{ items: [{ body: { id: 'https://example.com/text.vtt', type: 'Text' } }] }]
       };
-      expect(iiifParser.getWaveformResource({ ...canvas, accompanyingCanvas })).toBeNull();
+      expect(iiifParser.getWaveformResource(canvas)).toEqual([]);
+    });
+
+    describe('for a multi-source Canvas', () => {
+      test('returns an array of waveform resources for each Annotation in-order from their "seeAlso" properties', () => {
+        const waveform = iiifParser.getWaveformResource(waveformManifest.items[7]);
+        expect(Array.isArray(waveform)).toBe(true);
+        expect(waveform).toHaveLength(2);
+        expect(waveform[0]).toEqual(expect.objectContaining({
+          id: 'https://example.com/waveform-side-1.json', waveformType: 'data', source: 'seeAlso', format: 'application/json'
+        }));
+        expect(waveform[1]).toEqual(expect.objectContaining({
+          id: 'https://example.com/waveform-side-2.dat', waveformType: 'data', source: 'seeAlso', format: 'application/octet-stream'
+        }));
+      });
+
+      test('omits invalid "seeAlso" waveform format in a source', () => {
+        const waveform = iiifParser.getWaveformResource(waveformManifest.items[7]);
+        expect(waveform).toHaveLength(2);
+      });
     });
   });
 });

--- a/src/services/testing-helpers.js
+++ b/src/services/testing-helpers.js
@@ -50,5 +50,21 @@ export function manifestState(manifest, canvasIndex = 0, isPlaylist = false) {
     renderings: getRenderingFiles(manifest),
     annotations: [],
     auth: { token: null, status: 'idle' },
+    srcIndex: 0,
   };
+};
+
+// Build a minimal valid 'audiowaveform' binary buffer dataset
+export const buildWaveformBinary = (samples) => {
+  const headerSize = 24;
+  const buffer = new ArrayBuffer(headerSize + samples.length);
+  const view = new DataView(buffer);
+  view.setInt32(0, 2, true);
+  view.setUint32(4, 1, true);
+  view.setInt32(8, 44100, true);
+  view.setInt32(12, 512, true);
+  view.setUint32(16, samples.length / 2, true);
+  view.setInt32(20, 1, true);
+  new Int8Array(buffer, headerSize).set(samples);
+  return buffer;
 };

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -84,17 +84,10 @@
 /* time-control elements */
 .video-js .vjs-time-control,
 .video-js .vjs-time-control .vjs-duration {
+  box-sizing: content-box;
   min-width: 0.5rem;
   padding: 0 0.25rem;
-  width: auto !important;
-}
-
-.vjs-time-divider {
-  display: block;
-}
-
-.vjs-duration {
-  display: block !important;
+  width: fit-content !important;
 }
 
 .vjs-playback-rate-value {

--- a/src/test_data/single-canvas.js
+++ b/src/test_data/single-canvas.js
@@ -103,7 +103,7 @@ export default {
           items: [
             {
               type: "Canvas",
-              id: "http://example.com/single-canvas-manifest/canvas/1#t=3971.24"
+              id: "http://example.com/single-canvas-manifest/canvas/1#t=3971.24,7000.422"
             }
           ]
         }

--- a/src/test_data/waveform-example.js
+++ b/src/test_data/waveform-example.js
@@ -3,20 +3,13 @@ export default {
   id: "http://example.com/waveform-example/manifest.json",
   type: "Manifest",
   label: {
-    it: [
-      "L'Elisir D'Amore"
-    ],
-    en: [
-      "The Elixir of Love"
-    ]
+    it: ["L'Elisir D'Amore"],
+    en: ["The Elixir of Love"]
   },
   items: [
     {
       id: "http://example.com/waveform-example/canvas/1",
-      type: "Canvas",
-      width: 1920,
-      height: 1080,
-      duration: 7278.422,
+      type: "Canvas", width: 1920, height: 1080, duration: 7278.422,
       items: [
         {
           id: "http://example.com/waveform-example/canvas/1/annotation_page/1",
@@ -24,16 +17,10 @@ export default {
           items: [
             {
               id: "http://example.com/waveform-example/canvas/1/annotation_page/1/annotation/1",
-              type: "Annotation",
-              motivation: "painting",
-              target: "http://example.com/waveform-example/canvas/1",
+              type: "Annotation", motivation: "painting", target: "http://example.com/waveform-example/canvas/1",
               body: {
                 id: "http://example.com/donizetti-elixir/low.mp4",
-                type: "Video",
-                format: "video/mp4",
-                height: 1080,
-                width: 1920,
-                duration: 7278.422
+                type: "Video", format: "video/mp4", height: 1080, width: 1920, duration: 7278.422
               }
             }
           ]
@@ -41,19 +28,14 @@ export default {
       ],
       seeAlso: [
         {
-          type: "Dataset",
-          format: "application/json",
-          id: "http://example.com/waveform.json",
+          type: "Dataset", format: "application/json", id: "http://example.com/waveform.json",
           label: { en: ["waveform.json"] }
         }
       ]
     },
     {
       id: 'https://example.com/waveform-example/canvas/2',
-      type: 'Canvas',
-      height: 1080,
-      width: 1920,
-      duration: 7278.422,
+      type: 'Canvas', height: 1080, width: 1920, duration: 7278.422,
       items: [
         {
           id: 'https://example.com/waveform-example/canvas/2/page/1',
@@ -61,19 +43,13 @@ export default {
           items: [
             {
               id: 'https://example.com/waveform-example/canvas/2/page/1/annotation/1',
-              type: 'Annotation',
-              motivation: 'painting',
+              type: 'Annotation', motivation: 'painting', target: 'https://example.com/waveform-example/canvas/2',
               body: {
                 id: "https://example.com/high/media.mp4",
-                type: "Video",
-                format: "video/mp4",
-                height: 1080,
-                width: 1920,
-                duration: 7278.422
-              },
-              target: 'https://example.com/waveform-example/canvas/2',
-            },
-          ],
+                type: "Video", format: "video/mp4", height: 1080, width: 1920, duration: 7278.422
+              }
+            }
+          ]
         }
       ],
       accompanyingCanvas: {
@@ -82,22 +58,19 @@ export default {
         items: [
           {
             id: "http://example.com/waveform-example/canvas/2/accompanying/page",
+            type: "AnnotationPage",
             items: [
               {
-                body: {
-                  format: "image/jpeg", height: 200, width: 800,
-                  id: "http://example.com/waveform.jpg", type: "Image"
-                },
                 id: "http://example.com/waveform-example/canvas/2/accompanying/page/annotation",
-                motivation: "painting",
-                target: "http://example.com/waveform-example/canvas/2/accompanying",
-                type: "Annotation"
+                motivation: "painting", type: "Annotation", target: "http://example.com/waveform-example/canvas/2/accompanying",
+                body: {
+                  format: "image/jpeg", height: 200, width: 800, id: "http://example.com/waveform.jpg", type: "Image"
+                }
               }
-            ],
-            "type": "AnnotationPage"
+            ]
           }
-        ],
-      },
+        ]
+      }
     },
     {
       id: "http://example.com/waveform-example/canvas/3",
@@ -110,14 +83,10 @@ export default {
           items: [
             {
               id: "http://example.com/waveform-example/canvas/3/annotation_page/1/annotation/1",
-              type: "Annotation",
-              motivation: "painting",
-              target: "http://example.com/waveform-example/canvas/3",
+              type: "Annotation", motivation: "painting", target: "http://example.com/waveform-example/canvas/3",
               body: {
                 id: "http://example.com/waveform-example/audio.mp3",
-                type: "Sound",
-                format: "audio/mp3",
-                duration: 300.0
+                type: "Sound", format: "audio/mp3", duration: 300.0
               }
             }
           ]
@@ -125,17 +94,14 @@ export default {
       ],
       seeAlso: [
         {
-          type: "Dataset",
-          format: "application/json",
-          id: "http://example.com/waveform.json",
-          label: { en: ["waveform.json"] }
+          type: "Dataset", format: "application/octet-stream", id: "http://example.com/waveform.dat",
+          label: { en: ["waveform.dat"] }
         }
       ]
     },
     {
       id: "http://example.com/waveform-example/canvas/4",
-      type: "Canvas",
-      duration: 300.0,
+      type: "Canvas", duration: 300.0,
       items: [
         {
           id: "http://example.com/waveform-example/canvas/4/annotation_page/1",
@@ -143,14 +109,10 @@ export default {
           items: [
             {
               id: "http://example.com/waveform-example/canvas/4/annotation_page/1/annotation/1",
-              type: "Annotation",
-              motivation: "painting",
-              target: "http://example.com/waveform-example/canvas/4",
+              type: "Annotation", motivation: "painting", target: "http://example.com/waveform-example/canvas/4",
               body: {
                 id: "http://example.com/waveform-example/audio.mp3",
-                type: "Sound",
-                format: "audio/mp3",
-                duration: 300.0
+                type: "Sound", format: "audio/mp3", duration: 300.0
               }
             }
           ]
@@ -158,10 +120,140 @@ export default {
       ],
       seeAlso: [
         {
-          type: "Dataset",
-          format: "text/xml",
-          id: "http://example.com/waveform.xml",
+          type: "Dataset", format: "text/xml", id: "http://example.com/waveform.xml",
           label: { en: ["not a waveform"] }
+        }
+      ]
+    },
+    {
+      id: "http://example.com/waveform-example/canvas/5",
+      type: "Canvas", duration: 300.0,
+      items: [
+        {
+          id: "http://example.com/waveform-example/canvas/5/annotation_page/1",
+          type: "AnnotationPage",
+          items: [
+            {
+              id: "http://example.com/waveform-example/canvas/5/annotation_page/1/annotation/1",
+              type: "Annotation", motivation: "painting", target: "http://example.com/waveform-example/canvas/5",
+              body: {
+                id: "http://example.com/waveform-example/audio.mp3",
+                type: "Sound", format: "audio/mp3", duration: 300.0
+              }
+            }
+          ]
+        }
+      ],
+      seeAlso: [
+        {
+          type: "Dataset", format: "application/json", id: "http://example.com/waveform.json",
+          label: { en: ["waveform.json"] }
+        }
+      ],
+      accompanyingCanvas: {
+        height: 200, width: 800, type: "Canvas", label: { en: ["Waveform"] },
+        id: "http://example.com/waveform-example/canvas/5/accompanying",
+        items: [
+          {
+            id: "http://example.com/waveform-example/canvas/5/accompanying/page",
+            type: "AnnotationPage",
+            items: [
+              {
+                body: {
+                  format: "image/jpeg", height: 200, width: 800,
+                  id: "http://example.com/waveform.jpg", type: "Image"
+                },
+                id: "http://example.com/waveform-example/canvas/5/accompanying/page/annotation",
+                motivation: "painting", type: "Annotation", target: "http://example.com/waveform-example/canvas/5/accompanying"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      id: 'https://example.com/waveform-example/canvas/6',
+      type: 'Canvas', height: 1080, width: 1920, duration: 7278.422,
+      items: [
+        {
+          id: 'https://example.com/waveform-example/canvas/6/page/1',
+          type: 'AnnotationPage',
+          items: [
+            {
+              id: 'https://example.com/waveform-example/canvas/6/page/1/annotation/1',
+              type: 'Annotation', motivation: 'painting', target: 'https://example.com/waveform-example/canvas/6',
+              body: {
+                id: "https://example.com/high/media.mp4",
+                type: "Video", format: "video/mp4", height: 1080, width: 1920, duration: 7278.422
+              }
+            },
+          ],
+        }
+      ],
+      seeAlso: [
+        {
+          type: "Image", format: "image/png", id: "http://example.com/waveform.png",
+          label: { en: ["waveform.png"] }
+        }
+      ]
+    },
+    {
+      id: 'https://example.com/waveform-example/canvas/7',
+      type: 'Canvas', height: 1080, width: 1920, duration: 7278.422,
+      items: [
+        {
+          id: 'https://example.com/waveform-example/canvas/7/page/1',
+          type: 'AnnotationPage',
+          items: [
+            {
+              id: 'https://example.com/waveform-example/canvas/7/page/1/annotation/1',
+              type: 'Annotation', motivation: 'painting', target: 'https://example.com/waveform-example/canvas/7',
+              body: {
+                id: "https://example.com/high/media.mp4",
+                type: "Video", format: "video/mp4", height: 1080, width: 1920, duration: 7278.422
+              }
+            },
+          ],
+        }
+      ],
+      seeAlso: [
+        {
+          type: "Image", format: "image/png", id: "http://example.com/waveform.png",
+          label: { en: ["waveform.png"] }
+        },
+        {
+          type: "Dataset", format: "application/json", id: "http://example.com/waveform.json",
+          label: { en: ["waveform.json"] }
+        }
+      ]
+    },
+    {
+      id: 'https://example.com/waveform-example/canvas/8',
+      type: 'Canvas', height: 40, width: 1280, duration: 550.32,
+      items: [
+        {
+          id: 'https://example.com/waveform-example/canvas/8/page/1',
+          type: 'AnnotationPage',
+          items: [
+            {
+              type: 'Annotation', motivation: 'painting', id: "https://example.com/waveform-example/canvas/8/page/1/annotation/1",
+              target: 'https://example.com/waveform-example/canvas/8#t=0,100',
+              body: { id: 'https://example.com/side-1.mp3', type: 'Sound', height: 40, width: 1280, duration: 100 },
+              seeAlso: [{ id: 'https://example.com/waveform-side-1.json', type: 'Dataset', format: 'application/json' }],
+            },
+            {
+              type: 'Annotation', motivation: 'painting', id: "https://example.com/waveform-example/canvas/8/page/1/annotation/2",
+              target: 'https://example.com/waveform-example/canvas/8#t=100,300',
+              body: { id: 'https://example.com/side-2.mp3', type: 'Sound', height: 40, width: 1280, duration: 200 },
+              seeAlso: [{ id: 'https://example.com/waveform-side-2.dat', type: 'Dataset', format: 'application/octet-stream' }],
+            },
+            {
+              type: 'Annotation', motivation: 'painting', id: "https://example.com/waveform-example/canvas/8/page/1/annotation/3",
+              target: 'https://example.com/waveform-example/canvas/8#t=300',
+              body: { id: 'https://example.com/side-2.mp3', type: 'Sound', height: 40, width: 1280, duration: 250.32 },
+              seeAlso: [{ id: 'https://example.com/waveform-side-3.png', type: 'Image', format: 'image/png' }],
+            }
+          ],
         }
       ]
     }


### PR DESCRIPTION
Related issue: #1008 

Changes in this PR:
- Parse waveform resources at each Annotation level in a Canvas for multi-source Canvases
- Combine dataset waveforms at each Annotation and display a contiguous waveform for the entire Canvas in the waveform panel
- Bug fixes;
  - Fix track-scrubber's handling of multi-source Canvases. The relevant use-case: when a timespan finishes playing while the track-scrubber panel is open it displays the entire Canvas duration in the track-scrubber. The track-scrubber needs to convey the source changes to VideoJS instance when the user seeks past the boundaries of the current source in the track-scrubber's progress-bar.