### PR TITLE
Integrate 'provides' prop values to decide display of Annotations

### DIFF
--- a/public/manifests/dev/lunchroom-manners-v4.json
+++ b/public/manifests/dev/lunchroom-manners-v4.json
@@ -111,6 +111,7 @@
 								"supplementing"
 							],
 							"provides": [
+								"audioDescription",
 								"subtitles"
 							],
 							"body": {

--- a/src/services/annotation-parser.test.js
+++ b/src/services/annotation-parser.test.js
@@ -759,6 +759,121 @@ const highlightingAnnotationWithCaptions = {
   ]
 };
 
+// IIIF Presentation v4 Manifest with 'provides' property in 'supplementing' Annotations
+const providesAnnotations = {
+  '@context': 'http://iiif.io/api/presentation/4/context.json',
+  id: 'https://example.com/provides-annotations/manifest.json',
+  type: 'Manifest',
+  label: { 'en': ['Supplementing Annotations with Provides'] },
+  items: [
+    {
+      id: 'https://example.com/provides-annotations/canvas/1',
+      type: 'Timeline',
+      duration: 3400.0,
+      annotations: [
+        {
+          type: 'AnnotationPage',
+          id: 'https://example.com/provides-annotations/canvas/1/annotation-page/1',
+          items: [
+            {
+              id: 'https://example.com/provides-annotations/canvas/1/annotation-page/1/annotation/1',
+              type: 'Annotation', motivation: ['supplementing'], provides: ['transcript', 'audioDescription'],
+              body: {
+                id: 'https://example.com/provides-annotations/lunchroom_manners/supplemental/1/transcripts',
+                type: 'Text', format: 'text/vtt', label: { en: ['Transcript in WebVTT format'] }, language: 'en',
+              },
+              target: { id: "https://example.com/provides-annotations/canvas/1", type: "Timeline" }
+            },
+            {
+              id: 'https://example.com/provides-annotations/canvas/1/annotation-page/1/annotation/2',
+              type: 'Annotation', motivation: ['supplementing'], provides: ['audioDescription'],
+              body: {
+                id: 'https://example.com/provides-annotations/lunchroom_manners/supplemental/2/captions',
+                type: 'Text', format: 'text/vtt', label: { en: ['AD in WebVTT format'] }, language: 'en',
+              },
+              target: { id: "https://example.com/provides-annotations/canvas/1", type: "Timeline" }
+            },
+            {
+              id: 'https://example.com/provides-annotations/canvas/1/annotation-page/1/annotation/3',
+              type: 'Annotation', motivation: ['supplementing'], provides: ['transcript', 'closedCaptions'],
+              body: {
+                id: 'https://example.com/provides-annotations/lunchroom_manners/supplemental/3/captions',
+                type: 'Text', format: 'text/vtt', label: { en: ['Captions in WebVTT format'] }, language: 'en',
+              },
+              target: { id: "https://example.com/provides-annotations/canvas/1", type: "Timeline" }
+            },
+          ]
+        }
+      ],
+      items: [
+        {
+          id: "https://example.com/provides-annotations/canvas/1/page",
+          type: "AnnotationPage",
+          items: [
+            {
+              id: "https://example.com/provides-annotations/canvas/1/page/annotation",
+              type: "Annotation", motivation: ["painting"],
+              body: {
+                id: "https://example.com/provides-annotations/mahler-symphony.mp3",
+                type: "Sound", format: "audio/mp3", duration: 3400
+              },
+              target: { id: "https://example.com/provides-annotations/canvas/1", type: "Timeline" }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      id: 'https://example.com/provides-annotations/canvas/2',
+      type: 'Timeline',
+      duration: 3400.0,
+      annotations: [
+        {
+          type: 'AnnotationPage',
+          id: 'https://example.com/provides-annotations/canvas/2/annotation-page/1',
+          items: [
+            {
+              id: 'https://example.com/provides-annotations/canvas/2/annotation-page/1/annotation/1',
+              type: 'Annotation', motivation: ['supplementing'], provides: ['transcript'],
+              body: {
+                id: 'https://example.com/provides-annotations/lunchroom_manners/supplemental/1/transcripts',
+                type: 'Text', format: 'text/vtt', label: { en: ['Transcript in WebVTT format'] }, language: 'en',
+              },
+              target: { id: "https://example.com/provides-annotations/canvas/2", type: "Timeline" }
+            },
+            {
+              id: 'https://example.com/provides-annotations/canvas/2/annotation-page/1/annotation/3',
+              type: 'Annotation', motivation: ['supplementing'], provides: ['closedCaptions'],
+              body: {
+                id: 'https://example.com/provides-annotations/lunchroom_manners/supplemental/3/captions',
+                type: 'Text', format: 'text/vtt', label: { en: ['Captions in WebVTT format'] }, language: 'en',
+              },
+              target: { id: "https://example.com/provides-annotations/canvas/2", type: "Timeline" }
+            },
+          ]
+        }
+      ],
+      items: [
+        {
+          id: "https://example.com/provides-annotations/canvas/2/page",
+          type: "AnnotationPage",
+          items: [
+            {
+              id: "https://example.com/provides-annotations/canvas/2/page/annotation",
+              type: "Annotation", motivation: ["painting"],
+              body: {
+                id: "https://example.com/provides-annotations/mahler-symphony.mp3",
+                type: "Sound", format: "audio/mp3", duration: 3400
+              },
+              target: { id: "https://example.com/provides-annotations/canvas/2", type: "Timeline" }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+
 describe('annotation-parser', () => {
   describe('parseAnnotationSets()', () => {
     test('returns null when canvasIndex is undefined', () => {
@@ -973,6 +1088,45 @@ describe('annotation-parser', () => {
           canvasId: 'https://example.com/linked-mixed-annotations/canvas-1/canvas/1',
           value: 'Test Marker 2',
         });
+      });
+    });
+
+    describe('parses "supplementing" Annotations with "provides" property', () => {
+      test('returns an annotationSet for each Annotation item', () => {
+        const { canvasIndex, annotationSets } = annotationParser.parseAnnotationSets(providesAnnotations, 0);
+        expect(canvasIndex).toEqual(0);
+        expect(annotationSets.length).toEqual(3);
+
+        expect(annotationSets[0].label).toEqual('Transcript in WebVTT format');
+        expect(annotationSets[1].label).toEqual('AD in WebVTT format');
+        expect(annotationSets[2].label).toEqual('Captions in WebVTT format');
+      });
+
+      test('returns an annotationSet when "provides" has both "transcript" and "closedCaptions" values', () => {
+        const { canvasIndex, annotationSets } = annotationParser.parseAnnotationSets(providesAnnotations, 0);
+        expect(canvasIndex).toEqual(0);
+        expect(annotationSets.length).toEqual(3);
+
+        expect(annotationSets[2].label).toEqual('Captions in WebVTT format');
+      });
+
+      test('returns only one annotationSet when "provides" value has both "transcript" and "audioDescriotion"', () => {
+        const { canvasIndex, annotationSets } = annotationParser.parseAnnotationSets(providesAnnotations, 0);
+        expect(canvasIndex).toEqual(0);
+        expect(annotationSets.length).toEqual(3);
+
+        // Only one annotationSet is labeled "Transcript in WebVTT format"
+        expect(annotationSets[0].label).toEqual('Transcript in WebVTT format');
+        expect(annotationSets[1].label).toEqual('AD in WebVTT format');
+        expect(annotationSets[2].label).toEqual('Captions in WebVTT format');
+      });
+
+      test('does not return an annotationSet for Annotation with "provides" value "closedCaptions"', () => {
+        const { canvasIndex, annotationSets } = annotationParser.parseAnnotationSets(providesAnnotations, 1);
+        expect(canvasIndex).toEqual(1);
+        expect(annotationSets.length).toEqual(1);
+
+        expect(annotationSets[0].label).toEqual('Transcript in WebVTT format');
       });
     });
   });

--- a/src/services/annotations-parser.js
+++ b/src/services/annotations-parser.js
@@ -4,9 +4,10 @@ import {
   getLabelValue, getMediaFragment, handleFetchErrors,
   identifySupplementingAnnotation,
   parseTimeStrings, sortAnnotations,
-  timeToHHmmss
+  timeToHHmmss,
+  S_ANNOTATION_TYPE
 } from "./utility-helpers";
-import { hasMotivation, normalizeMotivation } from "./iiif-version-parser";
+import { hasMotivation, normalizeValues } from "./iiif-version-parser";
 
 // Global variable to store random tag colors for the current tags
 let TAG_COLORS = [];
@@ -137,11 +138,12 @@ function parseAnnotationPages(annotationPages, duration, manifestLabel = '') {
           annotationPage.items.map((item) => {
             // Parse linked resources as a single annotation set
             if (isExternalAnnotation(item.body)) {
-              const { body, id, motivation, target } = item;
-              const annotationMotivation = normalizeMotivation(motivation);
+              const { body, id, motivation, provides, target } = item;
+              const annotationMotivation = normalizeValues(motivation);
+              const annotationProvides = normalizeValues(provides);
               // Only add WebVTT, SRT, and JSON files as annotations
               const timeSynced = TIME_SYNCED_FORMATS.includes(body.format);
-              const annotationInfo = parseAnnotationBody(body, annotationMotivation)[0];
+              const annotationInfo = parseAnnotationBody(body, annotationMotivation, annotationProvides)[0];
               if (annotationInfo != undefined) {
                 annotationSets.push({
                   ...annotationInfo,
@@ -236,13 +238,14 @@ export function parseAnnotationItem(annotation, duration) {
     canvasId = source.id;
     times = parseSelector(selector, duration);
   }
-  const motivations = normalizeMotivation(annotation.motivation);
+  const motivations = normalizeValues(annotation.motivation);
+  const provides = normalizeValues(annotation.provides);
   const item = {
     motivation: motivations,
     id: annotation.id,
     time: times,
     canvasId,
-    value: parseAnnotationBody(annotation.body, motivations),
+    value: parseAnnotationBody(annotation.body, motivations, provides),
   };
   return item;
 };
@@ -327,8 +330,9 @@ function parseTextualBody(textualBody, motivations) {
  * @function parseAnnotationBody
  * @param {Array || Object} annotationBody body property of an Annotation
  * @param {Array} motivations motivation(s) of Annotation/AnnotationPage
+ * @param {Array} provides 'provides' value of the Annotation
  */
-function parseAnnotationBody(annotationBody, motivations) {
+function parseAnnotationBody(annotationBody, motivations, provides = []) {
   if (!Array.isArray(annotationBody)) {
     annotationBody = [annotationBody];
   }
@@ -343,7 +347,7 @@ function parseAnnotationBody(annotationBody, motivations) {
       case 'Text':
         const { format, id, label } = body;
         // Skip linked annotations that are captions in Avalon manifests
-        let sType = identifySupplementingAnnotation(id);
+        let sType = identifySupplementingAnnotation(id, provides);
         // Default to derive filename from URL
         let filename = id.split('/').pop();
         let parsedLabel = filename ? filename.split('.')[0] : '';
@@ -353,7 +357,8 @@ function parseAnnotationBody(annotationBody, motivations) {
           // Assume that an unassigned language is meant to be the downloadable filename
           filename = label.hasOwnProperty('none') ? getLabelValue(label.none[0]) : parsedLabel;
         }
-        if (sType !== 2) {
+        // Add a 'supplementing' Annotation categorized as either a 'transcript' or 'audioDescription' only once
+        if ([S_ANNOTATION_TYPE.transcript, S_ANNOTATION_TYPE.audioDescription].some(t => sType.includes(t))) {
           values.push({
             format: format,
             label: parsedLabel,

--- a/src/services/iiif-parser.test.js
+++ b/src/services/iiif-parser.test.js
@@ -182,12 +182,17 @@ describe('iiif-parser', () => {
   });
 
   describe('getMediaInfo()', () => {
+    let originalError;
     beforeEach(() => {
       // Mock canPlayType to always return 'maybe' (truthy value)
       HTMLMediaElement.prototype.canPlayType = jest.fn(() => 'maybe');
+      // Mock console.error function
+      originalError = console.error;
+      console.error = jest.fn();
     });
     afterEach(() => {
       jest.restoreAllMocks();
+      console.error = originalError;
     });
 
     describe('with Presentation 3 Manifest', () => {
@@ -340,6 +345,48 @@ describe('iiif-parser', () => {
         });
         expect(sources[0].src).toEqual('http://example.com/low.mp4#t=120.5,7278.422');
       });
+
+      describe('with "supplementing" Annotation with "provides" value', () => {
+        it('["transcript"] is excluded from tracks', () => {
+          const { tracks } = iiifParser.getMediaInfo({
+            manifest: multiCanvasV4Manifest,
+            canvasIndex: 2, version: '4',
+          });
+          expect(tracks).toHaveLength(0);
+        });
+
+        it('["subtitles"] is appended as a track', () => {
+          const { tracks } = iiifParser.getMediaInfo({
+            manifest: multiCanvasV4Manifest,
+            canvasIndex: 3, version: '4',
+          });
+          expect(tracks).toHaveLength(2);
+          expect(tracks[1].label).toEqual('Subtitles in WebVTT format');
+          expect(tracks[1].kind).toEqual('subtitles');
+        });
+
+        it('["transcript", "closedCaptions"] is appended as a track', () => {
+          const { tracks } = iiifParser.getMediaInfo({
+            manifest: multiCanvasV4Manifest,
+            canvasIndex: 3, version: '4',
+          });
+          expect(tracks).toHaveLength(2);
+          expect(tracks[0].label).toEqual('Caption Transcript in WebVTT format');
+          expect(tracks[0].kind).toEqual('subtitles');
+          expect(tracks[1].label).toEqual('Subtitles in WebVTT format');
+          expect(tracks[1].kind).toEqual('subtitles');
+        });
+
+        it('["audioDescription"] is appended as a track', () => {
+          const { audioDescTracks } = iiifParser.getMediaInfo({
+            manifest: multiCanvasV4Manifest,
+            canvasIndex: 3, version: '4',
+          });
+          expect(audioDescTracks).toHaveLength(1);
+          expect(audioDescTracks[0].label).toEqual('AD in WebVTT format');
+          expect(audioDescTracks[0].kind).toEqual('descriptions');
+        });
+      });
     });
 
     it('returns an error when invalid canvas index is given', () => {
@@ -448,9 +495,9 @@ describe('iiif-parser', () => {
       originalError = console.error;
       console.error = jest.fn();
     });
-    afterAll(() => {
-      console.error = originalError;
-    });
+
+    afterAll(() => console.error = originalError);
+
     it('returns url for video manifest', () => {
       const posterUrl = iiifParser.getPlaceholderResource(lunchroomManifest.items[0], true);
       expect(posterUrl).toEqual(

--- a/src/services/iiif-version-parser.js
+++ b/src/services/iiif-version-parser.js
@@ -52,18 +52,20 @@ export function getAccompanyingProp(version) {
  * @returns {Array}
  */
 export function hasMotivation(motivation, expected) {
-  const motivations = normalizeMotivation(motivation);
+  const motivations = normalizeValues(motivation);
   return motivations.includes(expected);
 }
 
 /**
- * Normalize an Annotation/AnnotationPage 'motivation' to an array. This allows to read and parse
- * 'motivation' values for both Presentation v3 and v4;
- * - in Presentation v3 'motivation' is conventionally a single String (e.g. 'painting')
- * @function VersionParser#normalizeMotivation
- * @param {String|Array} motivation 'motivation' value read off an Annotation
- * @returns {Array}
+ * Normalize a value read off of an Annotation/AnnotationPage to an array. This allows to
+ * read and parse properties in IIIF resources that have different formats in different
+ * IIIF Presentation versions,
+ * - 'motivation' -> in v3 it is conventionally a single String while it MUST be an array in v4
+ * - 'provides' -> introduced in v4 and absent in v3 and in Annotation in v4 that haven't set it
+ * @function VersionParser#normalizeValues
+ * @param {String|Array} values values read off a IIIF resource
+ * @returns 
  */
-export function normalizeMotivation(motivation) {
-  return [].concat(motivation ?? []);
+export function normalizeValues(values) {
+  return [].concat(values ?? []);
 }

--- a/src/services/iiif-version-parser.test.js
+++ b/src/services/iiif-version-parser.test.js
@@ -1,6 +1,6 @@
 import {
   getIIIFAPIVersion, getPlaceholderProp, getAccompanyingProp,
-  hasMotivation, normalizeMotivation
+  hasMotivation, normalizeValues
 } from './iiif-version-parser';
 
 describe('iiif-version-parser', () => {
@@ -86,21 +86,41 @@ describe('iiif-version-parser', () => {
     });
   });
 
-  describe('normalizeMotivation()', () => {
-    test('converts a string motivation into an array', () => {
-      expect(normalizeMotivation('painting')).toEqual(['painting']);
+  describe('normalizeValues()', () => {
+    describe('with "motivation" values', () => {
+      test('converts a string value into an array', () => {
+        expect(normalizeValues('painting')).toEqual(['painting']);
+      });
+
+      test('returns an array value unchanged', () => {
+        expect(normalizeValues(['painting'])).toEqual(['painting']);
+      });
+
+      test('returns an empty array when undefined', () => {
+        expect(normalizeValues(undefined)).toEqual([]);
+      });
+
+      test('returns an empty array when null', () => {
+        expect(normalizeValues(null)).toEqual([]);
+      });
     });
 
-    test('returns an array motivation unchanged', () => {
-      expect(normalizeMotivation(['painting'])).toEqual(['painting']);
-    });
+    describe('with "provides" values', () => {
+      test('converts a string value into an array', () => {
+        expect(normalizeValues('transcript')).toEqual(['transcript']);
+      });
 
-    test('returns an empty array when motivation is undefined', () => {
-      expect(normalizeMotivation(undefined)).toEqual([]);
-    });
+      test('returns an array value unchanged', () => {
+        expect(normalizeValues(['transcript', 'captions'])).toEqual(['transcript', 'captions']);
+      });
 
-    test('returns an empty array when motivation is null', () => {
-      expect(normalizeMotivation(null)).toEqual([]);
+      test('returns an empty array when undefined', () => {
+        expect(normalizeValues(undefined)).toEqual([]);
+      });
+
+      test('returns an empty array when null', () => {
+        expect(normalizeValues(null)).toEqual([]);
+      });
     });
   });
 

--- a/src/services/transcript-parser.js
+++ b/src/services/transcript-parser.js
@@ -7,7 +7,9 @@ import {
   identifyMachineGen,
   identifySupplementingAnnotation,
   getAnnotations,
+  S_ANNOTATION_TYPE,
 } from '@Services/utility-helpers';
+import { normalizeValues } from '@Services/iiif-version-parser';
 import { parseAnnotationSets } from '@Services/annotations-parser';
 
 // ENum for supported transcript MIME types
@@ -153,10 +155,13 @@ function buildTranscriptAnnotation(annotations, index, manifestURL, resource, ti
           label = `${i}`;
         }
         let id = annotBody.id;
-        let sType = identifySupplementingAnnotation(id);
+        let sType = identifySupplementingAnnotation(id, normalizeValues(annotation.provides));
         let { isMachineGen, labelText } = identifyMachineGen(label);
         if (filename === '') { filename = labelText; };
-        if (sType === 1 || sType === 3 || sType === 4) {
+        /* Only add the 'supplementing' Annotation to the transcripts list if it is,
+        - indicated as a transcript file in the Manifest 
+        - indicated as an AD text track in the Manifest */
+        if ([S_ANNOTATION_TYPE.transcript, S_ANNOTATION_TYPE.audioDescription].some(t => sType.includes(t))) {
           canvasTranscripts.push({
             title: labelText,
             filename: filename,

--- a/src/services/transcript-parser.test.js
+++ b/src/services/transcript-parser.test.js
@@ -4,9 +4,9 @@ import noAnnotationManifest from '@TestData/multiple-canvas-auto-advance';
 import multipleCanvas from '@TestData/transcript-multiple-canvas';
 import annotationTranscript from '@TestData/transcript-annotation';
 import multiSourceManifest from '@TestData/multi-source-manifest';
-import paintingAnnotationManifest from '@TestData/transcript-multiple-canvas';
 import noSupplementingManifest from '@TestData/single-canvas';
 import adManifest from '@TestData/ad-annotation';
+import providesManifest from '@TestData/multi-canvas-v4';
 import mammoth from 'mammoth';
 import { cleanup } from '@testing-library/react';
 import * as utils from '@Services/utility-helpers';
@@ -84,8 +84,8 @@ describe('transcript-parser', () => {
       expect(transcripts[1].items).toHaveLength(0);
     });
 
-    describe('valid manifestURL with supplementing annotations', () => {
-      test('for transcript as a list of annotations', async () => {
+    describe('with a valid manifestURL with "supplementing" annotations', () => {
+      test('returns transcripts for a list of annotations', async () => {
         const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValueOnce({
           status: 200,
           headers: { get: jest.fn(() => 'application/json') },
@@ -113,33 +113,127 @@ describe('transcript-parser', () => {
         ]);
       });
 
-      test('for transcripts as an external resource', async () => {
+      describe('returns transcript(s) for external resource(s)', () => {
+        test('without "provides" property', async () => {
+          const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+            status: 200,
+            headers: { get: jest.fn(() => 'application/json') },
+            json: jest.fn(() => multipleCanvas),
+          });
+
+          const transcripts = await transcriptParser.readSupplementingAnnotations(
+            'https://example.com/multiple-canvas/manifest.json', '', signal
+          );
+
+          expect(fetchSpy).toHaveBeenCalledTimes(1);
+          expect(fetchSpy).toHaveBeenCalledWith(
+            'https://example.com/multiple-canvas/manifest.json', { signal }
+          );
+          expect(transcripts).toHaveLength(2);
+          expect(transcripts[0].items).toHaveLength(0);
+          expect(transcripts[1].items).toEqual([
+            {
+              title: 'Captions in WebVTT format',
+              filename: 'sample-subtitles.vtt',
+              id: 'Captions in WebVTT format-1-0',
+              url: 'https://example.com/sample/subtitles.vtt',
+              isMachineGen: false,
+              format: 'text/vtt'
+            }
+          ]);
+        });
+
+        describe('with a "provides" value', () => {
+          test('["transcript"]', async () => {
+            const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+              status: 200,
+              headers: { get: jest.fn(() => 'application/json') },
+              json: jest.fn(() => providesManifest),
+            });
+
+            const transcripts = await transcriptParser.readSupplementingAnnotations(
+              'http://example.com/multi-canvas-manifest-v4/manifest.json', '', signal
+            );
+
+            expect(fetchSpy).toHaveBeenCalledTimes(1);
+            expect(transcripts).toHaveLength(4);
+            expect(transcripts[2].items).toHaveLength(1);
+            expect(transcripts[2].items).toEqual([
+              {
+                title: 'Transcript in WebVTT format', filename: 'audio-transcript.vtt',
+                id: 'Transcript in WebVTT format-2-0', isMachineGen: false, format: 'text/vtt',
+                url: 'https://example.com/multi-canvas-manifest-v4/1/transcripts'
+              }
+            ]);
+          });
+
+          test('["transcript", "closedCaptions"]', async () => {
+            const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+              status: 200,
+              headers: { get: jest.fn(() => 'application/json') },
+              json: jest.fn(() => providesManifest),
+            });
+
+            const transcripts = await transcriptParser.readSupplementingAnnotations(
+              'http://example.com/multi-canvas-manifest-v4/manifest.json', '', signal
+            );
+
+            expect(fetchSpy).toHaveBeenCalledTimes(1);
+            expect(transcripts).toHaveLength(4);
+            expect(transcripts[3].items).toHaveLength(2);
+            expect(transcripts[3].items[0]).toEqual({
+              title: 'Caption Transcript in WebVTT format', filename: 'sample-captions.vtt',
+              id: 'Caption Transcript in WebVTT format-3-0', isMachineGen: false, format: 'text/vtt',
+              url: 'https://example.com/captions-transcript.vtt',
+            });
+          });
+
+          test('["audioDescription"]', async () => {
+            const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+              status: 200,
+              headers: { get: jest.fn(() => 'application/json') },
+              json: jest.fn(() => providesManifest),
+            });
+
+            const transcripts = await transcriptParser.readSupplementingAnnotations(
+              'http://example.com/multi-canvas-manifest-v4/manifest.json', '', signal
+            );
+
+            expect(fetchSpy).toHaveBeenCalledTimes(1);
+            expect(transcripts).toHaveLength(4);
+            expect(transcripts[3].items).toHaveLength(2);
+            expect(transcripts[3].items[1]).toEqual({
+              title: 'AD in WebVTT format', filename: 'ad.vtt',
+              id: 'AD in WebVTT format-3-2', isMachineGen: false, format: 'text/vtt',
+              url: 'https://example.com/ad.vtt',
+            });
+          });
+        });
+      });
+
+      test('does not return a transcript for external resource with "provides" value ["subtitles"]', async () => {
+        const manifestWithProvides = JSON.parse(JSON.stringify(multipleCanvas));
+        const annotation = manifestWithProvides.items[1].annotations[0].items[0];
+        annotation.provides = ['closedCaptions'];
+
         const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValueOnce({
           status: 200,
           headers: { get: jest.fn(() => 'application/json') },
-          json: jest.fn(() => multipleCanvas),
+          json: jest.fn(() => providesManifest),
         });
 
         const transcripts = await transcriptParser.readSupplementingAnnotations(
-          'https://example.com/multiple-canvas/manifest.json', '', signal
+          'http://example.com/multi-canvas-manifest-v4/manifest.json', '', signal
         );
 
         expect(fetchSpy).toHaveBeenCalledTimes(1);
-        expect(fetchSpy).toHaveBeenCalledWith(
-          'https://example.com/multiple-canvas/manifest.json', { signal }
+        expect(transcripts).toHaveLength(4);
+        expect(transcripts[3].items).toHaveLength(2);
+        expect(transcripts[3].items).not.toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ label: 'Subtitles in WebVTT format' })
+          ])
         );
-        expect(transcripts).toHaveLength(2);
-        expect(transcripts[0].items).toHaveLength(0);
-        expect(transcripts[1].items).toEqual([
-          {
-            title: 'Captions in WebVTT format',
-            filename: 'sample-subtitles.vtt',
-            id: 'Captions in WebVTT format-1-0',
-            url: 'https://example.com/sample/subtitles.vtt',
-            isMachineGen: false,
-            format: 'text/vtt'
-          }
-        ]);
       });
 
       test('for transcript as an AnnotationPage (Aviary)', async () => {
@@ -502,11 +596,11 @@ puppet show \nwas put on at school.\n\r\n3\r\n00:00:26.700 --> 00:00:31.500\nIt 
           expect(response.tFileExt).toEqual('json');
         });
 
-        test('without supplementing annotaitons', async () => {
+        test('without "supplementing" annotations', async () => {
           const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValueOnce({
             status: 200,
             headers: { get: jest.fn(() => 'application/json') },
-            json: jest.fn(() => paintingAnnotationManifest),
+            json: jest.fn(() => multipleCanvas),
           });
           const response = await transcriptParser
             .parseTranscriptData({ url: 'https://example.com/transcript-multiple-canvas.json', format: 'application/json' });

--- a/src/services/utility-helpers.js
+++ b/src/services/utility-helpers.js
@@ -4,9 +4,18 @@ import mimeTypes from 'mime-types';
 import DOMPurify from 'dompurify';
 import { getPlaceholderResource } from './iiif-parser';
 import { IS_ANDROID, IS_MOBILE, IS_SAFARI } from '@Services/browser';
-import { hasMotivation, normalizeMotivation } from '@Services/iiif-version-parser';
+import { hasMotivation, normalizeValues } from '@Services/iiif-version-parser';
 
-const S_ANNOTATION_TYPE = { transcript: 1, caption: 2, both: 3, audioDescription: 4 };
+export const S_ANNOTATION_TYPE = { transcript: 1, caption: 2, audioDescription: 3 };
+
+/* Map IIIF Presentation v4 'provides' registry values (https://iiif.io/api/registry/accessibility/)
+to Ramp's Annotation display data structure internally. */
+const PROVIDES_TYPE_MAP = {
+  transcript: S_ANNOTATION_TYPE.transcript,
+  closedCaptions: S_ANNOTATION_TYPE.caption,
+  subtitles: S_ANNOTATION_TYPE.caption,
+  audioDescription: S_ANNOTATION_TYPE.audioDescription,
+};
 // Number of decimal places for milliseconds used in time calculations. 
 // This is used to ensure there are no mis-calculations around times that has a long decimal for milliseconds.
 const MILLISECOND_PRECISION = 1000;
@@ -379,7 +388,7 @@ export function getAnnotations(annotation, motivation = '', version = '3') {
   }
 
   // Normalize 'motivation' to an array on each Annotation
-  content = content.map((a) => ({ ...a, motivation: normalizeMotivation(a.motivation) }));
+  content = content.map((a) => ({ ...a, motivation: normalizeValues(a.motivation) }));
   // Filter the annotations if a motivation is given
   if (content && motivation != '') {
     const relevantAnnotations = content.filter(
@@ -409,22 +418,22 @@ export function parseResourceAnnotations({ annotation, duration, motivation, ver
     poster = '',
     error = 'No resources found in Canvas';
 
-  const parseAnnotation = (annotationItems) => {
+  const parseAnnotation = (annotationItems, provides = []) => {
     /**
-     * Convert annotation items to an array, because 'body' property 
+     * Convert annotation items to an array, because 'body' property
      * can sometimes contain an array instead of an object.
      * Ex: Aviary annotations: https://weareavp.aviaryplatform.com/iiif/hm52f7jz70/manifest
      */
     annotationItems = annotationItems?.length > 0 ? annotationItems : [annotationItems];
     annotationItems.map((a) => {
-      const source = getResourceInfo(a, start, duration, motivation);
+      const sources = getResourceInfo(a, start, duration, motivation, provides);
       // Check if the parsed sources has a resource URL
-      (source && source.src) && resources.push(source);
+      (sources && sources?.length > 0) && resources.push(...sources);
     });
   };
 
   if (annotation && annotation != undefined) {
-    const items = getAnnotations(annotation, '', version);
+    const items = getAnnotations(annotation, motivation, version);
     if (!items) { return { resources, canvasTargets, error }; }
     if (items.length === 0) {
       return {
@@ -436,7 +445,7 @@ export function parseResourceAnnotations({ annotation, duration, motivation, ver
     else if (items?.length > 1) {
       items.map((p, index) => {
         if (hasMotivation(p.motivation, motivation)) {
-          parseAnnotation(p.body);
+          parseAnnotation(p.body, normalizeValues(p.provides));
           if (motivation === 'painting') {
             isMultiSource = true;
             const target = parseCanvasTarget(p, duration, index);
@@ -448,12 +457,12 @@ export function parseResourceAnnotations({ annotation, duration, motivation, ver
     // When multiple qualities/sources are given for the resource in the Canvas => choice
     else if (items[0].body.items?.length > 0 && hasMotivation(items[0]?.motivation, motivation)) {
       items[0].body.items.map((p) => {
-        parseAnnotation(p);
+        parseAnnotation(p, normalizeValues(items[0].provides));
       });
     }
     // When a singe source is given for the resource in the Canvas
     else if (!isEmpty(items[0].body) && items[0].body?.id != '' && hasMotivation(items[0]?.motivation, motivation)) {
-      parseAnnotation(items[0].body);
+      parseAnnotation(items[0].body, normalizeValues(items[0].provides));
     } else if (motivation === 'painting') {
       return { resources, error, poster: getPlaceholderResource(annotation, false, version), canvasTargets };
     }
@@ -491,11 +500,10 @@ export function parseResourceAnnotations({ annotation, duration, motivation, ver
  * @param {Number} start custom start either from user props/Manifest start prop
  * @param {Number} duration duration of the media file
  * @param {String} motivation Annotation motivation
- * @returns parsed source/track information
+ * @param {Array} provides normalized 'provides' value read off the parent Annotation
+ * @returns {Array<Object>} array of source/track information for a given set of 'provides' values
  */
-function getResourceInfo(item, start, duration, motivation) {
-  let source = null;
-  let aType = S_ANNOTATION_TYPE.both;
+function getResourceInfo(item, start, duration, motivation, provides = []) {
   let fileExt = '';
   const resourceURL = item.id;
   if (resourceURL) {
@@ -510,44 +518,56 @@ function getResourceInfo(item, start, duration, motivation) {
   // If there are multiple labels, assume the first one
   // is the one intended for default display
   let label = getLabelValue(item.label);
-  // Detect forced captions by detecting '[forced]' text in the label
-  const isForced = typeof label === 'string' && label.toLowerCase().includes('[forced]');
-  if (motivation === 'supplementing') {
-    aType = identifySupplementingAnnotation(item.id);
-  }
-  if (aType != S_ANNOTATION_TYPE.transcript) {
-    let isSupported = true;
+
+  if (motivation === 'painting') {
     // Check if the media type is supported by the browser
-    if (motivation === 'painting') {
-      isSupported = checkMediaIsSupported(mimeType, fileExt);
-    }
+    const isSupported = checkMediaIsSupported(mimeType, fileExt);
     if (isSupported) {
-      source = {
+      return [{
         src: start > 0 ? `${item.id}#t=${start},${duration}` : item.id,
         key: item.id,
         type: mimeType,
         kind: item.type,
         label: label || 'auto',
-      };
-    }
-    if (motivation === 'supplementing') {
-      // Set language for captions/subtitles/descriptions
-      source.srclang = item.language ?? 'en';
-      if (aType === S_ANNOTATION_TYPE.audioDescription) {
-        // Mark VideoJS 'descriptions' kind for audio description tracks
-        source.kind = 'descriptions';
-      } else {
-        // And the rest as 'subtitles' for VTT annotations and others as 'metadata'
-        // Without this VideoJS resolves the kind='metadata' for subtitles file, 
-        // resulting in empty subtitles lists in iOS devices' native players.
-        source.kind = item.format.toLowerCase().includes('text/vtt')
-          ? 'subtitles'
-          : 'metadata';
-      }
-      if (isForced) source.forced = true;
+      }];
+    } else {
+      return [];
     }
   }
-  return source;
+  let sources = [];
+  if (motivation === 'supplementing') {
+    const aType = identifySupplementingAnnotation(item.id, provides);
+
+    // Detect forced captions by detecting '[forced]' text in the label
+    const isForced = typeof label === 'string' && label.toLowerCase().includes('[forced]');
+
+    /* Create objects for each supported "provides" value for the given 'supplementing' Annotation
+    for the VideoJS player to use to build <track> elements for captions/subtitles/audio description
+    text tracks. */
+    aType.forEach((t) => {
+      let source = { label, type: mimeType, key: item.id, src: item.id };
+      /* Do not create an object if the "provides" value is 'transcript' because, transcripts
+      are built seperately in the Transcript component outside the VideoJS instance. */
+      if (t !== S_ANNOTATION_TYPE.transcript) {
+        // Set language for captions/subtitles/descriptions
+        source.srclang = item.language ?? 'en';
+        if (t === S_ANNOTATION_TYPE.audioDescription) {
+          // Mark VideoJS 'descriptions' kind for audio description tracks
+          source.kind = 'descriptions';
+        } else {
+          // And the rest as 'subtitles' for VTT annotations and others as 'metadata'
+          // Without this VideoJS resolves the kind='metadata' for subtitles file, 
+          // resulting in empty subtitles lists in iOS devices' native players.
+          source.kind = item.format.toLowerCase().includes('text/vtt')
+            ? 'subtitles'
+            : 'metadata';
+        }
+        if (isForced) source.forced = true;
+        sources.push(source);
+      }
+    });
+  }
+  return sources;
 }
 
 /**
@@ -625,26 +645,37 @@ export function identifyMachineGen(label) {
 }
 
 /**
- * Resolve captions and transcripts in supplementing annotations.
- * This is specific for Avalon's usecase, where Avalon generates
- * adds 'transcripts' and 'captions' to the URI to distinguish them.
+ * Resolve transcript/caption/AD in 'supplementing' annotations.
+ * Checks the 'provides' property (introduced in Presentation v4) of
+ * the 'supplementing' annotation to determine if the given Annotation is a
+ * transcript/caption/AD track.
+ * Otherwise, falls back to checking the URI to distinguish the Annotation category
+ * according to Avalon's convention of adding 'transcripts/'captions'/'descriptions'
+ * to the URI in Presentation v3.
  * In other cases supplementing annotations are displayed as both
  * captions and transcripts in Ramp.
  * @function Utils#identifySupplementingAnnotation
  * @param {String} uri id from supplementing annotation
- * @returns {Number} a value from S_ANNOTATION_TYPE ENum
+ * @param {Array} provides 'provides' from supplementing Annotation
+ * @returns {Array<Number>} matching value(s) from S_ANNOTATION_TYPE ENum
  */
-export function identifySupplementingAnnotation(uri) {
-  if (!uri) { return; }
+export function identifySupplementingAnnotation(uri, provides = []) {
+  if (provides?.length > 0) {
+    return provides
+      .filter((key) => Object.prototype.hasOwnProperty.call(PROVIDES_TYPE_MAP, key))
+      .map((key) => PROVIDES_TYPE_MAP[key]);
+  }
+
+  if (!uri) { return []; }
   let identifier = uri.split('/').reverse()[0];
   if (identifier === 'transcripts') {
-    return S_ANNOTATION_TYPE.transcript;
-  } else if (identifier === 'captions') {
-    return S_ANNOTATION_TYPE.caption;
+    return [S_ANNOTATION_TYPE.transcript];
+  } else if (identifier === 'captions' || identifier === 'subtitles') {
+    return [S_ANNOTATION_TYPE.caption];
   } else if (identifier === 'descriptions') {
-    return S_ANNOTATION_TYPE.audioDescription;
+    return [S_ANNOTATION_TYPE.audioDescription];
   } else {
-    return S_ANNOTATION_TYPE.both;
+    return [S_ANNOTATION_TYPE.transcript, S_ANNOTATION_TYPE.caption];
   }
 }
 

--- a/src/services/utility-helpers.test.js
+++ b/src/services/utility-helpers.test.js
@@ -463,7 +463,7 @@ describe('util helper', () => {
       });
     });
 
-    test('does not parse painting annotations with no browser supported resources', () => {
+    test('does not parse "painting" annotations with no browser supported resources', () => {
       // Mock canPlayType to return '' (falsy value) to mock browser unsupported MIME types
       HTMLMediaElement.prototype.canPlayType = jest.fn(() => '');
       const annotations =
@@ -505,61 +505,130 @@ describe('util helper', () => {
       jest.restoreAllMocks();
     });
 
-    test('parses supplementin annotations', () => {
-      const annotations = [
-        {
-          type: 'AnnotationPage',
-          items: [
-            {
-              id: 'http://example.com/manifest/canvas/1/page/annotation/1',
-              type: 'Annotation',
-              motivation: 'supplementing',
-              body: {
-                id: 'http://example.com/manifest/English.vtt',
-                label: { en: ['Captions in WebVTT format'] },
-                language: 'en',
-                type: 'Text',
-                format: 'text/vtt',
+    describe('parses "supplementing" annotations', () => {
+      test('without "provides"', () => {
+        const annotations = [
+          {
+            type: 'AnnotationPage',
+            items: [
+              {
+                id: 'http://example.com/manifest/canvas/1/page/annotation/1',
+                type: 'Annotation',
+                motivation: 'supplementing',
+                body: {
+                  id: 'http://example.com/manifest/English.vtt',
+                  label: { en: ['Captions in WebVTT format'] },
+                  language: 'en',
+                  type: 'Text',
+                  format: 'text/vtt',
+                },
+                target: 'http://example.com/manifest/canvas/1',
               },
-              target: 'http://example.com/manifest/canvas/1',
-            },
-            {
-              id: 'http://example.com/manifest/canvas/1/page/annotation/2',
-              type: 'Annotation',
-              motivation: 'supplementing',
-              body: {
-                id: 'http://example.com/manifest/Italian.vtt',
-                label: { it: ['Sottotitoli in formato WebVTT'] },
-                language: 'it',
-                type: 'Text',
-                format: 'text/vtt',
+              {
+                id: 'http://example.com/manifest/canvas/1/page/annotation/2',
+                type: 'Annotation',
+                motivation: 'supplementing',
+                body: {
+                  id: 'http://example.com/manifest/Italian.vtt',
+                  label: { it: ['Sottotitoli in formato WebVTT'] },
+                  language: 'it',
+                  type: 'Text',
+                  format: 'text/vtt',
+                },
+                target: 'http://example.com/manifest/canvas/1',
+              }
+            ]
+          }
+        ];
+        const { resources, _, isMultiResource } = util.parseResourceAnnotations(
+          { annotation: annotations, duration: 896.55, motivation: 'supplementing' }
+        );
+        expect(resources).toHaveLength(2);
+        expect(resources[0]).toEqual({
+          src: 'http://example.com/manifest/English.vtt',
+          key: 'http://example.com/manifest/English.vtt',
+          type: 'text/vtt',
+          kind: 'subtitles',
+          srclang: 'en',
+          label: 'Captions in WebVTT format',
+        });
+        expect(resources[1]).toEqual({
+          src: 'http://example.com/manifest/Italian.vtt',
+          key: 'http://example.com/manifest/Italian.vtt',
+          type: 'text/vtt',
+          kind: 'subtitles',
+          srclang: 'it',
+          label: 'Sottotitoli in formato WebVTT',
+        });
+        expect(isMultiResource).toBeFalsy();
+      });
+
+      test('with "provides"', () => {
+        const annotations = [
+          {
+            type: 'AnnotationPage',
+            items: [
+              {
+                id: 'http://example.com/manifest/canvas/1/page/annotation/1',
+                type: 'Annotation',
+                motivation: ['supplementing'],
+                provides: ['closedCaptions'],
+                body: {
+                  id: 'http://example.com/manifest/English.vtt',
+                  label: { en: ['Captions in WebVTT format'] },
+                  language: 'en',
+                  type: 'Text',
+                  format: 'text/vtt',
+                },
+                target: 'http://example.com/manifest/canvas/1',
               },
-              target: 'http://example.com/manifest/canvas/1',
-            }
-          ]
-        }
-      ];
-      const { resources, _, isMultiResource } = util.parseResourceAnnotations(
-        { annotation: annotations, duration: 896.55, motivation: 'supplementing' }
-      );
-      expect(resources).toHaveLength(2);
-      expect(resources[0]).toEqual({
-        src: 'http://example.com/manifest/English.vtt',
-        key: 'http://example.com/manifest/English.vtt',
-        type: 'text/vtt',
-        kind: 'subtitles',
-        srclang: 'en',
-        label: 'Captions in WebVTT format',
+              {
+                id: 'http://example.com/manifest/canvas/1/page/annotation/2',
+                type: 'Annotation',
+                motivation: ['supplementing'],
+                provides: ['closedCaptions', 'audioDescription'],
+                body: {
+                  id: 'http://example.com/manifest/Italian.vtt',
+                  label: { it: ['Sottotitoli in formato WebVTT'] },
+                  language: 'it',
+                  type: 'Text',
+                  format: 'text/vtt',
+                },
+                target: 'http://example.com/manifest/canvas/1',
+              }
+            ]
+          }
+        ];
+        const { resources, _, isMultiResource } = util.parseResourceAnnotations(
+          { annotation: annotations, duration: 896.55, motivation: 'supplementing' }
+        );
+        expect(resources).toHaveLength(3);
+        expect(resources[0]).toEqual({
+          src: 'http://example.com/manifest/English.vtt',
+          key: 'http://example.com/manifest/English.vtt',
+          type: 'text/vtt',
+          kind: 'subtitles',
+          srclang: 'en',
+          label: 'Captions in WebVTT format',
+        });
+        expect(resources[1]).toEqual({
+          src: 'http://example.com/manifest/Italian.vtt',
+          key: 'http://example.com/manifest/Italian.vtt',
+          type: 'text/vtt',
+          kind: 'subtitles',
+          srclang: 'it',
+          label: 'Sottotitoli in formato WebVTT',
+        });
+        expect(resources[2]).toEqual({
+          src: 'http://example.com/manifest/Italian.vtt',
+          key: 'http://example.com/manifest/Italian.vtt',
+          type: 'text/vtt',
+          kind: 'descriptions',
+          srclang: 'it',
+          label: 'Sottotitoli in formato WebVTT',
+        });
+        expect(isMultiResource).toBeFalsy();
       });
-      expect(resources[1]).toEqual({
-        src: 'http://example.com/manifest/Italian.vtt',
-        key: 'http://example.com/manifest/Italian.vtt',
-        type: 'text/vtt',
-        kind: 'subtitles',
-        srclang: 'it',
-        label: 'Sottotitoli in formato WebVTT',
-      });
-      expect(isMultiResource).toBeFalsy();
     });
 
     test('parses forced caption annotation from label and sets forced flag', () => {
@@ -791,24 +860,82 @@ describe('util helper', () => {
   });
 
   describe('identifySupplementingAnnotation()', () => {
-    test('with transcripts at the end of URI', () => {
-      const value = util.identifySupplementingAnnotation('https://example.com/lunchroom-manners/transcripts');
-      expect(value).toEqual(1);
+    describe('without a "provides" array', () => {
+      test('with transcripts at the end of URI resolves to S_ANNOTATION_TYPE.transcript', () => {
+        const value = util.identifySupplementingAnnotation('https://example.com/lunchroom-manners/transcripts');
+        expect(value).toEqual([1]);
+      });
+
+      test('with captions at the end of URI resolves to S_ANNOTATION_TYPE.caption', () => {
+        const value = util.identifySupplementingAnnotation('https://example.com/lunchroom-manners/captions');
+        expect(value).toEqual([2]);
+      });
+
+      test('with subtitles at the end of URI resolves to S_ANNOTATION_TYPE.caption', () => {
+        const value = util.identifySupplementingAnnotation('https://example.com/lunchroom-manners/subtitles');
+        expect(value).toEqual([2]);
+      });
+
+      test('with descriptions at the end of URI resolves to S_ANNOTATION_TYPE.audioDescription', () => {
+        const value = util.identifySupplementingAnnotation('https://example.com/lunchroom-manners/descriptions');
+        expect(value).toEqual([3]);
+      });
+
+      test('with generic URI resolves to S_ANNOTATION_TYPE.transcript and S_ANNOTATION_TYPE.caption', () => {
+        const value = util.identifySupplementingAnnotation('https://example.com/lunchroom-manners/lunchroom-manners.vtt');
+        expect(value).toEqual([1, 2]);
+      });
     });
 
-    test('with captions at the end of URI', () => {
-      const value = util.identifySupplementingAnnotation('https://example.com/lunchroom-manners/captions');
-      expect(value).toEqual(2);
-    });
+    describe('with a "provides" array', () => {
+      test('with only "transcript"', () => {
+        const value = util.identifySupplementingAnnotation(
+          'https://example.com/lunchroom-manners/lunchroom-manners.vtt', ['transcript']
+        );
+        expect(value).toEqual([1]);
+      });
 
-    test('with descriptions at the end of URI', () => {
-      const value = util.identifySupplementingAnnotation('https://example.com/lunchroom-manners/descriptions');
-      expect(value).toEqual(4);
-    });
+      test('with only "closedCaptions"', () => {
+        const value = util.identifySupplementingAnnotation(
+          'https://example.com/lunchroom-manners/lunchroom-manners.vtt', ['closedCaptions']
+        );
+        expect(value).toEqual([2]);
+      });
 
-    test('with generic URI', () => {
-      const value = util.identifySupplementingAnnotation('https://example.com/lunchroom-manners/lunchroom-manners.vtt');
-      expect(value).toEqual(3);
+      test('with only "subtitles"', () => {
+        const value = util.identifySupplementingAnnotation(
+          'https://example.com/lunchroom-manners/lunchroom-manners.vtt', ['subtitles']
+        );
+        expect(value).toEqual([2]);
+      });
+
+      test('with only "audioDescription"', () => {
+        const value = util.identifySupplementingAnnotation(
+          'https://example.com/lunchroom-manners/lunchroom-manners.vtt', ['audioDescription']
+        );
+        expect(value).toEqual([3]);
+      });
+
+      test('with multiple mapped values', () => {
+        const value = util.identifySupplementingAnnotation(
+          'https://example.com/lunchroom-manners/lunchroom-manners.vtt', ['closedCaptions', 'audioDescription']
+        );
+        expect(value).toEqual([2, 3]);
+      });
+
+      test('with an unmapped value', () => {
+        const value = util.identifySupplementingAnnotation(
+          'https://example.com/lunchroom-manners/lunchroom-manners.vtt', ['alternativeText']
+        );
+        expect(value).toEqual([]);
+      });
+
+      test('and a URI with conflicting information, "provides" takes precedence', () => {
+        const value = util.identifySupplementingAnnotation(
+          'https://example.com/lunchroom-manners/captions', ['transcript']
+        );
+        expect(value).toEqual([1]);
+      });
     });
   });
 
@@ -1837,6 +1964,7 @@ describe('util helper', () => {
       });
     });
   });
+
   describe('getAnnotations()', () => {
     describe('for a Presentation 3 Manifest, returns annotation content', () => {
       test('with a motivation array for a painting annotation', () => {

--- a/src/test_data/multi-canvas-v4.js
+++ b/src/test_data/multi-canvas-v4.js
@@ -71,8 +71,7 @@ export default {
     },
     {
       id: "http://example.com/multi-canvas-manifest-v4/timeline/1",
-      type: "Timeline",
-      duration: 98.25,
+      type: "Timeline", duration: 98.25,
       items: [
         {
           id: "http://example.com/multi-canvas-manifest-v4/timeline/1/annotation_page/1",
@@ -89,15 +88,32 @@ export default {
             }
           ]
         }
-      ]
+      ],
+      annotations: [
+        {
+          id: 'http://example.com/multi-canvas-manifest-v4/timeline/1/page/2',
+          type: 'AnnotationPage',
+          items: [
+            {
+              id: 'http://example.com/multi-canvas-manifest-v4/timeline/1/annotation/1',
+              type: 'Annotation',
+              motivation: ['supplementing'],
+              provides: ['transcript'],
+              body: {
+                id: 'https://example.com/multi-canvas-manifest-v4/1/transcripts', type: 'Text',
+                format: 'text/vtt', language: ['en'], label: {
+                  en: ['Transcript in WebVTT format'], none: ['audio-transcript.vtt']
+                }
+              },
+              target: { id: 'http://example.com/multi-canvas-manifest-v4/timeline/1', type: 'Timeline' }
+            }
+          ]
+        },
+      ],
     },
     {
       id: 'http://example.com/multi-canvas-manifest-v4/timeline/2',
-      type: 'Timeline',
-      width: 480,
-      height: 360,
-      duration: 660,
-      label: { en: ['Multi-src Audio Timeline'] },
+      type: 'Timeline', width: 480, height: 360, duration: 660, label: { en: ['Multi-src Audio Timeline'] },
       items: [
         {
           id: 'http://example.com/multi-canvas-manifest-v4/timeline/2/page',
@@ -105,8 +121,7 @@ export default {
           items: [
             {
               id: 'http://example.com/multi-canvas-manifest-v4/timeline/2/page/1',
-              type: 'Annotation',
-              motivation: ['painting'],
+              type: 'Annotation', motivation: ['painting'],
               body: {
                 type: 'Choice',
                 choiceHint: 'user',
@@ -136,12 +151,35 @@ export default {
           type: 'AnnotationPage',
           items: [
             {
-              id: 'http://example.com/multi-canvas-manifest-v4/timeline/2/annotation/1',
+              id: 'http://example.com/multi-canvas-manifest-v4/timeline/2/page/2/annotation/1',
               type: 'Annotation',
               motivation: ['supplementing'],
+              provides: ['transcript', 'closedCaptions'],
               body: {
-                id: 'https://example.com/audio-transcript.vtt', type: 'Text', format: 'text/vtt', language: ['en'],
-                label: { en: ['Captions in WebVTT format'], none: ['audio-transcript.vtt'] }
+                id: 'https://example.com/captions-transcript.vtt', type: 'Text', format: 'text/vtt', language: ['en'],
+                label: { en: ['Caption Transcript in WebVTT format'], none: ['sample-captions.vtt'] }
+              },
+              target: { id: 'http://example.com/multi-canvas-manifest-v4/timeline/2', type: 'Timeline' }
+            },
+            {
+              id: 'http://example.com/multi-canvas-manifest-v4/timeline/2/page/2/annotation/2',
+              type: 'Annotation',
+              motivation: ['supplementing'],
+              provides: ['subtitles'],
+              body: {
+                id: 'https://example.com/subtitles-transcript.vtt', type: 'Text', format: 'text/vtt', language: ['en'],
+                label: { en: ['Subtitles in WebVTT format'], none: ['sample-subtitles.vtt'] }
+              },
+              target: { id: 'http://example.com/multi-canvas-manifest-v4/timeline/2', type: 'Timeline' }
+            },
+            {
+              id: 'http://example.com/multi-canvas-manifest-v4/timeline/2/page/2/annotation/3',
+              type: 'Annotation',
+              motivation: ['supplementing'],
+              provides: ['audioDescription'],
+              body: {
+                id: 'https://example.com/ad.vtt', type: 'Text', format: 'text/vtt', language: ['en'],
+                label: { en: ['AD in WebVTT format'], none: ['ad.vtt'] }
               },
               target: { id: 'http://example.com/multi-canvas-manifest-v4/timeline/2', type: 'Timeline' }
             }


### PR DESCRIPTION
Related issue: #1009 

Changes in this PR:
- Read `provides` property from Annotations regardless of the IIIF version defaulting an empty array when the property does not exist because, even in IIIF Presentation v4 Manifests can have `"supplementing"` Annotations without `provides` property
- Map a11y values in IIIF [registry of accessibility](https://iiif.io/api/registry/accessibility/) via `provides` property in `"supplementing"` Annotations to Ramp's internal data structure as follows;
  - transcript --> displayed in both Transcript and Annotations components
  - closedCaptions/subtitles --> displayed in player as captions
  - audioDescription --> displayed in player as AD track, and in both Transcript and Annotations components
- When multiple values are given for `provides` assess each value and build internal data structure as needed for different UI components. e.g. when `provides=["transcript", "closedCaptions"]` create both a transcript annotation for Transcript component and a `<track>` element for the player
- Rename `normalizeMotivation()` in `iiif-version-parser.js` to `normalizeValues() to generalize its use-case for both `motivation` and `provides` values