### PR TITLE
Fix playhead and duration updates for multi-source switch

### DIFF
--- a/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJS/VideoJSPlayer.js
@@ -207,6 +207,15 @@ function VideoJSPlayer({
       });
     });
 
+    /* VHS can re-report an individual source's duration via a 'durationchange' event
+    after the initial play/seek events. This silently over-writes the Canvas duration
+    set by Ramp. This is especially required for multi-source Canvases. */
+    player.on('durationchange', () => {
+      if (canvasDurationRef.current && player.duration() !== canvasDurationRef.current) {
+        player.duration(canvasDurationRef.current);
+      }
+    });
+
     player.on('ready', function () {
       console.log('Player ready');
 

--- a/src/components/MediaPlayer/VideoJS/components/js/VideoJSProgress.js
+++ b/src/components/MediaPlayer/VideoJS/components/js/VideoJSProgress.js
@@ -129,6 +129,26 @@ class CustomSeekBar extends SeekBar {
         '--range-progress', `calc(${0}%)`
       );
     }
+
+    /* The super.update() call relies on VideoJS's native getPercent() in VideoJS's
+    '/control-bar/progress-control/seek-bar.js', which uses player.duration() for the
+    calculation.
+    For multi-source Canvases in Firefox this player.duration() comes up with an incorrect
+    time due a split-second difference in the event progressions. This pushes the playhead
+    towards the end of the player's progress-bar.
+    Since super.update() defers the update to the next repaint using 'requestAnimationFrame'
+    in the browser. Re-use that call for this specific method to correct it by cancelling
+    and replacing the pending native write instead of running before it and getting
+    overwritten a frame later. */
+    if (this.isMultiSourceRef.current && this.totalDuration > 0) {
+      // Recompute width using the total duration of sources in the Canvas
+      const width = Math.min(100,
+        Math.max(0, 100 * (this.player.currentTime() / this.totalDuration))
+      );
+      this.requestNamedAnimationFrame('Slider#update', () => {
+        this.playProgress.el_.style.width = `${width}%`;
+      });
+    }
   }
 
   // Create progress bar using Video.js' SeekBar component


### PR DESCRIPTION
Reported issues:

When a multi-source Canvas is loaded into the player and seeking slightly past the currently loaded source's boundary; the following incorrect behavior is observed;
- duration: the player's duration changes to the current source's duration
- playhead position: jumps to the end of the progress-bar which doesn't accurately depict the user interaction

Fixes in this PR:
- Update the player's duration to the Canvas duration (total duration of all Annotations) on the `durationchange` which is re-reported by VideoJS's VHS on source change for multi-source Canvases. Previously this event overwrote the Canvas duration set in Ramp on this source change
- Fix the playhead position by intervening VideoJS's native progress-control method `getPercent()` which calculates and updates the progress percentage with respect to the player's duration. Due to a slight delay in frames, this function uses the current source's duration instead of the Canvas duration (total of all sources in the Canvas) for this calculation. And this led to the playhead jumping towards the end of the progress-bar instead of staying-in its correct position (the user's mouse position) with respect to the Canvas duration